### PR TITLE
feat: 豆詳細APIのテイスト返却をIDから名称に変更

### DIFF
--- a/admin-frontend/src/api/coffee-beans.ts
+++ b/admin-frontend/src/api/coffee-beans.ts
@@ -19,7 +19,7 @@ export type CoffeeBeanListItem = {
 
 export type CoffeeBeanDetail = CoffeeBeanListItem & {
   images: { id: string; type: string; imageUrl: string }[];
-  tastes: { id: string; tasteId: string; evaluationValue: number }[];
+  tastes: { id: string; tasteName: string; evaluationValue: number }[];
 };
 
 export async function fetchCoffeeBeans(

--- a/admin-frontend/src/app/(admin)/coffee-beans/[id]/_components/CoffeeBeanDetail.module.css
+++ b/admin-frontend/src/app/(admin)/coffee-beans/[id]/_components/CoffeeBeanDetail.module.css
@@ -101,7 +101,7 @@
   border-radius: 8px;
 }
 
-.tasteId {
+.tasteName {
   font-size: 13px;
   font-weight: 600;
   color: var(--color-text-secondary);

--- a/admin-frontend/src/app/(admin)/coffee-beans/[id]/_components/CoffeeBeanDetail.tsx
+++ b/admin-frontend/src/app/(admin)/coffee-beans/[id]/_components/CoffeeBeanDetail.tsx
@@ -82,7 +82,7 @@ export function CoffeeBeanDetail({
             <div className={styles.tasteList}>
               {coffeeBean.tastes.map((taste) => (
                 <div key={taste.id} className={styles.tasteItem}>
-                  <span className={styles.tasteId}>{taste.tasteId}</span>
+                  <span className={styles.tasteName}>{taste.tasteName}</span>
                   <div className={styles.tasteBar}>
                     <div
                       className={styles.tasteFill}

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/application/query/CoffeeBeanQueryService.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/application/query/CoffeeBeanQueryService.kt
@@ -1,8 +1,10 @@
 package com.mametosho.admin.application.query
 
+import com.mametosho.admin.application.query.result.CoffeeBeanDetailResult
 import com.mametosho.admin.application.query.result.CoffeeBeanListResult
 import com.mametosho.admin.application.query.result.PagedResult
 
 interface CoffeeBeanQueryService {
     fun findList(page: Int, size: Int): PagedResult<CoffeeBeanListResult>
+    fun findDetail(id: String): CoffeeBeanDetailResult?
 }

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/application/query/result/CoffeeBeanDetailResult.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/application/query/result/CoffeeBeanDetailResult.kt
@@ -1,0 +1,28 @@
+package com.mametosho.admin.application.query.result
+
+data class CoffeeBeanDetailResult(
+    val id: String,
+    val shopId: String,
+    val shopifyBeanId: String,
+    val name: String,
+    val description: String,
+    val origin: String,
+    val farm: String?,
+    val roastLevel: String,
+    val processingMethod: String,
+    val isSpecialty: Boolean,
+    val images: List<ImageResult>,
+    val tastes: List<TasteResult>,
+) {
+    data class ImageResult(
+        val id: String,
+        val type: String,
+        val imageUrl: String,
+    )
+
+    data class TasteResult(
+        val id: String,
+        val tasteName: String,
+        val evaluationValue: Int,
+    )
+}

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/application/usecase/GetCoffeeBeanUsecase.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/application/usecase/GetCoffeeBeanUsecase.kt
@@ -1,17 +1,16 @@
 package com.mametosho.admin.application.usecase
 
-import com.mametosho.domain.model.coffeebean.CoffeeBean
-import com.mametosho.domain.model.coffeebean.CoffeeBeanId
-import com.mametosho.domain.repository.CoffeeBeanRepository
+import com.mametosho.admin.application.query.CoffeeBeanQueryService
+import com.mametosho.admin.application.query.result.CoffeeBeanDetailResult
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Service
 class GetCoffeeBeanUsecase(
-    private val coffeeBeanRepository: CoffeeBeanRepository,
+    private val coffeeBeanQueryService: CoffeeBeanQueryService,
 ) {
     @Transactional(readOnly = true)
-    open fun execute(id: String): CoffeeBean? {
-        return coffeeBeanRepository.findById(CoffeeBeanId(id))
+    open fun execute(id: String): CoffeeBeanDetailResult? {
+        return coffeeBeanQueryService.findDetail(id)
     }
 }

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/infrastructure/persistence/query/CoffeeBeanQueryServiceImpl.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/infrastructure/persistence/query/CoffeeBeanQueryServiceImpl.kt
@@ -41,35 +41,41 @@ class CoffeeBeanQueryServiceImpl(
     }
 
     override fun findDetail(id: String): CoffeeBeanDetailResult? {
-        val bean = coffeeBeanMapper.findById(id) ?: return null
-        val images = coffeeBeanMapper.findImagesByCoffeeBeanId(id)
-        val tastes = coffeeBeanMapper.findTasteDetailsByCoffeeBeanId(id)
+        val rows = coffeeBeanMapper.findDetailRowsById(id)
+        if (rows.isEmpty()) return null
 
+        val first = rows.first()
         return CoffeeBeanDetailResult(
-            id = bean.id,
-            shopId = bean.shopId,
-            shopifyBeanId = bean.shopifyBeanId,
-            name = bean.name,
-            description = bean.description,
-            origin = bean.origin,
-            farm = bean.farm,
-            roastLevel = bean.roastLevel,
-            processingMethod = bean.processingMethod,
-            isSpecialty = bean.isSpecialty,
-            images = images.map { img ->
-                CoffeeBeanDetailResult.ImageResult(
-                    id = img.id,
-                    type = img.type,
-                    imageUrl = img.imageUrl,
-                )
-            },
-            tastes = tastes.map { taste ->
-                CoffeeBeanDetailResult.TasteResult(
-                    id = taste.id,
-                    tasteName = taste.tasteName,
-                    evaluationValue = taste.evaluationValue,
-                )
-            },
+            id = first.beanId,
+            shopId = first.shopId,
+            shopifyBeanId = first.shopifyBeanId,
+            name = first.beanName,
+            description = first.description,
+            origin = first.origin,
+            farm = first.farm,
+            roastLevel = first.roastLevel,
+            processingMethod = first.processingMethod,
+            isSpecialty = first.isSpecialty,
+            images = rows
+                .filter { it.imageId != null }
+                .distinctBy { it.imageId }
+                .map { row ->
+                    CoffeeBeanDetailResult.ImageResult(
+                        id = checkNotNull(row.imageId),
+                        type = checkNotNull(row.imageType),
+                        imageUrl = checkNotNull(row.imageUrl),
+                    )
+                },
+            tastes = rows
+                .filter { it.tasteEvalId != null }
+                .distinctBy { it.tasteEvalId }
+                .map { row ->
+                    CoffeeBeanDetailResult.TasteResult(
+                        id = checkNotNull(row.tasteEvalId),
+                        tasteName = checkNotNull(row.tasteName),
+                        evaluationValue = checkNotNull(row.evaluationValue),
+                    )
+                },
         )
     }
 }

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/infrastructure/persistence/query/CoffeeBeanQueryServiceImpl.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/infrastructure/persistence/query/CoffeeBeanQueryServiceImpl.kt
@@ -1,6 +1,7 @@
 package com.mametosho.admin.infrastructure.persistence.query
 
 import com.mametosho.admin.application.query.CoffeeBeanQueryService
+import com.mametosho.admin.application.query.result.CoffeeBeanDetailResult
 import com.mametosho.admin.application.query.result.CoffeeBeanListResult
 import com.mametosho.admin.application.query.result.PagedResult
 import com.mametosho.infrastructure.persistence.mybatis.mapper.CoffeeBeanMapper
@@ -36,6 +37,39 @@ class CoffeeBeanQueryServiceImpl(
             totalCount = totalCount,
             page = page,
             size = size,
+        )
+    }
+
+    override fun findDetail(id: String): CoffeeBeanDetailResult? {
+        val bean = coffeeBeanMapper.findById(id) ?: return null
+        val images = coffeeBeanMapper.findImagesByCoffeeBeanId(id)
+        val tastes = coffeeBeanMapper.findTasteDetailsByCoffeeBeanId(id)
+
+        return CoffeeBeanDetailResult(
+            id = bean.id,
+            shopId = bean.shopId,
+            shopifyBeanId = bean.shopifyBeanId,
+            name = bean.name,
+            description = bean.description,
+            origin = bean.origin,
+            farm = bean.farm,
+            roastLevel = bean.roastLevel,
+            processingMethod = bean.processingMethod,
+            isSpecialty = bean.isSpecialty,
+            images = images.map { img ->
+                CoffeeBeanDetailResult.ImageResult(
+                    id = img.id,
+                    type = img.type,
+                    imageUrl = img.imageUrl,
+                )
+            },
+            tastes = tastes.map { taste ->
+                CoffeeBeanDetailResult.TasteResult(
+                    id = taste.id,
+                    tasteName = taste.tasteName,
+                    evaluationValue = taste.evaluationValue,
+                )
+            },
         )
     }
 }

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/controller/CoffeeBeanController.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/controller/CoffeeBeanController.kt
@@ -137,7 +137,7 @@ class CoffeeBeanController(
                                       "tastes": [
                                         {
                                           "id": "00000000-0000-4000-8000-000000000020",
-                                          "tasteId": "00000000-0000-4000-8000-000000000030",
+                                          "tasteName": "酸味",
                                           "evaluationValue": 4
                                         }
                                       ]
@@ -176,9 +176,9 @@ class CoffeeBeanController(
         @Parameter(description = "コーヒー豆ID", required = true, example = "00000000-0000-4000-8000-000000000001")
         @PathVariable id: String,
     ): ResponseEntity<CoffeeBeanDetailResponse> {
-        val coffeeBean = getCoffeeBeanUsecase.execute(id)
+        val result = getCoffeeBeanUsecase.execute(id)
             ?: return ResponseEntity.notFound().build()
-        return ResponseEntity.ok(CoffeeBeanDetailResponse.from(coffeeBean))
+        return ResponseEntity.ok(CoffeeBeanDetailResponse.from(result))
     }
 
     @PostMapping(consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/CoffeeBeanDetailResponse.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/CoffeeBeanDetailResponse.kt
@@ -1,8 +1,6 @@
 package com.mametosho.admin.presentation.dto.response
 
-import com.mametosho.domain.model.coffeebean.CoffeeBean
-import com.mametosho.domain.model.coffeebean.CoffeeBeanImage
-import com.mametosho.domain.model.coffeebean.CoffeeBeanTaste
+import com.mametosho.admin.application.query.result.CoffeeBeanDetailResult
 import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "コーヒー豆詳細レスポンス")
@@ -40,48 +38,32 @@ data class CoffeeBeanDetailResponse(
         val type: String,
         @Schema(description = "画像URL", example = "https://example.com/image.jpg")
         val imageUrl: String,
-    ) {
-        companion object {
-            fun from(image: CoffeeBeanImage): ImageDetail = ImageDetail(
-                id = image.id.value,
-                type = image.type.name,
-                imageUrl = image.imageUrl.value,
-            )
-        }
-    }
+    )
 
     @Schema(description = "テイスト評価詳細")
     data class TasteDetail(
         @Schema(description = "テイスト評価ID", example = "00000000-0000-4000-8000-000000000020")
         val id: String,
-        @Schema(description = "テイストID", example = "00000000-0000-4000-8000-000000000030")
-        val tasteId: String,
+        @Schema(description = "テイスト名", example = "酸味")
+        val tasteName: String,
         @Schema(description = "評価値（0-5）", example = "4")
         val evaluationValue: Int,
-    ) {
-        companion object {
-            fun from(taste: CoffeeBeanTaste): TasteDetail = TasteDetail(
-                id = taste.id.value,
-                tasteId = taste.tasteId.value,
-                evaluationValue = taste.evaluationValue,
-            )
-        }
-    }
+    )
 
     companion object {
-        fun from(coffeeBean: CoffeeBean): CoffeeBeanDetailResponse = CoffeeBeanDetailResponse(
-            id = coffeeBean.id.value,
-            shopId = coffeeBean.shopId.value,
-            shopifyBeanId = coffeeBean.shopifyBeanId.value,
-            name = coffeeBean.name,
-            description = coffeeBean.description,
-            origin = coffeeBean.origin,
-            farm = coffeeBean.farm,
-            roastLevel = coffeeBean.roastLevel.name,
-            processingMethod = coffeeBean.processingMethod.name,
-            isSpecialty = coffeeBean.isSpecialty,
-            images = coffeeBean.images.map { ImageDetail.from(it) },
-            tastes = coffeeBean.tastes.map { TasteDetail.from(it) },
+        fun from(result: CoffeeBeanDetailResult): CoffeeBeanDetailResponse = CoffeeBeanDetailResponse(
+            id = result.id,
+            shopId = result.shopId,
+            shopifyBeanId = result.shopifyBeanId,
+            name = result.name,
+            description = result.description,
+            origin = result.origin,
+            farm = result.farm,
+            roastLevel = result.roastLevel,
+            processingMethod = result.processingMethod,
+            isSpecialty = result.isSpecialty,
+            images = result.images.map { ImageDetail(id = it.id, type = it.type, imageUrl = it.imageUrl) },
+            tastes = result.tastes.map { TasteDetail(id = it.id, tasteName = it.tasteName, evaluationValue = it.evaluationValue) },
         )
     }
 }

--- a/backend/admin-api/src/test/kotlin/com/mametosho/admin/application/usecase/GetCoffeeBeanUsecaseTest.kt
+++ b/backend/admin-api/src/test/kotlin/com/mametosho/admin/application/usecase/GetCoffeeBeanUsecaseTest.kt
@@ -1,12 +1,9 @@
 package com.mametosho.admin.application.usecase
 
-import com.mametosho.domain.model.coffeebean.CoffeeBean
-import com.mametosho.domain.model.coffeebean.CoffeeBeanId
-import com.mametosho.domain.model.coffeebean.ProcessingMethod
-import com.mametosho.domain.model.coffeebean.RoastLevel
-import com.mametosho.domain.model.coffeebean.ShopifyBeanId
-import com.mametosho.domain.model.shop.ShopId
-import com.mametosho.domain.repository.CoffeeBeanRepository
+import com.mametosho.admin.application.query.CoffeeBeanQueryService
+import com.mametosho.admin.application.query.result.CoffeeBeanDetailResult
+import com.mametosho.admin.application.query.result.CoffeeBeanListResult
+import com.mametosho.admin.application.query.result.PagedResult
 import org.junit.jupiter.api.Nested
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -14,29 +11,29 @@ import kotlin.test.assertNull
 
 class GetCoffeeBeanUsecaseTest {
 
-    private val existingBean = CoffeeBean(
-        id = CoffeeBeanId("00000000-0000-4000-8000-000000000001"),
-        shopId = ShopId("00000000-0000-4000-8000-000000000002"),
-        shopifyBeanId = ShopifyBeanId("test-bean-001"),
+    private val existingResult = CoffeeBeanDetailResult(
+        id = "00000000-0000-4000-8000-000000000001",
+        shopId = "00000000-0000-4000-8000-000000000002",
+        shopifyBeanId = "test-bean-001",
         name = "テストコーヒー豆",
         description = "テスト説明文",
         origin = "エチオピア",
         farm = "テスト農園",
-        roastLevel = RoastLevel.MEDIUM,
-        processingMethod = ProcessingMethod.WASHED,
+        roastLevel = "MEDIUM",
+        processingMethod = "WASHED",
         isSpecialty = true,
         images = emptyList(),
         tastes = emptyList(),
     )
 
-    private fun createUsecase(bean: CoffeeBean? = existingBean): GetCoffeeBeanUsecase {
-        val fakeRepository = object : CoffeeBeanRepository {
-            override fun save(coffeeBean: CoffeeBean) = Unit
-            override fun findById(id: CoffeeBeanId): CoffeeBean? =
-                if (id == existingBean.id) bean else null
-            override fun deleteById(id: CoffeeBeanId) = Unit
+    private fun createUsecase(result: CoffeeBeanDetailResult? = existingResult): GetCoffeeBeanUsecase {
+        val fakeQueryService = object : CoffeeBeanQueryService {
+            override fun findList(page: Int, size: Int): PagedResult<CoffeeBeanListResult> =
+                PagedResult(emptyList(), 0L, page, size)
+            override fun findDetail(id: String): CoffeeBeanDetailResult? =
+                if (id == existingResult.id) result else null
         }
-        return GetCoffeeBeanUsecase(fakeRepository)
+        return GetCoffeeBeanUsecase(fakeQueryService)
     }
 
     @Nested
@@ -46,7 +43,7 @@ class GetCoffeeBeanUsecaseTest {
             val usecase = createUsecase()
             val result = usecase.execute("00000000-0000-4000-8000-000000000001")
 
-            assertEquals(existingBean, result)
+            assertEquals(existingResult, result)
         }
     }
 

--- a/backend/admin-api/src/test/kotlin/com/mametosho/admin/presentation/controller/CoffeeBeanControllerTest.kt
+++ b/backend/admin-api/src/test/kotlin/com/mametosho/admin/presentation/controller/CoffeeBeanControllerTest.kt
@@ -1,6 +1,7 @@
 package com.mametosho.admin.presentation.controller
 
 import com.mametosho.admin.application.query.CoffeeBeanQueryService
+import com.mametosho.admin.application.query.result.CoffeeBeanDetailResult
 import com.mametosho.admin.application.query.result.CoffeeBeanListResult
 import com.mametosho.admin.application.query.result.PagedResult
 import com.mametosho.admin.application.usecase.CreateCoffeeBeanUsecase
@@ -40,10 +41,25 @@ class CoffeeBeanControllerTest {
         tastes = emptyList(),
     )
 
+    private val sampleDetailResult = CoffeeBeanDetailResult(
+        id = "00000000-0000-4000-8000-000000000001",
+        shopId = "00000000-0000-4000-8000-000000000002",
+        shopifyBeanId = "test-bean-001",
+        name = "テストコーヒー豆",
+        description = "テスト説明文",
+        origin = "エチオピア",
+        farm = "テスト農園",
+        roastLevel = "MEDIUM",
+        processingMethod = "WASHED",
+        isSpecialty = true,
+        images = emptyList(),
+        tastes = emptyList(),
+    )
+
     private val fakeRepository = object : com.mametosho.domain.repository.CoffeeBeanRepository {
         override fun save(coffeeBean: CoffeeBean) = Unit
-        override fun findById(id: com.mametosho.domain.model.coffeebean.CoffeeBeanId): CoffeeBean? = null
-        override fun deleteById(id: com.mametosho.domain.model.coffeebean.CoffeeBeanId) = Unit
+        override fun findById(id: CoffeeBeanId): CoffeeBean? = null
+        override fun deleteById(id: CoffeeBeanId) = Unit
     }
 
     private val fakeImageStorageService = FakeImageStorageService
@@ -75,19 +91,19 @@ class CoffeeBeanControllerTest {
         size = 20,
     )
 
-    private val fakeQueryService = object : CoffeeBeanQueryService {
-        override fun findList(page: Int, size: Int): PagedResult<CoffeeBeanListResult> = sampleListResult
-    }
-
     private fun createController(
         coffeeBean: CoffeeBean = sampleCoffeeBean,
-        getResult: CoffeeBean? = sampleCoffeeBean,
+        getResult: CoffeeBeanDetailResult? = sampleDetailResult,
         listResult: PagedResult<CoffeeBeanListResult> = sampleListResult,
         updateResult: CoffeeBean? = sampleCoffeeBean,
         deleteResult: Boolean = true,
     ): CoffeeBeanController {
-        val fakeGetUsecase = object : GetCoffeeBeanUsecase(fakeRepository) {
-            override fun execute(id: String): CoffeeBean? = getResult
+        val fakeQueryService = object : CoffeeBeanQueryService {
+            override fun findList(page: Int, size: Int): PagedResult<CoffeeBeanListResult> = listResult
+            override fun findDetail(id: String): CoffeeBeanDetailResult? = getResult
+        }
+        val fakeGetUsecase = object : GetCoffeeBeanUsecase(fakeQueryService) {
+            override fun execute(id: String): CoffeeBeanDetailResult? = getResult
         }
         val fakeListUsecase = object : ListCoffeeBeansUsecase(fakeQueryService) {
             override fun execute(page: Int, size: Int): PagedResult<CoffeeBeanListResult> = listResult

--- a/backend/admin-api/src/test/kotlin/com/mametosho/admin/presentation/dto/response/CoffeeBeanDetailResponseTest.kt
+++ b/backend/admin-api/src/test/kotlin/com/mametosho/admin/presentation/dto/response/CoffeeBeanDetailResponseTest.kt
@@ -1,18 +1,6 @@
 package com.mametosho.admin.presentation.dto.response
 
-import com.mametosho.domain.model.coffeebean.CoffeeBean
-import com.mametosho.domain.model.coffeebean.CoffeeBeanId
-import com.mametosho.domain.model.coffeebean.CoffeeBeanImage
-import com.mametosho.domain.model.coffeebean.CoffeeBeanImageId
-import com.mametosho.domain.model.coffeebean.CoffeeBeanImageType
-import com.mametosho.domain.model.coffeebean.CoffeeBeanTaste
-import com.mametosho.domain.model.coffeebean.CoffeeBeanTasteId
-import com.mametosho.domain.model.coffeebean.ProcessingMethod
-import com.mametosho.domain.model.coffeebean.RoastLevel
-import com.mametosho.domain.model.coffeebean.ShopifyBeanId
-import com.mametosho.domain.model.shared.ImageUrl
-import com.mametosho.domain.model.shop.ShopId
-import com.mametosho.domain.model.taste.TasteId
+import com.mametosho.admin.application.query.result.CoffeeBeanDetailResult
 import org.junit.jupiter.api.Nested
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -20,20 +8,20 @@ import kotlin.test.assertNull
 
 class CoffeeBeanDetailResponseTest {
 
-    private fun createCoffeeBean(
+    private fun createResult(
         farm: String? = "テスト農園",
-        images: List<CoffeeBeanImage> = emptyList(),
-        tastes: List<CoffeeBeanTaste> = emptyList(),
-    ): CoffeeBean = CoffeeBean(
-        id = CoffeeBeanId("00000000-0000-4000-8000-000000000001"),
-        shopId = ShopId("00000000-0000-4000-8000-000000000002"),
-        shopifyBeanId = ShopifyBeanId("test-bean-001"),
+        images: List<CoffeeBeanDetailResult.ImageResult> = emptyList(),
+        tastes: List<CoffeeBeanDetailResult.TasteResult> = emptyList(),
+    ): CoffeeBeanDetailResult = CoffeeBeanDetailResult(
+        id = "00000000-0000-4000-8000-000000000001",
+        shopId = "00000000-0000-4000-8000-000000000002",
+        shopifyBeanId = "test-bean-001",
         name = "テストコーヒー豆",
         description = "テスト説明文",
         origin = "エチオピア",
         farm = farm,
-        roastLevel = RoastLevel.MEDIUM,
-        processingMethod = ProcessingMethod.WASHED,
+        roastLevel = "MEDIUM",
+        processingMethod = "WASHED",
         isSpecialty = true,
         images = images,
         tastes = tastes,
@@ -43,19 +31,19 @@ class CoffeeBeanDetailResponseTest {
     inner class 正常系変換 {
         @Test
         fun `全フィールドが正しく変換される`() {
-            val image = CoffeeBeanImage(
-                id = CoffeeBeanImageId("00000000-0000-4000-8000-000000000010"),
-                type = CoffeeBeanImageType.MAIN,
-                imageUrl = ImageUrl("https://example.com/image.jpg"),
+            val image = CoffeeBeanDetailResult.ImageResult(
+                id = "00000000-0000-4000-8000-000000000010",
+                type = "MAIN",
+                imageUrl = "https://example.com/image.jpg",
             )
-            val taste = CoffeeBeanTaste(
-                id = CoffeeBeanTasteId("00000000-0000-4000-8000-000000000020"),
-                tasteId = TasteId("00000000-0000-4000-8000-000000000030"),
+            val taste = CoffeeBeanDetailResult.TasteResult(
+                id = "00000000-0000-4000-8000-000000000020",
+                tasteName = "酸味",
                 evaluationValue = 4,
             )
-            val coffeeBean = createCoffeeBean(images = listOf(image), tastes = listOf(taste))
+            val result = createResult(images = listOf(image), tastes = listOf(taste))
 
-            val response = CoffeeBeanDetailResponse.from(coffeeBean)
+            val response = CoffeeBeanDetailResponse.from(result)
 
             assertEquals("00000000-0000-4000-8000-000000000001", response.id)
             assertEquals("00000000-0000-4000-8000-000000000002", response.shopId)
@@ -73,7 +61,7 @@ class CoffeeBeanDetailResponseTest {
             assertEquals("https://example.com/image.jpg", response.images[0].imageUrl)
             assertEquals(1, response.tastes.size)
             assertEquals("00000000-0000-4000-8000-000000000020", response.tastes[0].id)
-            assertEquals("00000000-0000-4000-8000-000000000030", response.tastes[0].tasteId)
+            assertEquals("酸味", response.tastes[0].tasteName)
             assertEquals(4, response.tastes[0].evaluationValue)
         }
     }
@@ -82,9 +70,9 @@ class CoffeeBeanDetailResponseTest {
     inner class nullable項目 {
         @Test
         fun `farmがnullの場合nullが返る`() {
-            val coffeeBean = createCoffeeBean(farm = null)
+            val result = createResult(farm = null)
 
-            val response = CoffeeBeanDetailResponse.from(coffeeBean)
+            val response = CoffeeBeanDetailResponse.from(result)
 
             assertNull(response.farm)
         }
@@ -94,18 +82,18 @@ class CoffeeBeanDetailResponseTest {
     inner class 空コレクション {
         @Test
         fun `画像が空の場合空リストが返る`() {
-            val coffeeBean = createCoffeeBean(images = emptyList())
+            val result = createResult(images = emptyList())
 
-            val response = CoffeeBeanDetailResponse.from(coffeeBean)
+            val response = CoffeeBeanDetailResponse.from(result)
 
             assertEquals(emptyList(), response.images)
         }
 
         @Test
         fun `テイスト評価が空の場合空リストが返る`() {
-            val coffeeBean = createCoffeeBean(tastes = emptyList())
+            val result = createResult(tastes = emptyList())
 
-            val response = CoffeeBeanDetailResponse.from(coffeeBean)
+            val response = CoffeeBeanDetailResponse.from(result)
 
             assertEquals(emptyList(), response.tastes)
         }

--- a/backend/common/src/main/kotlin/com/mametosho/infrastructure/persistence/mybatis/entity/CoffeeBeanDetailRow.kt
+++ b/backend/common/src/main/kotlin/com/mametosho/infrastructure/persistence/mybatis/entity/CoffeeBeanDetailRow.kt
@@ -1,0 +1,20 @@
+package com.mametosho.infrastructure.persistence.mybatis.entity
+
+data class CoffeeBeanDetailRow(
+    val beanId: String,
+    val shopId: String,
+    val shopifyBeanId: String,
+    val beanName: String,
+    val description: String,
+    val origin: String,
+    val farm: String?,
+    val roastLevel: String,
+    val processingMethod: String,
+    val isSpecialty: Boolean,
+    val imageId: String?,
+    val imageType: String?,
+    val imageUrl: String?,
+    val tasteEvalId: String?,
+    val tasteName: String?,
+    val evaluationValue: Int?,
+)

--- a/backend/common/src/main/kotlin/com/mametosho/infrastructure/persistence/mybatis/entity/CoffeeBeanTasteDetailRow.kt
+++ b/backend/common/src/main/kotlin/com/mametosho/infrastructure/persistence/mybatis/entity/CoffeeBeanTasteDetailRow.kt
@@ -1,0 +1,7 @@
+package com.mametosho.infrastructure.persistence.mybatis.entity
+
+data class CoffeeBeanTasteDetailRow(
+    val id: String,
+    val tasteName: String,
+    val evaluationValue: Int,
+)

--- a/backend/common/src/main/kotlin/com/mametosho/infrastructure/persistence/mybatis/entity/CoffeeBeanTasteDetailRow.kt
+++ b/backend/common/src/main/kotlin/com/mametosho/infrastructure/persistence/mybatis/entity/CoffeeBeanTasteDetailRow.kt
@@ -1,7 +1,0 @@
-package com.mametosho.infrastructure.persistence.mybatis.entity
-
-data class CoffeeBeanTasteDetailRow(
-    val id: String,
-    val tasteName: String,
-    val evaluationValue: Int,
-)

--- a/backend/common/src/main/kotlin/com/mametosho/infrastructure/persistence/mybatis/mapper/CoffeeBeanMapper.kt
+++ b/backend/common/src/main/kotlin/com/mametosho/infrastructure/persistence/mybatis/mapper/CoffeeBeanMapper.kt
@@ -1,8 +1,8 @@
 package com.mametosho.infrastructure.persistence.mybatis.mapper
 
+import com.mametosho.infrastructure.persistence.mybatis.entity.CoffeeBeanDetailRow
 import com.mametosho.infrastructure.persistence.mybatis.entity.CoffeeBeanEntity
 import com.mametosho.infrastructure.persistence.mybatis.entity.CoffeeBeanImageEntity
-import com.mametosho.infrastructure.persistence.mybatis.entity.CoffeeBeanTasteDetailRow
 import com.mametosho.infrastructure.persistence.mybatis.entity.CoffeeBeanTasteEntity
 import org.apache.ibatis.annotations.Delete
 import org.apache.ibatis.annotations.Insert
@@ -28,13 +28,19 @@ interface CoffeeBeanMapper {
 
     @Select(
         """
-        SELECT cbt.id, t.name AS taste_name, cbt.evaluation_value
-        FROM coffee_bean_tastes cbt
-        INNER JOIN tastes t ON cbt.tastes_id = t.id
-        WHERE cbt.coffee_bean_id = #{coffeeBeanId}
+        SELECT
+            cb.id AS bean_id, cb.shop_id, cb.shopify_bean_id, cb.name AS bean_name,
+            cb.description, cb.origin, cb.farm, cb.roast_level, cb.processing_method, cb.is_specialty,
+            cbi.id AS image_id, cbi.type AS image_type, cbi.image_url,
+            cbt.id AS taste_eval_id, t.name AS taste_name, cbt.evaluation_value
+        FROM coffee_beans cb
+        LEFT JOIN coffee_bean_images cbi ON cbi.coffee_bean_id = cb.id
+        LEFT JOIN coffee_bean_tastes cbt ON cbt.coffee_bean_id = cb.id
+        LEFT JOIN tastes t ON cbt.tastes_id = t.id
+        WHERE cb.id = #{id}
         """,
     )
-    fun findTasteDetailsByCoffeeBeanId(coffeeBeanId: String): List<CoffeeBeanTasteDetailRow>
+    fun findDetailRowsById(id: String): List<CoffeeBeanDetailRow>
 
     @Select(
         """

--- a/backend/common/src/main/kotlin/com/mametosho/infrastructure/persistence/mybatis/mapper/CoffeeBeanMapper.kt
+++ b/backend/common/src/main/kotlin/com/mametosho/infrastructure/persistence/mybatis/mapper/CoffeeBeanMapper.kt
@@ -2,6 +2,7 @@ package com.mametosho.infrastructure.persistence.mybatis.mapper
 
 import com.mametosho.infrastructure.persistence.mybatis.entity.CoffeeBeanEntity
 import com.mametosho.infrastructure.persistence.mybatis.entity.CoffeeBeanImageEntity
+import com.mametosho.infrastructure.persistence.mybatis.entity.CoffeeBeanTasteDetailRow
 import com.mametosho.infrastructure.persistence.mybatis.entity.CoffeeBeanTasteEntity
 import org.apache.ibatis.annotations.Delete
 import org.apache.ibatis.annotations.Insert
@@ -24,6 +25,16 @@ interface CoffeeBeanMapper {
 
     @Select("SELECT id, coffee_bean_id, tastes_id, evaluation_value FROM coffee_bean_tastes WHERE coffee_bean_id = #{coffeeBeanId}")
     fun findTastesByCoffeeBeanId(coffeeBeanId: String): List<CoffeeBeanTasteEntity>
+
+    @Select(
+        """
+        SELECT cbt.id, t.name AS taste_name, cbt.evaluation_value
+        FROM coffee_bean_tastes cbt
+        INNER JOIN tastes t ON cbt.tastes_id = t.id
+        WHERE cbt.coffee_bean_id = #{coffeeBeanId}
+        """,
+    )
+    fun findTasteDetailsByCoffeeBeanId(coffeeBeanId: String): List<CoffeeBeanTasteDetailRow>
 
     @Select(
         """


### PR DESCRIPTION
## Summary

- 豆詳細API（`GET /api/admin/coffee-beans/:id`）のテイスト評価レスポンスで、`tasteId`（UUID）の代わりに`tasteName`（テイスト名）を返すよう変更
- CQRS の Query 側でのみ対応し、ドメインモデル（`CoffeeBeanTaste`）には一切変更を加えていない
- admin-frontend の表示も `tasteId` → `tasteName` に更新

## 変更の詳細

**バックエンド**
- `CoffeeBeanDetailResult` を Query の Result クラスとして新規追加（`tastes` は `tasteName` を保持）
- `CoffeeBeanTasteDetailRow` を新規追加（`coffee_bean_tastes INNER JOIN tastes` のフラット行）
- `CoffeeBeanMapper` に `findTasteDetailsByCoffeeBeanId` を追加（JOIN クエリ）
- `CoffeeBeanQueryService` に `findDetail(id)` を追加し、`CoffeeBeanQueryServiceImpl` で実装
- `GetCoffeeBeanUsecase` を `CoffeeBeanRepository` から `CoffeeBeanQueryService` に変更
- `CoffeeBeanDetailResponse.TasteDetail` を `tasteId` → `tasteName` に変更

**フロントエンド**
- `CoffeeBeanDetail` 型の `tastes` を `tasteId: string` → `tasteName: string` に変更
- 詳細画面でテイスト名を表示するよう更新

## Test plan

- [ ] `./gradlew :admin-api:test :common:test` が全て通ること
- [ ] 豆詳細画面でテイスト評価の名称（例：酸味、苦味）が表示されること
- [ ] テイストが0件の豆でも正常に表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)