### PR TITLE
fix: テスト用にS3ダミー設定を追加してCIを修正

### DIFF
--- a/backend/admin-api/src/test/resources/application-test.yml
+++ b/backend/admin-api/src/test/resources/application-test.yml
@@ -11,3 +11,9 @@ mybatis:
 jwt:
   secret-key: test-secret-key-must-be-at-least-32-bytes-long-for-hmac
   expiration-seconds: 3600
+
+storage:
+  s3:
+    bucket-name: test-bucket
+    region: ap-northeast-1
+    base-url: http://localhost:4566/test-bucket


### PR DESCRIPTION
## 原因

`admin-api/src/main/resources/application.yml` に下記の設定があり、全プロファイルで読み込まれていました。

```yaml
storage:
  s3:
    bucket-name: ${S3_BUCKET_NAME}
```

テスト実行時（`@ActiveProfiles("test")`）は `S3_BUCKET_NAME` 環境変数が未設定のため、`@ConditionalOnProperty` がプロパティ評価時にプレースホルダー解決を試みて `PlaceholderResolutionException` が発生していました。

## 修正内容

`admin-api/src/test/resources/application-test.yml` にダミーの S3 設定を追加しました。テストでは `FakeImageStorageService` が `@Primary` で登録されるため、実際の S3 アクセスは発生しません。

## 影響範囲

- テストのみ。dev/prod 環境は環境変数 (`S3_BUCKET_NAME` 等) から引き続き設定されます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)