### PR TITLE
fix: RDS SGルールのfor_eachを静的キーのmapに変更

### DIFF
--- a/infrastructure/terraform/environments/dev/main.tf
+++ b/infrastructure/terraform/environments/dev/main.tf
@@ -89,9 +89,9 @@ module "rds" {
   vpc_id             = module.vpc.vpc_id
   private_subnet_ids = module.vpc.private_subnet_ids
 
-  allowed_security_group_ids = [
-    module.bastion.security_group_id,
-  ]
+  allowed_security_group_ids = {
+    bastion = module.bastion.security_group_id
+  }
 
   instance_class          = "db.t4g.micro"
   db_name                 = "mametosho"

--- a/infrastructure/terraform/modules/rds/main.tf
+++ b/infrastructure/terraform/modules/rds/main.tf
@@ -12,7 +12,7 @@ resource "aws_security_group" "main" {
 }
 
 resource "aws_security_group_rule" "ingress_allowed" {
-  for_each = toset(var.allowed_security_group_ids)
+  for_each = var.allowed_security_group_ids
 
   type                     = "ingress"
   from_port                = 3306

--- a/infrastructure/terraform/modules/rds/variables.tf
+++ b/infrastructure/terraform/modules/rds/variables.tf
@@ -19,8 +19,8 @@ variable "private_subnet_ids" {
 }
 
 variable "allowed_security_group_ids" {
-  type        = list(string)
-  description = "Security group IDs allowed to access RDS"
+  type        = map(string)
+  description = "Security group IDs allowed to access RDS (key is a static label, value is the SG ID)"
 }
 
 variable "instance_class" {


### PR DESCRIPTION
## 概要
`terraform destroy`（および初回 apply）で発生する `Invalid for_each argument` エラーを修正。

## 原因
`modules/rds/main.tf` の `aws_security_group_rule.ingress_allowed` で
`for_each = toset(var.allowed_security_group_ids)` としていたが、
`allowed_security_group_ids` には `module.bastion.security_group_id`（apply 時にしか
決まらない unknown 値）が渡される。`for_each` はキー集合を plan 段階で確定する必要があるため、
unknown 値を `toset()` のキーにするとエラーになる。

`c3d0432` で inline ingress を standalone な `aws_security_group_rule` + `for_each(toset)` に
変換した際に、属性値（unknown 可）→ for_each のキー（unknown 不可）へと性質が変わったことが発端。

## 修正
`allowed_security_group_ids` を `list(string)` → `map(string)` に変更し、
`for_each` のキーを静的な `bastion` に固定。値が apply 時 unknown でもキー集合は
plan 段階で確定するため、apply/destroy とも正常に動作する。
（Terraform 公式のエラーメッセージが推奨する対応そのもの）

## 確認
- `terraform validate` 成功
- `terraform destroy` が for_each エラーを出さず完走（VPC まで削除完了）

🤖 Generated with [Claude Code](https://claude.com/claude-code)