### PR TITLE
feat: 店・豆の公開/非公開(下書き)機能

### DIFF
--- a/admin-frontend/src/api/coffee-beans.ts
+++ b/admin-frontend/src/api/coffee-beans.ts
@@ -15,6 +15,7 @@ export type CoffeeBeanListItem = {
   roastLevel: string;
   processingMethod: string;
   isSpecialty: boolean;
+  publishStatus: "DRAFT" | "PUBLISHED";
 };
 
 export type CoffeeBeanDetail = CoffeeBeanListItem & {

--- a/admin-frontend/src/api/generated/admin-api.ts
+++ b/admin-frontend/src/api/generated/admin-api.ts
@@ -128,6 +128,26 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/api/admin/tastes": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * テイスト一覧取得
+     * @description テイスト（酸味・苦味・甘味・コク・香りなど）の一覧を取得します。
+     */
+    get: operations["listTastes"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -164,6 +184,11 @@ export interface components {
        * @example TOKYO
        */
       prefecture?: string;
+      /**
+       * @description 公開状態（DRAFT: 下書き / PUBLISHED: 公開）
+       * @example PUBLISHED
+       */
+      publishStatus?: string;
     };
     /** @description 店舗登録レスポンス */
     ShopResponse: {
@@ -193,6 +218,11 @@ export interface components {
        */
       error?: string;
       /**
+       * @description エラーメッセージ
+       * @example tastes must not be empty
+       */
+      message?: string;
+      /**
        * @description リクエストパス
        * @example /api/admin/resources/00000000-0000-4000-8000-000000000099
        */
@@ -207,7 +237,7 @@ export interface components {
       tasteId?: string;
       /**
        * Format: int32
-       * @description 評価値
+       * @description 評価値（0-5）
        * @example 3
        */
       evaluationValue?: number;
@@ -254,6 +284,11 @@ export interface components {
        * @example WASHED
        */
       processingMethod?: string;
+      /**
+       * @description 公開状態（DRAFT: 下書き / PUBLISHED: 公開）
+       * @example PUBLISHED
+       */
+      publishStatus?: string;
       /** @description テイスト評価一覧 */
       tastes?: components["schemas"]["TasteRequest"][];
       specialty?: boolean;
@@ -298,6 +333,11 @@ export interface components {
        * @example TOKYO
        */
       prefecture?: string;
+      /**
+       * @description 公開状態（DRAFT: 下書き / PUBLISHED: 公開）
+       * @example DRAFT
+       */
+      publishStatus?: string;
     };
     /** @description コーヒー豆登録リクエスト */
     CreateCoffeeBeanRequest: {
@@ -341,6 +381,11 @@ export interface components {
        * @example WASHED
        */
       processingMethod?: string;
+      /**
+       * @description 公開状態（DRAFT: 下書き / PUBLISHED: 公開）
+       * @example DRAFT
+       */
+      publishStatus?: string;
       /** @description テイスト評価一覧 */
       tastes?: components["schemas"]["TasteRequest"][];
       specialty?: boolean;
@@ -432,6 +477,11 @@ export interface components {
        * @example TOKYO
        */
       prefecture?: string;
+      /**
+       * @description 公開状態（DRAFT: 下書き / PUBLISHED: 公開）
+       * @example PUBLISHED
+       */
+      publishStatus?: string;
       /** @description 画像一覧 */
       images?: components["schemas"]["ImageDetail"][];
     };
@@ -482,6 +532,11 @@ export interface components {
        * @example WASHED
        */
       processingMethod?: string;
+      /**
+       * @description 公開状態（DRAFT: 下書き / PUBLISHED: 公開）
+       * @example PUBLISHED
+       */
+      publishStatus?: string;
       /** @description 画像一覧 */
       images?: components["schemas"]["ImageDetail"][];
       /** @description テイスト評価一覧 */
@@ -495,6 +550,11 @@ export interface components {
        * @example 00000000-0000-4000-8000-000000000020
        */
       id?: string;
+      /**
+       * @description テイストマスタID
+       * @example 00000000-0000-4000-8000-000000000041
+       */
+      tasteId?: string;
       /**
        * @description テイスト名
        * @example 酸味
@@ -970,6 +1030,26 @@ export interface operations {
       };
       /** @description 認証失敗 */
       401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": unknown;
+        };
+      };
+    };
+  };
+  listTastes: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 取得成功 */
+      200: {
         headers: {
           [name: string]: unknown;
         };

--- a/admin-frontend/src/api/generated/admin-api.ts
+++ b/admin-frontend/src/api/generated/admin-api.ts
@@ -188,7 +188,7 @@ export interface components {
        * @description 公開状態（DRAFT: 下書き / PUBLISHED: 公開）
        * @example PUBLISHED
        */
-      publishStatus?: string;
+      publishStatus: string;
     };
     /** @description 店舗登録レスポンス */
     ShopResponse: {
@@ -288,7 +288,7 @@ export interface components {
        * @description 公開状態（DRAFT: 下書き / PUBLISHED: 公開）
        * @example PUBLISHED
        */
-      publishStatus?: string;
+      publishStatus: string;
       /** @description テイスト評価一覧 */
       tastes?: components["schemas"]["TasteRequest"][];
       specialty?: boolean;
@@ -337,7 +337,7 @@ export interface components {
        * @description 公開状態（DRAFT: 下書き / PUBLISHED: 公開）
        * @example DRAFT
        */
-      publishStatus?: string;
+      publishStatus: string;
     };
     /** @description コーヒー豆登録リクエスト */
     CreateCoffeeBeanRequest: {
@@ -385,7 +385,7 @@ export interface components {
        * @description 公開状態（DRAFT: 下書き / PUBLISHED: 公開）
        * @example DRAFT
        */
-      publishStatus?: string;
+      publishStatus: string;
       /** @description テイスト評価一覧 */
       tastes?: components["schemas"]["TasteRequest"][];
       specialty?: boolean;
@@ -481,7 +481,7 @@ export interface components {
        * @description 公開状態（DRAFT: 下書き / PUBLISHED: 公開）
        * @example PUBLISHED
        */
-      publishStatus?: string;
+      publishStatus: string;
       /** @description 画像一覧 */
       images?: components["schemas"]["ImageDetail"][];
     };
@@ -536,7 +536,7 @@ export interface components {
        * @description 公開状態（DRAFT: 下書き / PUBLISHED: 公開）
        * @example PUBLISHED
        */
-      publishStatus?: string;
+      publishStatus: string;
       /** @description 画像一覧 */
       images?: components["schemas"]["ImageDetail"][];
       /** @description テイスト評価一覧 */

--- a/admin-frontend/src/api/shops.ts
+++ b/admin-frontend/src/api/shops.ts
@@ -14,6 +14,7 @@ export type ShopListItem = {
   particular: string | null;
   shopUrl: string;
   prefecture: string;
+  publishStatus: "DRAFT" | "PUBLISHED";
 };
 
 export type ImageDetail = {

--- a/admin-frontend/src/app/(admin)/coffee-beans/[id]/_components/CoffeeBeanDetail.tsx
+++ b/admin-frontend/src/app/(admin)/coffee-beans/[id]/_components/CoffeeBeanDetail.tsx
@@ -2,6 +2,7 @@ import Image from "next/image";
 import Link from "next/link";
 import type { CoffeeBeanDetail as CoffeeBeanDetailType } from "@/api/coffee-beans";
 import type { TasteListItem } from "@/api/tastes";
+import { PublishStatusBadge } from "@/components/PublishStatusBadge";
 import {
   getProcessingMethodLabel,
   getRoastLevelLabel,
@@ -36,6 +37,13 @@ export function CoffeeBeanDetail({
 
       <div className={styles.content}>
         <dl className={styles.fieldList}>
+          <div className={styles.field}>
+            <dt className={styles.fieldLabel}>公開状態</dt>
+            <dd className={styles.fieldValue}>
+              <PublishStatusBadge status={coffeeBean.publishStatus} />
+            </dd>
+          </div>
+
           <div className={styles.field}>
             <dt className={styles.fieldLabel}>Shopify Bean ID</dt>
             <dd className={styles.fieldValue}>{coffeeBean.shopifyBeanId}</dd>

--- a/admin-frontend/src/app/(admin)/coffee-beans/[id]/_components/EditCoffeeBeanModal.tsx
+++ b/admin-frontend/src/app/(admin)/coffee-beans/[id]/_components/EditCoffeeBeanModal.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/app/(admin)/coffee-beans/_lib/coffeeBeanLabels";
 import { ImageUploadField } from "@/components/ImageUploadField";
 import modalStyles from "@/components/modal.module.css";
+import { PUBLISH_STATUS_OPTIONS } from "@/components/publishStatus";
 import { ShopSearchSelect } from "@/components/ShopSearchSelect";
 import {
   type EditCoffeeBeanState,
@@ -52,6 +53,7 @@ export function EditCoffeeBeanModal({
   const roastLevelId = useId();
   const processingMethodId = useId();
   const isSpecialtyId = useId();
+  const publishStatusId = useId();
 
   useEffect(() => {
     const dialog = dialogRef.current;
@@ -275,6 +277,32 @@ export function EditCoffeeBeanModal({
             <option value="false">なし</option>
           </select>
           {state.fieldErrors?.isSpecialty?.map((msg) => (
+            <span key={msg} className={modalStyles.fieldError}>
+              {msg}
+            </span>
+          ))}
+        </div>
+
+        <div className={modalStyles.field}>
+          <label htmlFor={publishStatusId} className={modalStyles.label}>
+            公開状態
+            <span className={modalStyles.required}>*</span>
+          </label>
+          <select
+            id={publishStatusId}
+            name="publishStatus"
+            defaultValue={
+              state.values?.publishStatus ?? coffeeBean.publishStatus
+            }
+            className={modalStyles.select}
+          >
+            {PUBLISH_STATUS_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+          {state.fieldErrors?.publishStatus?.map((msg) => (
             <span key={msg} className={modalStyles.fieldError}>
               {msg}
             </span>

--- a/admin-frontend/src/app/(admin)/coffee-beans/[id]/_components/editCoffeeBeanAction.ts
+++ b/admin-frontend/src/app/(admin)/coffee-beans/[id]/_components/editCoffeeBeanAction.ts
@@ -29,6 +29,7 @@ export async function editCoffeeBeanAction(
     roastLevel: (formData.get("roastLevel") as string) ?? "",
     processingMethod: (formData.get("processingMethod") as string) ?? "",
     isSpecialty: (formData.get("isSpecialty") as string) ?? "false",
+    publishStatus: (formData.get("publishStatus") as string) ?? "DRAFT",
   };
 
   const result = editCoffeeBeanSchema.safeParse({

--- a/admin-frontend/src/app/(admin)/coffee-beans/[id]/_components/editCoffeeBeanAction.ts
+++ b/admin-frontend/src/app/(admin)/coffee-beans/[id]/_components/editCoffeeBeanAction.ts
@@ -29,7 +29,7 @@ export async function editCoffeeBeanAction(
     roastLevel: (formData.get("roastLevel") as string) ?? "",
     processingMethod: (formData.get("processingMethod") as string) ?? "",
     isSpecialty: (formData.get("isSpecialty") as string) ?? "false",
-    publishStatus: (formData.get("publishStatus") as string) ?? "DRAFT",
+    publishStatus: (formData.get("publishStatus") as string) ?? "",
   };
 
   const result = editCoffeeBeanSchema.safeParse({

--- a/admin-frontend/src/app/(admin)/coffee-beans/_components/CoffeeBeanListTable.tsx
+++ b/admin-frontend/src/app/(admin)/coffee-beans/_components/CoffeeBeanListTable.tsx
@@ -3,6 +3,7 @@ import type { CoffeeBeanListItem } from "@/api/coffee-beans";
 import type { PagedResponse } from "@/api/types";
 import styles from "@/components/list-page.module.css";
 import { Pagination } from "@/components/Pagination";
+import { PublishStatusBadge } from "@/components/PublishStatusBadge";
 import {
   getProcessingMethodLabel,
   getRoastLevelLabel,
@@ -37,6 +38,7 @@ export function CoffeeBeanListTable({
               <th>焙煎度</th>
               <th>精製方法</th>
               <th>スペシャルティ</th>
+              <th>公開状態</th>
             </tr>
           </thead>
           <tbody>
@@ -88,6 +90,14 @@ export function CoffeeBeanListTable({
                     className={styles.rowLink}
                   >
                     {bean.isSpecialty ? "あり" : "なし"}
+                  </Link>
+                </td>
+                <td>
+                  <Link
+                    href={`/coffee-beans/${bean.id}`}
+                    className={styles.rowLink}
+                  >
+                    <PublishStatusBadge status={bean.publishStatus} />
                   </Link>
                 </td>
               </tr>

--- a/admin-frontend/src/app/(admin)/coffee-beans/_components/CreateCoffeeBeanModal.tsx
+++ b/admin-frontend/src/app/(admin)/coffee-beans/_components/CreateCoffeeBeanModal.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/app/(admin)/coffee-beans/_lib/coffeeBeanLabels";
 import { ImageUploadField } from "@/components/ImageUploadField";
 import modalStyles from "@/components/modal.module.css";
+import { PUBLISH_STATUS_OPTIONS } from "@/components/publishStatus";
 import { ShopSearchSelect } from "@/components/ShopSearchSelect";
 import {
   type CreateCoffeeBeanState,
@@ -54,6 +55,7 @@ export function CreateCoffeeBeanModal({
   const roastLevelId = useId();
   const processingMethodId = useId();
   const isSpecialtyId = useId();
+  const publishStatusId = useId();
 
   useEffect(() => {
     const dialog = dialogRef.current;
@@ -281,6 +283,30 @@ export function CreateCoffeeBeanModal({
             <option value="false">なし</option>
           </select>
           {state.fieldErrors?.isSpecialty?.map((msg) => (
+            <span key={msg} className={modalStyles.fieldError}>
+              {msg}
+            </span>
+          ))}
+        </div>
+
+        <div className={modalStyles.field}>
+          <label htmlFor={publishStatusId} className={modalStyles.label}>
+            公開状態
+            <span className={modalStyles.required}>*</span>
+          </label>
+          <select
+            id={publishStatusId}
+            name="publishStatus"
+            defaultValue={state.values?.publishStatus ?? "DRAFT"}
+            className={modalStyles.select}
+          >
+            {PUBLISH_STATUS_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+          {state.fieldErrors?.publishStatus?.map((msg) => (
             <span key={msg} className={modalStyles.fieldError}>
               {msg}
             </span>

--- a/admin-frontend/src/app/(admin)/coffee-beans/_components/createCoffeeBeanAction.ts
+++ b/admin-frontend/src/app/(admin)/coffee-beans/_components/createCoffeeBeanAction.ts
@@ -24,6 +24,7 @@ export async function createCoffeeBeanAction(
     roastLevel: (formData.get("roastLevel") as string) ?? "",
     processingMethod: (formData.get("processingMethod") as string) ?? "",
     isSpecialty: (formData.get("isSpecialty") as string) ?? "false",
+    publishStatus: (formData.get("publishStatus") as string) ?? "DRAFT",
   };
 
   const result = coffeeBeanFieldsSchema.safeParse(values);

--- a/admin-frontend/src/app/(admin)/coffee-beans/_components/createCoffeeBeanAction.ts
+++ b/admin-frontend/src/app/(admin)/coffee-beans/_components/createCoffeeBeanAction.ts
@@ -24,7 +24,7 @@ export async function createCoffeeBeanAction(
     roastLevel: (formData.get("roastLevel") as string) ?? "",
     processingMethod: (formData.get("processingMethod") as string) ?? "",
     isSpecialty: (formData.get("isSpecialty") as string) ?? "false",
-    publishStatus: (formData.get("publishStatus") as string) ?? "DRAFT",
+    publishStatus: (formData.get("publishStatus") as string) ?? "",
   };
 
   const result = coffeeBeanFieldsSchema.safeParse(values);

--- a/admin-frontend/src/app/(admin)/coffee-beans/_lib/coffeeBeanFormSchema.ts
+++ b/admin-frontend/src/app/(admin)/coffee-beans/_lib/coffeeBeanFormSchema.ts
@@ -35,6 +35,9 @@ export const coffeeBeanFieldsSchema = z.object({
       error: "スペシャルティを選択してください。",
     })
     .transform((v) => v === "true"),
+  publishStatus: z.enum(["DRAFT", "PUBLISHED"], {
+    error: "公開状態を選択してください。",
+  }),
 });
 
 export type CoffeeBeanFormValues = {
@@ -47,6 +50,7 @@ export type CoffeeBeanFormValues = {
   roastLevel?: string;
   processingMethod?: string;
   isSpecialty?: string;
+  publishStatus?: string;
 };
 
 export type CoffeeBeanFormState = {
@@ -62,6 +66,7 @@ export type CoffeeBeanFormState = {
     roastLevel?: string[];
     processingMethod?: string[];
     isSpecialty?: string[];
+    publishStatus?: string[];
   };
   values?: CoffeeBeanFormValues;
 };

--- a/admin-frontend/src/app/(admin)/shops/[id]/_components/EditShopModal.tsx
+++ b/admin-frontend/src/app/(admin)/shops/[id]/_components/EditShopModal.tsx
@@ -11,6 +11,7 @@ import type { ShopDetail } from "@/api/shops";
 import { PREFECTURE_OPTIONS } from "@/app/(admin)/shops/_lib/prefecture";
 import { ImageUploadField } from "@/components/ImageUploadField";
 import modalStyles from "@/components/modal.module.css";
+import { PUBLISH_STATUS_OPTIONS } from "@/components/publishStatus";
 import { type EditShopState, editShopAction } from "./editShopAction";
 
 const initialState: EditShopState = {};
@@ -36,6 +37,7 @@ export function EditShopModal({
   const particularId = useId();
   const shopUrlId = useId();
   const prefectureId = useId();
+  const publishStatusId = useId();
 
   useEffect(() => {
     const dialog = dialogRef.current;
@@ -199,6 +201,30 @@ export function EditShopModal({
             ))}
           </select>
           {state.fieldErrors?.prefecture?.map((msg) => (
+            <span key={msg} className={modalStyles.fieldError}>
+              {msg}
+            </span>
+          ))}
+        </div>
+
+        <div className={modalStyles.field}>
+          <label htmlFor={publishStatusId} className={modalStyles.label}>
+            公開状態
+            <span className={modalStyles.required}>*</span>
+          </label>
+          <select
+            id={publishStatusId}
+            name="publishStatus"
+            defaultValue={state.values?.publishStatus ?? shop.publishStatus}
+            className={modalStyles.input}
+          >
+            {PUBLISH_STATUS_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+          {state.fieldErrors?.publishStatus?.map((msg) => (
             <span key={msg} className={modalStyles.fieldError}>
               {msg}
             </span>

--- a/admin-frontend/src/app/(admin)/shops/[id]/_components/ShopDetail.tsx
+++ b/admin-frontend/src/app/(admin)/shops/[id]/_components/ShopDetail.tsx
@@ -2,6 +2,7 @@ import Image from "next/image";
 import Link from "next/link";
 import type { ShopDetail as ShopDetailType } from "@/api/shops";
 import { getPrefectureLabel } from "@/app/(admin)/shops/_lib/prefecture";
+import { PublishStatusBadge } from "@/components/PublishStatusBadge";
 import { ShopActions } from "./ShopActions";
 import styles from "./ShopDetail.module.css";
 
@@ -20,6 +21,13 @@ export function ShopDetail({ shop }: { shop: ShopDetailType }) {
 
       <div className={styles.content}>
         <dl className={styles.fieldList}>
+          <div className={styles.field}>
+            <dt className={styles.fieldLabel}>公開状態</dt>
+            <dd className={styles.fieldValue}>
+              <PublishStatusBadge status={shop.publishStatus} />
+            </dd>
+          </div>
+
           <div className={styles.field}>
             <dt className={styles.fieldLabel}>Shopify Shop ID</dt>
             <dd className={styles.fieldValue}>{shop.shopifyShopId}</dd>

--- a/admin-frontend/src/app/(admin)/shops/[id]/_components/editShopAction.ts
+++ b/admin-frontend/src/app/(admin)/shops/[id]/_components/editShopAction.ts
@@ -25,7 +25,7 @@ export async function editShopAction(
     particular: (formData.get("particular") as string) ?? "",
     shopUrl: (formData.get("shopUrl") as string) ?? "",
     prefecture: (formData.get("prefecture") as string) ?? "",
-    publishStatus: (formData.get("publishStatus") as string) ?? "DRAFT",
+    publishStatus: (formData.get("publishStatus") as string) ?? "",
   };
 
   const result = editShopSchema.safeParse({

--- a/admin-frontend/src/app/(admin)/shops/[id]/_components/editShopAction.ts
+++ b/admin-frontend/src/app/(admin)/shops/[id]/_components/editShopAction.ts
@@ -25,6 +25,7 @@ export async function editShopAction(
     particular: (formData.get("particular") as string) ?? "",
     shopUrl: (formData.get("shopUrl") as string) ?? "",
     prefecture: (formData.get("prefecture") as string) ?? "",
+    publishStatus: (formData.get("publishStatus") as string) ?? "DRAFT",
   };
 
   const result = editShopSchema.safeParse({
@@ -56,12 +57,21 @@ export async function editShopAction(
     particular,
     shopUrl,
     prefecture,
+    publishStatus,
   } = result.data;
 
   const response = await multipartRequest(
     `/api/admin/shops/${id}`,
     "PUT",
-    { shopifyShopId, name, introduction, particular, shopUrl, prefecture },
+    {
+      shopifyShopId,
+      name,
+      introduction,
+      particular,
+      shopUrl,
+      prefecture,
+      publishStatus,
+    },
     formData,
   );
 

--- a/admin-frontend/src/app/(admin)/shops/_components/CreateShopModal.tsx
+++ b/admin-frontend/src/app/(admin)/shops/_components/CreateShopModal.tsx
@@ -10,6 +10,7 @@ import {
 import { PREFECTURE_OPTIONS } from "@/app/(admin)/shops/_lib/prefecture";
 import { ImageUploadField } from "@/components/ImageUploadField";
 import styles from "@/components/modal.module.css";
+import { PUBLISH_STATUS_OPTIONS } from "@/components/publishStatus";
 import { type CreateShopState, createShopAction } from "./createShopAction";
 
 const initialState: CreateShopState = {};
@@ -33,6 +34,7 @@ export function CreateShopModal({
   const particularId = useId();
   const shopUrlId = useId();
   const prefectureId = useId();
+  const publishStatusId = useId();
 
   useEffect(() => {
     const dialog = dialogRef.current;
@@ -197,6 +199,30 @@ export function CreateShopModal({
             ))}
           </select>
           {state.fieldErrors?.prefecture?.map((msg) => (
+            <span key={msg} className={styles.fieldError}>
+              {msg}
+            </span>
+          ))}
+        </div>
+
+        <div className={styles.field}>
+          <label htmlFor={publishStatusId} className={styles.label}>
+            公開状態
+            <span className={styles.required}>*</span>
+          </label>
+          <select
+            id={publishStatusId}
+            name="publishStatus"
+            defaultValue={state.values?.publishStatus ?? "DRAFT"}
+            className={styles.input}
+          >
+            {PUBLISH_STATUS_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+          {state.fieldErrors?.publishStatus?.map((msg) => (
             <span key={msg} className={styles.fieldError}>
               {msg}
             </span>

--- a/admin-frontend/src/app/(admin)/shops/_components/ShopListTable.tsx
+++ b/admin-frontend/src/app/(admin)/shops/_components/ShopListTable.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import type { PagedResponse, ShopListItem } from "@/api/shops";
 import styles from "@/components/list-page.module.css";
 import { Pagination } from "@/components/Pagination";
+import { PublishStatusBadge } from "@/components/PublishStatusBadge";
 import { CreateShopButton } from "./CreateShopButton";
 
 export function ShopListTable({
@@ -31,6 +32,7 @@ export function ShopListTable({
               <th>紹介文</th>
               <th>こだわり</th>
               <th>店舗URL</th>
+              <th>公開状態</th>
             </tr>
           </thead>
           <tbody>
@@ -68,6 +70,11 @@ export function ShopListTable({
                     className={`${styles.rowLink} ${styles.truncatedCell}`}
                   >
                     {shop.shopUrl}
+                  </Link>
+                </td>
+                <td>
+                  <Link href={`/shops/${shop.id}`} className={styles.rowLink}>
+                    <PublishStatusBadge status={shop.publishStatus} />
                   </Link>
                 </td>
               </tr>

--- a/admin-frontend/src/app/(admin)/shops/_components/createShopAction.ts
+++ b/admin-frontend/src/app/(admin)/shops/_components/createShopAction.ts
@@ -20,7 +20,7 @@ export async function createShopAction(
     particular: (formData.get("particular") as string) ?? "",
     shopUrl: (formData.get("shopUrl") as string) ?? "",
     prefecture: (formData.get("prefecture") as string) ?? "",
-    publishStatus: (formData.get("publishStatus") as string) ?? "DRAFT",
+    publishStatus: (formData.get("publishStatus") as string) ?? "",
   };
 
   const result = shopFieldsSchema.safeParse(values);

--- a/admin-frontend/src/app/(admin)/shops/_components/createShopAction.ts
+++ b/admin-frontend/src/app/(admin)/shops/_components/createShopAction.ts
@@ -20,6 +20,7 @@ export async function createShopAction(
     particular: (formData.get("particular") as string) ?? "",
     shopUrl: (formData.get("shopUrl") as string) ?? "",
     prefecture: (formData.get("prefecture") as string) ?? "",
+    publishStatus: (formData.get("publishStatus") as string) ?? "DRAFT",
   };
 
   const result = shopFieldsSchema.safeParse(values);
@@ -37,13 +38,28 @@ export async function createShopAction(
     return { error: "ロゴ画像は必須です。", values };
   }
 
-  const { shopifyShopId, name, introduction, particular, shopUrl, prefecture } =
-    result.data;
+  const {
+    shopifyShopId,
+    name,
+    introduction,
+    particular,
+    shopUrl,
+    prefecture,
+    publishStatus,
+  } = result.data;
 
   const response = await multipartRequest(
     "/api/admin/shops",
     "POST",
-    { shopifyShopId, name, introduction, particular, shopUrl, prefecture },
+    {
+      shopifyShopId,
+      name,
+      introduction,
+      particular,
+      shopUrl,
+      prefecture,
+      publishStatus,
+    },
     formData,
   );
 

--- a/admin-frontend/src/app/(admin)/shops/_lib/shopFormSchema.ts
+++ b/admin-frontend/src/app/(admin)/shops/_lib/shopFormSchema.ts
@@ -33,6 +33,9 @@ export const shopFieldsSchema = z.object({
   prefecture: z.enum(prefectureValues, {
     error: "都道府県を選択してください。",
   }),
+  publishStatus: z.enum(["DRAFT", "PUBLISHED"], {
+    error: "公開状態を選択してください。",
+  }),
 });
 
 export type ShopFormValues = {
@@ -42,6 +45,7 @@ export type ShopFormValues = {
   particular?: string;
   shopUrl?: string;
   prefecture?: string;
+  publishStatus?: string;
 };
 
 export type ShopFormState = {
@@ -54,6 +58,7 @@ export type ShopFormState = {
     particular?: string[];
     shopUrl?: string[];
     prefecture?: string[];
+    publishStatus?: string[];
   };
   values?: ShopFormValues;
 };

--- a/admin-frontend/src/components/PublishStatusBadge.module.css
+++ b/admin-frontend/src/components/PublishStatusBadge.module.css
@@ -1,0 +1,21 @@
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.5;
+  white-space: nowrap;
+}
+
+.published {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.draft {
+  background: var(--color-bg-page);
+  color: var(--color-text-secondary);
+  border: 1px solid var(--color-border);
+}

--- a/admin-frontend/src/components/PublishStatusBadge.tsx
+++ b/admin-frontend/src/components/PublishStatusBadge.tsx
@@ -1,0 +1,15 @@
+import styles from "./PublishStatusBadge.module.css";
+import { getPublishStatusLabel } from "./publishStatus";
+
+export function PublishStatusBadge({ status }: { status: string }) {
+  const isPublished = status === "PUBLISHED";
+  return (
+    <span
+      className={`${styles.badge} ${
+        isPublished ? styles.published : styles.draft
+      }`}
+    >
+      {getPublishStatusLabel(status)}
+    </span>
+  );
+}

--- a/admin-frontend/src/components/publishStatus.ts
+++ b/admin-frontend/src/components/publishStatus.ts
@@ -1,0 +1,20 @@
+export const PUBLISH_STATUSES = ["DRAFT", "PUBLISHED"] as const;
+export type PublishStatus = (typeof PUBLISH_STATUSES)[number];
+
+export const PUBLISH_STATUS_LABELS: Record<PublishStatus, string> = {
+  DRAFT: "下書き",
+  PUBLISHED: "公開",
+};
+
+/**
+ * セレクトの選択肢順（デフォルトの下書きを先頭に）。
+ */
+export const PUBLISH_STATUS_OPTIONS: { value: PublishStatus; label: string }[] =
+  [
+    { value: "DRAFT", label: PUBLISH_STATUS_LABELS.DRAFT },
+    { value: "PUBLISHED", label: PUBLISH_STATUS_LABELS.PUBLISHED },
+  ];
+
+export function getPublishStatusLabel(value: string): string {
+  return PUBLISH_STATUS_LABELS[value as PublishStatus] ?? value;
+}

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/application/query/result/CoffeeBeanDetailResult.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/application/query/result/CoffeeBeanDetailResult.kt
@@ -11,6 +11,7 @@ data class CoffeeBeanDetailResult(
     val roastLevel: String,
     val processingMethod: String,
     val isSpecialty: Boolean,
+    val publishStatus: String,
     val images: List<ImageResult>,
     val tastes: List<TasteResult>,
 ) {

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/application/query/result/CoffeeBeanSummaryResult.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/application/query/result/CoffeeBeanSummaryResult.kt
@@ -11,4 +11,5 @@ data class CoffeeBeanSummaryResult(
     val roastLevel: String,
     val processingMethod: String,
     val isSpecialty: Boolean,
+    val publishStatus: String,
 )

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/application/usecase/CreateCoffeeBeanUsecase.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/application/usecase/CreateCoffeeBeanUsecase.kt
@@ -40,6 +40,7 @@ class CreateCoffeeBeanUsecase(
             roastLevel = request.roastLevel,
             processingMethod = request.processingMethod,
             isSpecialty = request.isSpecialty,
+            publishStatus = request.publishStatus,
             images = images,
             tastes = request.tastes.map { it.tasteId to it.evaluationValue },
             id = coffeeBeanId,

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/application/usecase/CreateShopUsecase.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/application/usecase/CreateShopUsecase.kt
@@ -38,6 +38,7 @@ class CreateShopUsecase(
             particular = request.particular,
             shopUrl = request.shopUrl,
             prefecture = Prefecture.valueOf(request.prefecture),
+            publishStatus = request.publishStatus,
             images = images,
             id = shopId,
         )

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/application/usecase/UpdateCoffeeBeanUsecase.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/application/usecase/UpdateCoffeeBeanUsecase.kt
@@ -47,6 +47,7 @@ class UpdateCoffeeBeanUsecase(
             roastLevel = request.roastLevel,
             processingMethod = request.processingMethod,
             isSpecialty = request.isSpecialty,
+            publishStatus = request.publishStatus,
             images = images,
             tastes = request.tastes.map { it.tasteId to it.evaluationValue },
         )

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/application/usecase/UpdateShopUsecase.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/application/usecase/UpdateShopUsecase.kt
@@ -46,6 +46,7 @@ class UpdateShopUsecase(
             particular = request.particular,
             shopUrl = request.shopUrl,
             prefecture = Prefecture.valueOf(request.prefecture),
+            publishStatus = request.publishStatus,
             images = images,
         )
         shopRepository.save(updatedShop)

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/infrastructure/persistence/query/CoffeeBeanQueryServiceImpl.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/infrastructure/persistence/query/CoffeeBeanQueryServiceImpl.kt
@@ -29,6 +29,7 @@ class CoffeeBeanQueryServiceImpl(
                 roastLevel = row.roastLevel,
                 processingMethod = row.processingMethod,
                 isSpecialty = row.isSpecialty,
+                publishStatus = row.publishStatus,
             )
         }
 
@@ -56,6 +57,7 @@ class CoffeeBeanQueryServiceImpl(
             roastLevel = first.roastLevel,
             processingMethod = first.processingMethod,
             isSpecialty = first.isSpecialty,
+            publishStatus = first.publishStatus,
             images = rows
                 .filter { it.imageId != null }
                 .distinctBy { it.imageId }

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/controller/CoffeeBeanController.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/controller/CoffeeBeanController.kt
@@ -73,7 +73,8 @@ class CoffeeBeanController(
                                           "farm": "イルガチェフェ農園",
                                           "roastLevel": "MEDIUM",
                                           "processingMethod": "WASHED",
-                                          "isSpecialty": true
+                                          "isSpecialty": true,
+                                          "publishStatus": "PUBLISHED"
                                         }
                                       ],
                                       "totalCount": 1,
@@ -127,6 +128,7 @@ class CoffeeBeanController(
                                       "roastLevel": "MEDIUM",
                                       "processingMethod": "WASHED",
                                       "isSpecialty": true,
+                                      "publishStatus": "PUBLISHED",
                                       "images": [
                                         {
                                           "id": "00000000-0000-4000-8000-000000000010",

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/controller/ShopController.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/controller/ShopController.kt
@@ -69,7 +69,9 @@ class ShopController(
                                           "name": "テスト珈琲店",
                                           "introduction": "こだわりの珈琲をお届けします。",
                                           "particular": "厳選された豆のみを使用しています。",
-                                          "shopUrl": "https://example.com"
+                                          "shopUrl": "https://example.com",
+                                          "prefecture": "TOKYO",
+                                          "publishStatus": "PUBLISHED"
                                         }
                                       ],
                                       "totalCount": 1,
@@ -121,6 +123,8 @@ class ShopController(
                                       "introduction": "こだわりの珈琲をお届けします。",
                                       "particular": "厳選された豆のみを使用しています。",
                                       "shopUrl": "https://example.com",
+                                      "prefecture": "TOKYO",
+                                      "publishStatus": "PUBLISHED",
                                       "images": [
                                         {
                                           "id": "00000000-0000-4000-8000-000000000010",

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/request/CreateCoffeeBeanRequest.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/request/CreateCoffeeBeanRequest.kt
@@ -31,7 +31,11 @@ data class CreateCoffeeBeanRequest(
     @Schema(description = "スペシャルティコーヒーかどうか", example = "true")
     val isSpecialty: Boolean,
 
-    @Schema(description = "公開状態（DRAFT: 下書き / PUBLISHED: 公開）", example = "DRAFT")
+    @Schema(
+        description = "公開状態（DRAFT: 下書き / PUBLISHED: 公開）",
+        example = "DRAFT",
+        requiredMode = Schema.RequiredMode.REQUIRED,
+    )
     val publishStatus: String,
 
     @Schema(description = "テイスト評価一覧")

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/request/CreateCoffeeBeanRequest.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/request/CreateCoffeeBeanRequest.kt
@@ -31,6 +31,9 @@ data class CreateCoffeeBeanRequest(
     @Schema(description = "スペシャルティコーヒーかどうか", example = "true")
     val isSpecialty: Boolean,
 
+    @Schema(description = "公開状態（DRAFT: 下書き / PUBLISHED: 公開）", example = "DRAFT")
+    val publishStatus: String,
+
     @Schema(description = "テイスト評価一覧")
     val tastes: List<TasteRequest>,
 ) {

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/request/CreateShopRequest.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/request/CreateShopRequest.kt
@@ -22,6 +22,10 @@ data class CreateShopRequest(
     @Schema(description = "都道府県", example = "TOKYO")
     val prefecture: String,
 
-    @Schema(description = "公開状態（DRAFT: 下書き / PUBLISHED: 公開）", example = "DRAFT")
+    @Schema(
+        description = "公開状態（DRAFT: 下書き / PUBLISHED: 公開）",
+        example = "DRAFT",
+        requiredMode = Schema.RequiredMode.REQUIRED,
+    )
     val publishStatus: String,
 )

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/request/CreateShopRequest.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/request/CreateShopRequest.kt
@@ -21,4 +21,7 @@ data class CreateShopRequest(
 
     @Schema(description = "都道府県", example = "TOKYO")
     val prefecture: String,
+
+    @Schema(description = "公開状態（DRAFT: 下書き / PUBLISHED: 公開）", example = "DRAFT")
+    val publishStatus: String,
 )

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/request/UpdateCoffeeBeanRequest.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/request/UpdateCoffeeBeanRequest.kt
@@ -31,6 +31,9 @@ data class UpdateCoffeeBeanRequest(
     @Schema(description = "スペシャルティコーヒーかどうか", example = "true")
     val isSpecialty: Boolean,
 
+    @Schema(description = "公開状態（DRAFT: 下書き / PUBLISHED: 公開）", example = "PUBLISHED")
+    val publishStatus: String,
+
     @Schema(description = "テイスト評価一覧")
     val tastes: List<TasteRequest>,
 ) {

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/request/UpdateCoffeeBeanRequest.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/request/UpdateCoffeeBeanRequest.kt
@@ -31,7 +31,11 @@ data class UpdateCoffeeBeanRequest(
     @Schema(description = "スペシャルティコーヒーかどうか", example = "true")
     val isSpecialty: Boolean,
 
-    @Schema(description = "公開状態（DRAFT: 下書き / PUBLISHED: 公開）", example = "PUBLISHED")
+    @Schema(
+        description = "公開状態（DRAFT: 下書き / PUBLISHED: 公開）",
+        example = "PUBLISHED",
+        requiredMode = Schema.RequiredMode.REQUIRED,
+    )
     val publishStatus: String,
 
     @Schema(description = "テイスト評価一覧")

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/request/UpdateShopRequest.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/request/UpdateShopRequest.kt
@@ -22,6 +22,10 @@ data class UpdateShopRequest(
     @Schema(description = "都道府県", example = "TOKYO")
     val prefecture: String,
 
-    @Schema(description = "公開状態（DRAFT: 下書き / PUBLISHED: 公開）", example = "PUBLISHED")
+    @Schema(
+        description = "公開状態（DRAFT: 下書き / PUBLISHED: 公開）",
+        example = "PUBLISHED",
+        requiredMode = Schema.RequiredMode.REQUIRED,
+    )
     val publishStatus: String,
 )

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/request/UpdateShopRequest.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/request/UpdateShopRequest.kt
@@ -21,4 +21,7 @@ data class UpdateShopRequest(
 
     @Schema(description = "都道府県", example = "TOKYO")
     val prefecture: String,
+
+    @Schema(description = "公開状態（DRAFT: 下書き / PUBLISHED: 公開）", example = "PUBLISHED")
+    val publishStatus: String,
 )

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/CoffeeBeanDetailResponse.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/CoffeeBeanDetailResponse.kt
@@ -25,7 +25,11 @@ data class CoffeeBeanDetailResponse(
     val processingMethod: String,
     @Schema(description = "スペシャルティコーヒーかどうか", example = "true")
     val isSpecialty: Boolean,
-    @Schema(description = "公開状態（DRAFT: 下書き / PUBLISHED: 公開）", example = "PUBLISHED")
+    @Schema(
+        description = "公開状態（DRAFT: 下書き / PUBLISHED: 公開）",
+        example = "PUBLISHED",
+        requiredMode = Schema.RequiredMode.REQUIRED,
+    )
     val publishStatus: String,
     @Schema(description = "画像一覧")
     val images: List<ImageDetail>,

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/CoffeeBeanDetailResponse.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/CoffeeBeanDetailResponse.kt
@@ -25,6 +25,8 @@ data class CoffeeBeanDetailResponse(
     val processingMethod: String,
     @Schema(description = "スペシャルティコーヒーかどうか", example = "true")
     val isSpecialty: Boolean,
+    @Schema(description = "公開状態（DRAFT: 下書き / PUBLISHED: 公開）", example = "PUBLISHED")
+    val publishStatus: String,
     @Schema(description = "画像一覧")
     val images: List<ImageDetail>,
     @Schema(description = "テイスト評価一覧")
@@ -64,6 +66,7 @@ data class CoffeeBeanDetailResponse(
             roastLevel = result.roastLevel,
             processingMethod = result.processingMethod,
             isSpecialty = result.isSpecialty,
+            publishStatus = result.publishStatus,
             images = result.images.map { ImageDetail(id = it.id, type = it.type, imageUrl = it.imageUrl) },
             tastes = result.tastes.map {
                 TasteDetail(id = it.id, tasteId = it.tasteId, tasteName = it.tasteName, evaluationValue = it.evaluationValue)

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/CoffeeBeanSummaryResponse.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/CoffeeBeanSummaryResponse.kt
@@ -25,6 +25,8 @@ data class CoffeeBeanSummaryResponse(
     val processingMethod: String,
     @Schema(description = "スペシャルティコーヒーかどうか", example = "true")
     val isSpecialty: Boolean,
+    @Schema(description = "公開状態（DRAFT: 下書き / PUBLISHED: 公開）", example = "PUBLISHED")
+    val publishStatus: String,
 ) {
     companion object {
         fun from(result: CoffeeBeanSummaryResult): CoffeeBeanSummaryResponse = CoffeeBeanSummaryResponse(
@@ -38,6 +40,7 @@ data class CoffeeBeanSummaryResponse(
             roastLevel = result.roastLevel,
             processingMethod = result.processingMethod,
             isSpecialty = result.isSpecialty,
+            publishStatus = result.publishStatus,
         )
     }
 }

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/CoffeeBeanSummaryResponse.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/CoffeeBeanSummaryResponse.kt
@@ -25,7 +25,11 @@ data class CoffeeBeanSummaryResponse(
     val processingMethod: String,
     @Schema(description = "スペシャルティコーヒーかどうか", example = "true")
     val isSpecialty: Boolean,
-    @Schema(description = "公開状態（DRAFT: 下書き / PUBLISHED: 公開）", example = "PUBLISHED")
+    @Schema(
+        description = "公開状態（DRAFT: 下書き / PUBLISHED: 公開）",
+        example = "PUBLISHED",
+        requiredMode = Schema.RequiredMode.REQUIRED,
+    )
     val publishStatus: String,
 ) {
     companion object {

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/ShopDetailResponse.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/ShopDetailResponse.kt
@@ -20,6 +20,8 @@ data class ShopDetailResponse(
     val shopUrl: String,
     @Schema(description = "都道府県", example = "TOKYO")
     val prefecture: String,
+    @Schema(description = "公開状態（DRAFT: 下書き / PUBLISHED: 公開）", example = "PUBLISHED")
+    val publishStatus: String,
     @Schema(description = "画像一覧")
     val images: List<ImageDetail>,
 ) {
@@ -50,6 +52,7 @@ data class ShopDetailResponse(
             particular = shop.particular,
             shopUrl = shop.shopUrl,
             prefecture = shop.prefecture.name,
+            publishStatus = shop.publishStatus.name,
             images = shop.images.map { ImageDetail.from(it) },
         )
     }

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/ShopDetailResponse.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/ShopDetailResponse.kt
@@ -20,7 +20,11 @@ data class ShopDetailResponse(
     val shopUrl: String,
     @Schema(description = "都道府県", example = "TOKYO")
     val prefecture: String,
-    @Schema(description = "公開状態（DRAFT: 下書き / PUBLISHED: 公開）", example = "PUBLISHED")
+    @Schema(
+        description = "公開状態（DRAFT: 下書き / PUBLISHED: 公開）",
+        example = "PUBLISHED",
+        requiredMode = Schema.RequiredMode.REQUIRED,
+    )
     val publishStatus: String,
     @Schema(description = "画像一覧")
     val images: List<ImageDetail>,

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/ShopSummaryResponse.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/ShopSummaryResponse.kt
@@ -19,7 +19,11 @@ data class ShopSummaryResponse(
     val shopUrl: String,
     @Schema(description = "都道府県", example = "TOKYO")
     val prefecture: String,
-    @Schema(description = "公開状態（DRAFT: 下書き / PUBLISHED: 公開）", example = "PUBLISHED")
+    @Schema(
+        description = "公開状態（DRAFT: 下書き / PUBLISHED: 公開）",
+        example = "PUBLISHED",
+        requiredMode = Schema.RequiredMode.REQUIRED,
+    )
     val publishStatus: String,
 ) {
     companion object {

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/ShopSummaryResponse.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/ShopSummaryResponse.kt
@@ -19,6 +19,8 @@ data class ShopSummaryResponse(
     val shopUrl: String,
     @Schema(description = "都道府県", example = "TOKYO")
     val prefecture: String,
+    @Schema(description = "公開状態（DRAFT: 下書き / PUBLISHED: 公開）", example = "PUBLISHED")
+    val publishStatus: String,
 ) {
     companion object {
         fun from(shop: Shop): ShopSummaryResponse = ShopSummaryResponse(
@@ -29,6 +31,7 @@ data class ShopSummaryResponse(
             particular = shop.particular,
             shopUrl = shop.shopUrl,
             prefecture = shop.prefecture.name,
+            publishStatus = shop.publishStatus.name,
         )
     }
 }

--- a/backend/admin-api/src/test/kotlin/com/mametosho/admin/application/usecase/CreateCoffeeBeanUsecaseTest.kt
+++ b/backend/admin-api/src/test/kotlin/com/mametosho/admin/application/usecase/CreateCoffeeBeanUsecaseTest.kt
@@ -41,6 +41,7 @@ class CreateCoffeeBeanUsecaseTest {
         roastLevel: String = "MEDIUM",
         processingMethod: String = "WASHED",
         isSpecialty: Boolean = true,
+        publishStatus: String = "PUBLISHED",
         tastes: List<CreateCoffeeBeanRequest.TasteRequest> = listOf(
             CreateCoffeeBeanRequest.TasteRequest(
                 tasteId = "00000000-0000-4000-8000-000000000041",
@@ -57,6 +58,7 @@ class CreateCoffeeBeanUsecaseTest {
         roastLevel = roastLevel,
         processingMethod = processingMethod,
         isSpecialty = isSpecialty,
+        publishStatus = publishStatus,
         tastes = tastes,
     )
 

--- a/backend/admin-api/src/test/kotlin/com/mametosho/admin/application/usecase/CreateShopUsecaseTest.kt
+++ b/backend/admin-api/src/test/kotlin/com/mametosho/admin/application/usecase/CreateShopUsecaseTest.kt
@@ -1,6 +1,7 @@
 package com.mametosho.admin.application.usecase
 
 import com.mametosho.admin.presentation.dto.request.CreateShopRequest
+import com.mametosho.domain.model.shared.PublishStatus
 import com.mametosho.domain.model.shop.Shop
 import com.mametosho.domain.model.shop.ShopId
 import com.mametosho.domain.repository.ShopRepository
@@ -23,7 +24,12 @@ class CreateShopUsecaseTest {
         }
 
         override fun findById(id: ShopId): Shop? = null
-        override fun findAll(page: Int, size: Int, name: String?): Pair<List<Shop>, Long> = Pair(emptyList(), 0L)
+        override fun findAll(
+            page: Int,
+            size: Int,
+            name: String?,
+            publishStatus: PublishStatus?,
+        ): Pair<List<Shop>, Long> = Pair(emptyList(), 0L)
         override fun deleteById(id: ShopId) = Unit
     }
 
@@ -38,6 +44,7 @@ class CreateShopUsecaseTest {
         particular: String? = "テストこだわり",
         shopUrl: String = "https://example.com",
         prefecture: String = "TOKYO",
+        publishStatus: String = "PUBLISHED",
     ): CreateShopRequest = CreateShopRequest(
         shopifyShopId = shopifyShopId,
         name = name,
@@ -45,6 +52,7 @@ class CreateShopUsecaseTest {
         particular = particular,
         shopUrl = shopUrl,
         prefecture = prefecture,
+        publishStatus = publishStatus,
     )
 
     @Nested

--- a/backend/admin-api/src/test/kotlin/com/mametosho/admin/application/usecase/DeleteCoffeeBeanUsecaseTest.kt
+++ b/backend/admin-api/src/test/kotlin/com/mametosho/admin/application/usecase/DeleteCoffeeBeanUsecaseTest.kt
@@ -24,6 +24,7 @@ class DeleteCoffeeBeanUsecaseTest {
         roastLevel = "MEDIUM",
         processingMethod = "WASHED",
         isSpecialty = true,
+        publishStatus = "PUBLISHED",
         images = listOf("MAIN" to "https://example.com/bean.jpg"),
         tastes = listOf("00000000-0000-4000-8000-000000000041" to 3),
     )

--- a/backend/admin-api/src/test/kotlin/com/mametosho/admin/application/usecase/DeleteShopUsecaseTest.kt
+++ b/backend/admin-api/src/test/kotlin/com/mametosho/admin/application/usecase/DeleteShopUsecaseTest.kt
@@ -1,6 +1,7 @@
 package com.mametosho.admin.application.usecase
 
 import com.mametosho.domain.model.shared.ImageUrl
+import com.mametosho.domain.model.shared.PublishStatus
 import com.mametosho.domain.model.shop.Shop
 import com.mametosho.domain.model.shop.ShopId
 import com.mametosho.domain.model.shop.ShopImage
@@ -29,6 +30,7 @@ class DeleteShopUsecaseTest {
         particular = "テストこだわり",
         shopUrl = "https://example.com",
         prefecture = Prefecture.TOKYO,
+        publishStatus = PublishStatus.PUBLISHED,
         images = listOf(
             ShopImage(
                 id = ShopImageId("00000000-0000-4000-8000-000000000011"),
@@ -52,7 +54,12 @@ class DeleteShopUsecaseTest {
             return if (id.value == existingShopId) existingShop else null
         }
 
-        override fun findAll(page: Int, size: Int, name: String?): Pair<List<Shop>, Long> = Pair(emptyList(), 0L)
+        override fun findAll(
+            page: Int,
+            size: Int,
+            name: String?,
+            publishStatus: PublishStatus?,
+        ): Pair<List<Shop>, Long> = Pair(emptyList(), 0L)
         override fun deleteById(id: ShopId) {
             deletedIds.add(id)
         }

--- a/backend/admin-api/src/test/kotlin/com/mametosho/admin/application/usecase/GetCoffeeBeanUsecaseTest.kt
+++ b/backend/admin-api/src/test/kotlin/com/mametosho/admin/application/usecase/GetCoffeeBeanUsecaseTest.kt
@@ -22,6 +22,7 @@ class GetCoffeeBeanUsecaseTest {
         roastLevel = "MEDIUM",
         processingMethod = "WASHED",
         isSpecialty = true,
+        publishStatus = "PUBLISHED",
         images = emptyList(),
         tastes = emptyList(),
     )

--- a/backend/admin-api/src/test/kotlin/com/mametosho/admin/application/usecase/UpdateCoffeeBeanUsecaseTest.kt
+++ b/backend/admin-api/src/test/kotlin/com/mametosho/admin/application/usecase/UpdateCoffeeBeanUsecaseTest.kt
@@ -29,6 +29,7 @@ class UpdateCoffeeBeanUsecaseTest {
         roastLevel = "LIGHT",
         processingMethod = "WASHED",
         isSpecialty = false,
+        publishStatus = "PUBLISHED",
         images = listOf("MAIN" to "https://example.com/bean.jpg"),
         tastes = listOf("00000000-0000-4000-8000-000000000041" to 3),
     )
@@ -59,6 +60,7 @@ class UpdateCoffeeBeanUsecaseTest {
         roastLevel: String = "FRENCH",
         processingMethod: String = "NATURAL",
         isSpecialty: Boolean = true,
+        publishStatus: String = "PUBLISHED",
         tastes: List<UpdateCoffeeBeanRequest.TasteRequest> = listOf(
             UpdateCoffeeBeanRequest.TasteRequest(
                 tasteId = "00000000-0000-4000-8000-000000000042",
@@ -75,6 +77,7 @@ class UpdateCoffeeBeanUsecaseTest {
         roastLevel = roastLevel,
         processingMethod = processingMethod,
         isSpecialty = isSpecialty,
+        publishStatus = publishStatus,
         tastes = tastes,
     )
 

--- a/backend/admin-api/src/test/kotlin/com/mametosho/admin/application/usecase/UpdateShopUsecaseTest.kt
+++ b/backend/admin-api/src/test/kotlin/com/mametosho/admin/application/usecase/UpdateShopUsecaseTest.kt
@@ -2,6 +2,7 @@ package com.mametosho.admin.application.usecase
 
 import com.mametosho.admin.presentation.dto.request.UpdateShopRequest
 import com.mametosho.domain.model.shared.ImageUrl
+import com.mametosho.domain.model.shared.PublishStatus
 import com.mametosho.domain.model.shop.Shop
 import com.mametosho.domain.model.shop.ShopId
 import com.mametosho.domain.model.shop.ShopImage
@@ -31,6 +32,7 @@ class UpdateShopUsecaseTest {
         particular = "既存こだわり",
         shopUrl = "https://existing.example.com",
         prefecture = Prefecture.TOKYO,
+        publishStatus = PublishStatus.PUBLISHED,
         images = listOf(
             ShopImage(
                 id = ShopImageId("00000000-0000-4000-8000-000000000011"),
@@ -56,7 +58,12 @@ class UpdateShopUsecaseTest {
             return if (id.value == existingShopId) existingShop else null
         }
 
-        override fun findAll(page: Int, size: Int, name: String?): Pair<List<Shop>, Long> = Pair(emptyList(), 0L)
+        override fun findAll(
+            page: Int,
+            size: Int,
+            name: String?,
+            publishStatus: PublishStatus?,
+        ): Pair<List<Shop>, Long> = Pair(emptyList(), 0L)
         override fun deleteById(id: ShopId) = Unit
     }
 
@@ -69,6 +76,7 @@ class UpdateShopUsecaseTest {
         particular: String? = "更新こだわり",
         shopUrl: String = "https://updated.example.com",
         prefecture: String = "OSAKA",
+        publishStatus: String = "PUBLISHED",
     ): UpdateShopRequest = UpdateShopRequest(
         shopifyShopId = shopifyShopId,
         name = name,
@@ -76,6 +84,7 @@ class UpdateShopUsecaseTest {
         particular = particular,
         shopUrl = shopUrl,
         prefecture = prefecture,
+        publishStatus = publishStatus,
     )
 
     @Nested

--- a/backend/admin-api/src/test/kotlin/com/mametosho/admin/presentation/controller/CoffeeBeanControllerTest.kt
+++ b/backend/admin-api/src/test/kotlin/com/mametosho/admin/presentation/controller/CoffeeBeanControllerTest.kt
@@ -112,6 +112,7 @@ class CoffeeBeanControllerTest {
         roastLevel = "MEDIUM",
         processingMethod = "WASHED",
         isSpecialty = true,
+        publishStatus = "PUBLISHED",
         tastes = listOf(CreateCoffeeBeanRequest.TasteRequest(tasteId = tasteId, evaluationValue = 4)),
     )
 
@@ -125,6 +126,7 @@ class CoffeeBeanControllerTest {
         roastLevel = "FRENCH",
         processingMethod = "NATURAL",
         isSpecialty = true,
+        publishStatus = "PUBLISHED",
         tastes = listOf(UpdateCoffeeBeanRequest.TasteRequest(tasteId = tasteId, evaluationValue = 3)),
     )
 

--- a/backend/admin-api/src/test/kotlin/com/mametosho/admin/presentation/controller/ShopControllerTest.kt
+++ b/backend/admin-api/src/test/kotlin/com/mametosho/admin/presentation/controller/ShopControllerTest.kt
@@ -138,6 +138,7 @@ class ShopControllerTest {
                 particular = "テストこだわり",
                 shopUrl = "https://example.com",
                 prefecture = "TOKYO",
+                publishStatus = "PUBLISHED",
             )
 
             val response = shopController.createShop(request, listOf(logoFile), listOf("LOGO"))
@@ -161,6 +162,7 @@ class ShopControllerTest {
                 particular = "更新こだわり",
                 shopUrl = "https://updated.example.com",
                 prefecture = "OSAKA",
+                publishStatus = "PUBLISHED",
             )
 
             val response = shopController.updateShop("00000000-0000-4000-8000-000000000001", request, listOf(logoFile), listOf("LOGO"))
@@ -178,6 +180,7 @@ class ShopControllerTest {
                 particular = null,
                 shopUrl = "https://example.com",
                 prefecture = "TOKYO",
+                publishStatus = "PUBLISHED",
             )
 
             val response = shopController.updateShop("00000000-0000-4000-8000-999999999999", request, listOf(logoFile), listOf("LOGO"))

--- a/backend/admin-api/src/test/kotlin/com/mametosho/admin/presentation/dto/response/CoffeeBeanDetailResponseTest.kt
+++ b/backend/admin-api/src/test/kotlin/com/mametosho/admin/presentation/dto/response/CoffeeBeanDetailResponseTest.kt
@@ -23,6 +23,7 @@ class CoffeeBeanDetailResponseTest {
         roastLevel = "MEDIUM",
         processingMethod = "WASHED",
         isSpecialty = true,
+        publishStatus = "PUBLISHED",
         images = images,
         tastes = tastes,
     )
@@ -56,6 +57,7 @@ class CoffeeBeanDetailResponseTest {
             assertEquals("MEDIUM", response.roastLevel)
             assertEquals("WASHED", response.processingMethod)
             assertEquals(true, response.isSpecialty)
+            assertEquals("PUBLISHED", response.publishStatus)
             assertEquals(1, response.images.size)
             assertEquals("00000000-0000-4000-8000-000000000010", response.images[0].id)
             assertEquals("MAIN", response.images[0].type)

--- a/backend/admin-api/src/test/kotlin/com/mametosho/admin/presentation/dto/response/CoffeeBeanResponseTest.kt
+++ b/backend/admin-api/src/test/kotlin/com/mametosho/admin/presentation/dto/response/CoffeeBeanResponseTest.kt
@@ -11,6 +11,7 @@ import com.mametosho.domain.model.coffeebean.ProcessingMethod
 import com.mametosho.domain.model.coffeebean.RoastLevel
 import com.mametosho.domain.model.coffeebean.ShopifyBeanId
 import com.mametosho.domain.model.shared.ImageUrl
+import com.mametosho.domain.model.shared.PublishStatus
 import com.mametosho.domain.model.shop.ShopId
 import com.mametosho.domain.model.taste.TasteId
 import org.junit.jupiter.api.Nested
@@ -30,6 +31,7 @@ class CoffeeBeanResponseTest {
         roastLevel = RoastLevel.MEDIUM,
         processingMethod = ProcessingMethod.WASHED,
         isSpecialty = true,
+        publishStatus = PublishStatus.PUBLISHED,
         images = listOf(
             CoffeeBeanImage(
                 id = CoffeeBeanImageId("00000000-0000-4000-8000-000000000010"),

--- a/backend/admin-api/src/test/kotlin/com/mametosho/admin/presentation/dto/response/ShopResponseTest.kt
+++ b/backend/admin-api/src/test/kotlin/com/mametosho/admin/presentation/dto/response/ShopResponseTest.kt
@@ -1,6 +1,7 @@
 package com.mametosho.admin.presentation.dto.response
 
 import com.mametosho.domain.model.shared.ImageUrl
+import com.mametosho.domain.model.shared.PublishStatus
 import com.mametosho.domain.model.shop.Shop
 import com.mametosho.domain.model.shop.ShopId
 import com.mametosho.domain.model.shop.ShopImage
@@ -22,6 +23,7 @@ class ShopResponseTest {
         particular = "テストこだわり",
         shopUrl = "https://example.com",
         prefecture = Prefecture.TOKYO,
+        publishStatus = PublishStatus.PUBLISHED,
         images = listOf(
             ShopImage(
                 id = ShopImageId("00000000-0000-4000-8000-000000000011"),

--- a/backend/common/src/main/kotlin/com/mametosho/domain/model/coffeebean/CoffeeBean.kt
+++ b/backend/common/src/main/kotlin/com/mametosho/domain/model/coffeebean/CoffeeBean.kt
@@ -1,6 +1,7 @@
 package com.mametosho.domain.model.coffeebean
 
 import com.mametosho.domain.model.shared.ImageUrl
+import com.mametosho.domain.model.shared.PublishStatus
 import com.mametosho.domain.model.shop.ShopId
 import com.mametosho.domain.model.taste.TasteId
 import java.util.UUID
@@ -20,10 +21,11 @@ import java.util.UUID
  * @property roastLevel 焙煎度
  * @property processingMethod 精製方法
  * @property isSpecialty スペシャルティコーヒーかどうか
+ * @property publishStatus 公開状態（draft/published）
  * @property images 画像一覧
  * @property tastes テイスト評価一覧。同一TasteIdの重複は不可
  */
-@Suppress("MagicNumber")
+@Suppress("MagicNumber", "LongParameterList")
 data class CoffeeBean(
     val id: CoffeeBeanId,
     val shopId: ShopId,
@@ -35,6 +37,7 @@ data class CoffeeBean(
     val roastLevel: RoastLevel,
     val processingMethod: ProcessingMethod,
     val isSpecialty: Boolean,
+    val publishStatus: PublishStatus,
     val images: List<CoffeeBeanImage>,
     val tastes: List<CoffeeBeanTaste>,
 ) {
@@ -72,6 +75,7 @@ data class CoffeeBean(
      * @param roastLevel 焙煎度
      * @param processingMethod 精製方法
      * @param isSpecialty スペシャルティコーヒーかどうか
+     * @param publishStatus 公開状態（draft/published）
      * @param images 画像情報（種別とURL）のリスト
      * @param tastes テイスト評価情報（テイストIDと評価値）のリスト
      * @return 更新された[CoffeeBean]
@@ -86,6 +90,7 @@ data class CoffeeBean(
         roastLevel: String,
         processingMethod: String,
         isSpecialty: Boolean,
+        publishStatus: String,
         images: List<Pair<String, String>>,
         tastes: List<Pair<String, Int>>,
     ): CoffeeBean = CoffeeBean(
@@ -99,6 +104,7 @@ data class CoffeeBean(
         roastLevel = RoastLevel.valueOf(roastLevel),
         processingMethod = ProcessingMethod.valueOf(processingMethod),
         isSpecialty = isSpecialty,
+        publishStatus = PublishStatus.valueOf(publishStatus),
         images = images.map { (type, imageUrl) ->
             CoffeeBeanImage(
                 id = CoffeeBeanImageId(UUID.randomUUID().toString()),
@@ -130,6 +136,7 @@ data class CoffeeBean(
          * @param roastLevel 焙煎度
          * @param processingMethod 精製方法
          * @param isSpecialty スペシャルティコーヒーかどうか
+         * @param publishStatus 公開状態（draft/published）
          * @param images 画像情報（種別とURL）のリスト
          * @param tastes テイスト評価情報（テイストIDと評価値）のリスト
          * @return 生成された[CoffeeBean]
@@ -144,6 +151,7 @@ data class CoffeeBean(
             roastLevel: String,
             processingMethod: String,
             isSpecialty: Boolean,
+            publishStatus: String,
             images: List<Pair<String, String>>,
             tastes: List<Pair<String, Int>>,
             id: String = UUID.randomUUID().toString(),
@@ -158,6 +166,7 @@ data class CoffeeBean(
             roastLevel = RoastLevel.valueOf(roastLevel),
             processingMethod = ProcessingMethod.valueOf(processingMethod),
             isSpecialty = isSpecialty,
+            publishStatus = PublishStatus.valueOf(publishStatus),
             images = images.map { (type, imageUrl) ->
                 CoffeeBeanImage(
                     id = CoffeeBeanImageId(UUID.randomUUID().toString()),

--- a/backend/common/src/main/kotlin/com/mametosho/domain/model/shared/PublishStatus.kt
+++ b/backend/common/src/main/kotlin/com/mametosho/domain/model/shared/PublishStatus.kt
@@ -1,0 +1,12 @@
+package com.mametosho.domain.model.shared
+
+/**
+ * 公開状態。
+ *
+ * draft（下書き・非公開）と published（公開）の双方向の遷移が可能。
+ * 下書きのデータはCS（一般ユーザー向け）には公開されない。
+ */
+enum class PublishStatus {
+    DRAFT,
+    PUBLISHED,
+}

--- a/backend/common/src/main/kotlin/com/mametosho/domain/model/shop/Shop.kt
+++ b/backend/common/src/main/kotlin/com/mametosho/domain/model/shop/Shop.kt
@@ -1,6 +1,7 @@
 package com.mametosho.domain.model.shop
 
 import com.mametosho.domain.model.shared.ImageUrl
+import com.mametosho.domain.model.shared.PublishStatus
 import java.util.UUID
 
 /**
@@ -15,6 +16,7 @@ import java.util.UUID
  * @property particular こだわり
  * @property shopUrl 店舗URL
  * @property prefecture 都道府県
+ * @property publishStatus 公開状態（draft/published）
  * @property images 店舗画像一覧
  */
 @Suppress("MagicNumber")
@@ -26,6 +28,7 @@ data class Shop(
     val particular: String?,
     val shopUrl: String,
     val prefecture: Prefecture,
+    val publishStatus: PublishStatus,
     val images: List<ShopImage>,
 ) {
     init {
@@ -57,6 +60,7 @@ data class Shop(
      * @param introduction 店舗紹介
      * @param particular こだわり
      * @param shopUrl 店舗URL
+     * @param publishStatus 公開状態（draft/published）
      * @param images 画像情報（種別とURL）のリスト
      * @return 更新された[Shop]
      */
@@ -67,6 +71,7 @@ data class Shop(
         particular: String?,
         shopUrl: String,
         prefecture: Prefecture,
+        publishStatus: String,
         images: List<Pair<String, String>>,
     ): Shop = Shop(
         id = this.id,
@@ -76,6 +81,7 @@ data class Shop(
         particular = particular,
         shopUrl = shopUrl,
         prefecture = prefecture,
+        publishStatus = PublishStatus.valueOf(publishStatus),
         images = images.map { (type, imageUrl) ->
             ShopImage(
                 id = ShopImageId(UUID.randomUUID().toString()),
@@ -96,6 +102,7 @@ data class Shop(
          * @param introduction 店舗紹介
          * @param particular こだわり
          * @param shopUrl 店舗URL
+         * @param publishStatus 公開状態（draft/published）
          * @param images 画像情報（種別とURL）のリスト
          * @return 生成された[Shop]
          */
@@ -106,6 +113,7 @@ data class Shop(
             particular: String?,
             shopUrl: String,
             prefecture: Prefecture,
+            publishStatus: String,
             images: List<Pair<String, String>>,
             id: String = UUID.randomUUID().toString(),
         ): Shop = Shop(
@@ -116,6 +124,7 @@ data class Shop(
             particular = particular,
             shopUrl = shopUrl,
             prefecture = prefecture,
+            publishStatus = PublishStatus.valueOf(publishStatus),
             images = images.map { (type, imageUrl) ->
                 ShopImage(
                     id = ShopImageId(UUID.randomUUID().toString()),

--- a/backend/common/src/main/kotlin/com/mametosho/domain/repository/ShopRepository.kt
+++ b/backend/common/src/main/kotlin/com/mametosho/domain/repository/ShopRepository.kt
@@ -1,11 +1,25 @@
 package com.mametosho.domain.repository
 
+import com.mametosho.domain.model.shared.PublishStatus
 import com.mametosho.domain.model.shop.Shop
 import com.mametosho.domain.model.shop.ShopId
 
 interface ShopRepository {
     fun save(shop: Shop)
     fun findById(id: ShopId): Shop?
-    fun findAll(page: Int, size: Int, name: String? = null): Pair<List<Shop>, Long>
+
+    /**
+     * 店舗を一覧取得する。
+     *
+     * @param publishStatus 公開状態フィルタ。nullの場合は全状態を取得する（管理画面用）。
+     *   [PublishStatus.PUBLISHED] を指定すると公開済みのみ取得する（CS用）。
+     */
+    fun findAll(
+        page: Int,
+        size: Int,
+        name: String? = null,
+        publishStatus: PublishStatus? = null,
+    ): Pair<List<Shop>, Long>
+
     fun deleteById(id: ShopId)
 }

--- a/backend/common/src/main/kotlin/com/mametosho/infrastructure/persistence/mybatis/entity/CoffeeBeanDetailRow.kt
+++ b/backend/common/src/main/kotlin/com/mametosho/infrastructure/persistence/mybatis/entity/CoffeeBeanDetailRow.kt
@@ -11,6 +11,7 @@ data class CoffeeBeanDetailRow(
     val roastLevel: String,
     val processingMethod: String,
     val isSpecialty: Boolean,
+    val publishStatus: String,
     val imageId: String?,
     val imageType: String?,
     val imageUrl: String?,

--- a/backend/common/src/main/kotlin/com/mametosho/infrastructure/persistence/mybatis/entity/CoffeeBeanEntity.kt
+++ b/backend/common/src/main/kotlin/com/mametosho/infrastructure/persistence/mybatis/entity/CoffeeBeanEntity.kt
@@ -11,4 +11,5 @@ data class CoffeeBeanEntity(
     val roastLevel: String,
     val processingMethod: String,
     val isSpecialty: Boolean,
+    val publishStatus: String,
 )

--- a/backend/common/src/main/kotlin/com/mametosho/infrastructure/persistence/mybatis/entity/ShopEntity.kt
+++ b/backend/common/src/main/kotlin/com/mametosho/infrastructure/persistence/mybatis/entity/ShopEntity.kt
@@ -8,4 +8,5 @@ data class ShopEntity(
     val particular: String?,
     val shopUrl: String,
     val prefecture: String,
+    val publishStatus: String,
 )

--- a/backend/common/src/main/kotlin/com/mametosho/infrastructure/persistence/mybatis/entity/ShopListRow.kt
+++ b/backend/common/src/main/kotlin/com/mametosho/infrastructure/persistence/mybatis/entity/ShopListRow.kt
@@ -8,6 +8,7 @@ data class ShopListRow(
     val particular: String?,
     val shopUrl: String,
     val prefecture: String,
+    val publishStatus: String,
     val imageId: String?,
     val imageType: String?,
     val imageUrl: String?,

--- a/backend/common/src/main/kotlin/com/mametosho/infrastructure/persistence/mybatis/mapper/CoffeeBeanMapper.kt
+++ b/backend/common/src/main/kotlin/com/mametosho/infrastructure/persistence/mybatis/mapper/CoffeeBeanMapper.kt
@@ -14,7 +14,7 @@ import org.apache.ibatis.annotations.Select
 interface CoffeeBeanMapper {
     @Select(
         """
-        SELECT id, shop_id, shopify_bean_id, name, description, origin, farm, roast_level, processing_method, is_specialty
+        SELECT id, shop_id, shopify_bean_id, name, description, origin, farm, roast_level, processing_method, is_specialty, publish_status
         FROM coffee_beans WHERE id = #{id}
         """,
     )
@@ -30,7 +30,7 @@ interface CoffeeBeanMapper {
         """
         SELECT
             cb.id AS bean_id, cb.shop_id, cb.shopify_bean_id, cb.name AS bean_name,
-            cb.description, cb.origin, cb.farm, cb.roast_level, cb.processing_method, cb.is_specialty,
+            cb.description, cb.origin, cb.farm, cb.roast_level, cb.processing_method, cb.is_specialty, cb.publish_status,
             cbi.id AS image_id, cbi.type AS image_type, cbi.image_url,
             cbt.id AS taste_eval_id, cbt.tastes_id AS taste_id, t.name AS taste_name, cbt.evaluation_value
         FROM coffee_beans cb
@@ -45,7 +45,7 @@ interface CoffeeBeanMapper {
 
     @Select(
         """
-        SELECT id, shop_id, shopify_bean_id, name, description, origin, farm, roast_level, processing_method, is_specialty
+        SELECT id, shop_id, shopify_bean_id, name, description, origin, farm, roast_level, processing_method, is_specialty, publish_status
         FROM coffee_beans
         ORDER BY created_at DESC
         LIMIT #{size} OFFSET #{offset}
@@ -58,8 +58,8 @@ interface CoffeeBeanMapper {
 
     @Insert(
         """
-        INSERT INTO coffee_beans (id, shop_id, shopify_bean_id, name, description, origin, farm, roast_level, processing_method, is_specialty)
-        VALUES (#{id}, #{shopId}, #{shopifyBeanId}, #{name}, #{description}, #{origin}, #{farm}, #{roastLevel}, #{processingMethod}, #{isSpecialty})
+        INSERT INTO coffee_beans (id, shop_id, shopify_bean_id, name, description, origin, farm, roast_level, processing_method, is_specialty, publish_status)
+        VALUES (#{id}, #{shopId}, #{shopifyBeanId}, #{name}, #{description}, #{origin}, #{farm}, #{roastLevel}, #{processingMethod}, #{isSpecialty}, #{publishStatus})
         ON DUPLICATE KEY UPDATE
             shop_id = VALUES(shop_id),
             shopify_bean_id = VALUES(shopify_bean_id),
@@ -69,7 +69,8 @@ interface CoffeeBeanMapper {
             farm = VALUES(farm),
             roast_level = VALUES(roast_level),
             processing_method = VALUES(processing_method),
-            is_specialty = VALUES(is_specialty)
+            is_specialty = VALUES(is_specialty),
+            publish_status = VALUES(publish_status)
         """,
     )
     fun upsertCoffeeBean(entity: CoffeeBeanEntity)

--- a/backend/common/src/main/kotlin/com/mametosho/infrastructure/persistence/mybatis/mapper/ShopMapper.kt
+++ b/backend/common/src/main/kotlin/com/mametosho/infrastructure/persistence/mybatis/mapper/ShopMapper.kt
@@ -13,15 +13,16 @@ import org.apache.ibatis.annotations.Select
 interface ShopMapper {
     @Insert(
         """
-        INSERT INTO shops (id, shopify_shop_id, name, introduction, particular, shop_url, prefecture)
-        VALUES (#{id}, #{shopifyShopId}, #{name}, #{introduction}, #{particular}, #{shopUrl}, #{prefecture})
+        INSERT INTO shops (id, shopify_shop_id, name, introduction, particular, shop_url, prefecture, publish_status)
+        VALUES (#{id}, #{shopifyShopId}, #{name}, #{introduction}, #{particular}, #{shopUrl}, #{prefecture}, #{publishStatus})
         ON DUPLICATE KEY UPDATE
             shopify_shop_id = VALUES(shopify_shop_id),
             name = VALUES(name),
             introduction = VALUES(introduction),
             particular = VALUES(particular),
             shop_url = VALUES(shop_url),
-            prefecture = VALUES(prefecture)
+            prefecture = VALUES(prefecture),
+            publish_status = VALUES(publish_status)
         """,
     )
     fun upsertShop(entity: ShopEntity)
@@ -39,7 +40,7 @@ interface ShopMapper {
 
     @Select(
         """
-        SELECT s.id, s.shopify_shop_id, s.name, s.introduction, s.particular, s.shop_url, s.prefecture,
+        SELECT s.id, s.shopify_shop_id, s.name, s.introduction, s.particular, s.shop_url, s.prefecture, s.publish_status,
                si.id AS image_id, si.type AS image_type, si.image_url
         FROM shops s
         LEFT JOIN shop_images si ON si.shop_id = s.id
@@ -54,13 +55,16 @@ interface ShopMapper {
     @Select(
         """
         <script>
-        SELECT s.id, s.shopify_shop_id, s.name, s.introduction, s.particular, s.shop_url, s.prefecture,
+        SELECT s.id, s.shopify_shop_id, s.name, s.introduction, s.particular, s.shop_url, s.prefecture, s.publish_status,
                si.id AS image_id, si.type AS image_type, si.image_url
         FROM (
             SELECT id FROM shops
             <where>
                 <if test="name != null">
-                    name LIKE CONCAT('%', #{name}, '%')
+                    AND name LIKE CONCAT('%', #{name}, '%')
+                </if>
+                <if test="publishStatus != null">
+                    AND publish_status = #{publishStatus}
                 </if>
             </where>
             ORDER BY created_at DESC
@@ -76,6 +80,7 @@ interface ShopMapper {
         @Param("size") size: Int,
         @Param("offset") offset: Int,
         @Param("name") name: String?,
+        @Param("publishStatus") publishStatus: String?,
     ): List<ShopListRow>
 
     @Select(
@@ -84,11 +89,17 @@ interface ShopMapper {
         SELECT COUNT(*) FROM shops
         <where>
             <if test="name != null">
-                name LIKE CONCAT('%', #{name}, '%')
+                AND name LIKE CONCAT('%', #{name}, '%')
+            </if>
+            <if test="publishStatus != null">
+                AND publish_status = #{publishStatus}
             </if>
         </where>
         </script>
         """,
     )
-    fun countByCondition(@Param("name") name: String?): Long
+    fun countByCondition(
+        @Param("name") name: String?,
+        @Param("publishStatus") publishStatus: String?,
+    ): Long
 }

--- a/backend/common/src/main/kotlin/com/mametosho/infrastructure/persistence/repository/CoffeeBeanRepositoryImpl.kt
+++ b/backend/common/src/main/kotlin/com/mametosho/infrastructure/persistence/repository/CoffeeBeanRepositoryImpl.kt
@@ -11,6 +11,7 @@ import com.mametosho.domain.model.coffeebean.ProcessingMethod
 import com.mametosho.domain.model.coffeebean.RoastLevel
 import com.mametosho.domain.model.coffeebean.ShopifyBeanId
 import com.mametosho.domain.model.shared.ImageUrl
+import com.mametosho.domain.model.shared.PublishStatus
 import com.mametosho.domain.model.shop.ShopId
 import com.mametosho.domain.model.taste.TasteId
 import com.mametosho.domain.repository.CoffeeBeanRepository
@@ -39,6 +40,7 @@ class CoffeeBeanRepositoryImpl(
             roastLevel = RoastLevel.valueOf(entity.roastLevel),
             processingMethod = ProcessingMethod.valueOf(entity.processingMethod),
             isSpecialty = entity.isSpecialty,
+            publishStatus = PublishStatus.valueOf(entity.publishStatus),
             images = imageEntities.map { img ->
                 CoffeeBeanImage(
                     id = CoffeeBeanImageId(img.id),
@@ -69,6 +71,7 @@ class CoffeeBeanRepositoryImpl(
                 roastLevel = coffeeBean.roastLevel.name,
                 processingMethod = coffeeBean.processingMethod.name,
                 isSpecialty = coffeeBean.isSpecialty,
+                publishStatus = coffeeBean.publishStatus.name,
             ),
         )
         coffeeBeanMapper.deleteCoffeeBeanImagesByCoffeeBeanId(coffeeBean.id.value)

--- a/backend/common/src/main/kotlin/com/mametosho/infrastructure/persistence/repository/ShopRepositoryImpl.kt
+++ b/backend/common/src/main/kotlin/com/mametosho/infrastructure/persistence/repository/ShopRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.mametosho.infrastructure.persistence.repository
 
 import com.mametosho.domain.model.shared.ImageUrl
+import com.mametosho.domain.model.shared.PublishStatus
 import com.mametosho.domain.model.shop.Shop
 import com.mametosho.domain.model.shop.ShopId
 import com.mametosho.domain.model.shop.ShopImage
@@ -28,6 +29,7 @@ class ShopRepositoryImpl(
                 particular = shop.particular,
                 shopUrl = shop.shopUrl,
                 prefecture = shop.prefecture.name,
+                publishStatus = shop.publishStatus.name,
             ),
         )
         shopMapper.deleteShopImagesByShopId(shop.id.value)
@@ -48,10 +50,16 @@ class ShopRepositoryImpl(
         shopMapper.deleteShopById(id.value)
     }
 
-    override fun findAll(page: Int, size: Int, name: String?): Pair<List<Shop>, Long> {
+    override fun findAll(
+        page: Int,
+        size: Int,
+        name: String?,
+        publishStatus: PublishStatus?,
+    ): Pair<List<Shop>, Long> {
         val offset = page * size
-        val rows = shopMapper.findListRows(size, offset, name)
-        val totalCount = shopMapper.countByCondition(name)
+        val publishStatusName = publishStatus?.name
+        val rows = shopMapper.findListRows(size, offset, name, publishStatusName)
+        val totalCount = shopMapper.countByCondition(name, publishStatusName)
         if (rows.isEmpty()) return Pair(emptyList(), totalCount)
         val shops = rows.groupBy { it.id }.map { (_, shopRows) -> mapRowsToShop(shopRows) }
         return Pair(shops, totalCount)
@@ -73,6 +81,7 @@ class ShopRepositoryImpl(
             particular = first.particular,
             shopUrl = first.shopUrl,
             prefecture = Prefecture.valueOf(first.prefecture),
+            publishStatus = PublishStatus.valueOf(first.publishStatus),
             images = rows
                 .filter { it.imageId != null }
                 .map { row ->

--- a/backend/common/src/test/kotlin/com/mametosho/domain/model/coffeebean/CoffeeBeanTest.kt
+++ b/backend/common/src/test/kotlin/com/mametosho/domain/model/coffeebean/CoffeeBeanTest.kt
@@ -1,6 +1,7 @@
 package com.mametosho.domain.model.coffeebean
 
 import com.mametosho.domain.model.shared.ImageUrl
+import com.mametosho.domain.model.shared.PublishStatus
 import com.mametosho.domain.model.shop.ShopId
 import com.mametosho.domain.model.taste.TasteId
 import org.junit.jupiter.api.Nested
@@ -41,6 +42,7 @@ class CoffeeBeanTest {
         roastLevel = RoastLevel.LIGHT,
         processingMethod = ProcessingMethod.WASHED,
         isSpecialty = false,
+        publishStatus = PublishStatus.PUBLISHED,
         images = images,
         tastes = tastes,
     )
@@ -136,6 +138,7 @@ class CoffeeBeanTest {
                 roastLevel = "FRENCH",
                 processingMethod = "NATURAL",
                 isSpecialty = true,
+                publishStatus = "PUBLISHED",
                 images = listOf("MAIN" to "https://example.com/updated.png"),
                 tastes = listOf("00000000-0000-4000-8000-000000000041" to 3),
             )
@@ -156,6 +159,7 @@ class CoffeeBeanTest {
                 roastLevel = "FRENCH",
                 processingMethod = "NATURAL",
                 isSpecialty = true,
+                publishStatus = "PUBLISHED",
                 images = listOf("MAIN" to "https://example.com/updated.png"),
                 tastes = listOf("00000000-0000-4000-8000-000000000004" to 5),
             )
@@ -189,6 +193,7 @@ class CoffeeBeanTest {
                 roastLevel = "LIGHT",
                 processingMethod = "WASHED",
                 isSpecialty = false,
+                publishStatus = "PUBLISHED",
                 images = listOf("MAIN" to "https://example.com/bean.jpg"),
                 tastes = listOf("00000000-0000-4000-8000-000000000004" to 3),
             )

--- a/backend/common/src/test/kotlin/com/mametosho/domain/model/shop/ShopTest.kt
+++ b/backend/common/src/test/kotlin/com/mametosho/domain/model/shop/ShopTest.kt
@@ -1,6 +1,7 @@
 package com.mametosho.domain.model.shop
 
 import com.mametosho.domain.model.shared.ImageUrl
+import com.mametosho.domain.model.shared.PublishStatus
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.assertThrows
 import kotlin.test.Test
@@ -27,6 +28,7 @@ class ShopTest {
         particular = "産地直送の豆を使用",
         shopUrl = shopUrl,
         prefecture = Prefecture.TOKYO,
+        publishStatus = PublishStatus.PUBLISHED,
         images = images,
     )
 
@@ -80,6 +82,7 @@ class ShopTest {
                 particular = "更新こだわり",
                 shopUrl = "https://updated.example.com",
                 prefecture = Prefecture.OSAKA,
+                publishStatus = "PUBLISHED",
                 images = listOf("LOGO" to "https://example.com/logo.png", "MAIN" to "https://example.com/new.png"),
             )
 
@@ -102,6 +105,7 @@ class ShopTest {
                 particular = null,
                 shopUrl = "https://example.com",
                 prefecture = Prefecture.TOKYO,
+                publishStatus = "PUBLISHED",
                 images = listOf("LOGO" to "https://example.com/logo.png"),
             )
 
@@ -118,6 +122,7 @@ class ShopTest {
                 particular = null,
                 shopUrl = "https://example.com",
                 prefecture = Prefecture.TOKYO,
+                publishStatus = "PUBLISHED",
                 images = listOf("LOGO" to "https://example.com/logo.png", "MAIN" to "https://example.com/image.png"),
             )
 

--- a/backend/common/src/test/kotlin/com/mametosho/infrastructure/persistence/repository/CoffeeBeanRepositoryImplTest.kt
+++ b/backend/common/src/test/kotlin/com/mametosho/infrastructure/persistence/repository/CoffeeBeanRepositoryImplTest.kt
@@ -11,6 +11,7 @@ import com.mametosho.domain.model.coffeebean.ProcessingMethod
 import com.mametosho.domain.model.coffeebean.RoastLevel
 import com.mametosho.domain.model.coffeebean.ShopifyBeanId
 import com.mametosho.domain.model.shared.ImageUrl
+import com.mametosho.domain.model.shared.PublishStatus
 import com.mametosho.domain.model.shop.ShopId
 import com.mametosho.domain.model.taste.TasteId
 import java.util.Locale
@@ -117,6 +118,7 @@ class CoffeeBeanRepositoryImplTest {
         roastLevel = RoastLevel.MEDIUM,
         processingMethod = ProcessingMethod.WASHED,
         isSpecialty = true,
+        publishStatus = PublishStatus.PUBLISHED,
         images = images,
         tastes = tastes,
     )
@@ -271,6 +273,7 @@ class CoffeeBeanRepositoryImplTest {
                     roastLevel = roastLevel,
                     processingMethod = ProcessingMethod.WASHED,
                     isSpecialty = false,
+                    publishStatus = PublishStatus.PUBLISHED,
                     images = listOf(
                         CoffeeBeanImage(
                             id = CoffeeBeanImageId("00000000-0000-4000-${String.format(Locale.ROOT, "%04d", index)}-000000000099"),
@@ -310,6 +313,7 @@ class CoffeeBeanRepositoryImplTest {
                     roastLevel = RoastLevel.MEDIUM,
                     processingMethod = method,
                     isSpecialty = false,
+                    publishStatus = PublishStatus.PUBLISHED,
                     images = listOf(
                         CoffeeBeanImage(
                             id = CoffeeBeanImageId("00000000-0000-4000-${String.format(Locale.ROOT, "%04d", index)}-000000000099"),

--- a/backend/common/src/test/kotlin/com/mametosho/infrastructure/persistence/repository/ShopRepositoryImplTest.kt
+++ b/backend/common/src/test/kotlin/com/mametosho/infrastructure/persistence/repository/ShopRepositoryImplTest.kt
@@ -1,6 +1,7 @@
 package com.mametosho.infrastructure.persistence.repository
 
 import com.mametosho.domain.model.shared.ImageUrl
+import com.mametosho.domain.model.shared.PublishStatus
 import com.mametosho.domain.model.shop.Shop
 import com.mametosho.domain.model.shop.ShopId
 import com.mametosho.domain.model.shop.ShopImage
@@ -87,6 +88,7 @@ class ShopRepositoryImplTest {
         particular = particular,
         shopUrl = shopUrl,
         prefecture = Prefecture.TOKYO,
+        publishStatus = PublishStatus.PUBLISHED,
         images = images,
     )
 

--- a/backend/cs-api/src/main/kotlin/com/mametosho/cs/application/usecase/FindShopsUsecase.kt
+++ b/backend/cs-api/src/main/kotlin/com/mametosho/cs/application/usecase/FindShopsUsecase.kt
@@ -1,6 +1,7 @@
 package com.mametosho.cs.application.usecase
 
 import com.mametosho.cs.application.result.PagedResult
+import com.mametosho.domain.model.shared.PublishStatus
 import com.mametosho.domain.model.shop.Shop
 import com.mametosho.domain.repository.ShopRepository
 import org.springframework.stereotype.Service
@@ -12,7 +13,8 @@ class FindShopsUsecase(
 ) {
     @Transactional(readOnly = true)
     open fun execute(page: Int, size: Int): PagedResult<Shop> {
-        val (shops, totalCount) = shopRepository.findAll(page, size)
+        // CS（一般ユーザー向け）では公開済みの店舗のみを返す。下書きは除外する。
+        val (shops, totalCount) = shopRepository.findAll(page, size, publishStatus = PublishStatus.PUBLISHED)
         return PagedResult(shops, totalCount, page, size)
     }
 }

--- a/backend/cs-api/src/main/kotlin/com/mametosho/cs/infrastructure/persistence/mybatis/mapper/CoffeeBeanQueryMapper.kt
+++ b/backend/cs-api/src/main/kotlin/com/mametosho/cs/infrastructure/persistence/mybatis/mapper/CoffeeBeanQueryMapper.kt
@@ -20,6 +20,7 @@ interface CoffeeBeanQueryMapper {
             INNER JOIN coffee_bean_images cbi_inner
                 ON cbi_inner.coffee_bean_id = cb_inner.id AND cbi_inner.type = 'MAIN'
             <where>
+                AND cb_inner.publish_status = 'PUBLISHED'
                 <if test="origin != null">AND cb_inner.origin LIKE CONCAT('%', #{origin}, '%')</if>
                 <if test="roastLevel != null">AND cb_inner.roast_level = #{roastLevel}</if>
                 <if test="prefecture != null">AND s_inner.prefecture = #{prefecture}</if>
@@ -50,6 +51,7 @@ interface CoffeeBeanQueryMapper {
         INNER JOIN shops s ON cb.shop_id = s.id
         INNER JOIN coffee_bean_images cbi ON cbi.coffee_bean_id = cb.id AND cbi.type = 'MAIN'
         <where>
+            AND cb.publish_status = 'PUBLISHED'
             <if test="origin != null">AND cb.origin LIKE CONCAT('%', #{origin}, '%')</if>
             <if test="roastLevel != null">AND cb.roast_level = #{roastLevel}</if>
             <if test="prefecture != null">AND s.prefecture = #{prefecture}</if>

--- a/backend/cs-api/src/test/kotlin/com/mametosho/cs/application/usecase/FindShopsUsecaseTest.kt
+++ b/backend/cs-api/src/test/kotlin/com/mametosho/cs/application/usecase/FindShopsUsecaseTest.kt
@@ -1,6 +1,7 @@
 package com.mametosho.cs.application.usecase
 
 import com.mametosho.domain.model.shared.ImageUrl
+import com.mametosho.domain.model.shared.PublishStatus
 import com.mametosho.domain.model.shop.Prefecture
 import com.mametosho.domain.model.shop.Shop
 import com.mametosho.domain.model.shop.ShopId
@@ -17,6 +18,7 @@ class FindShopsUsecaseTest {
 
     private var capturedPage: Int? = null
     private var capturedSize: Int? = null
+    private var capturedPublishStatus: PublishStatus? = null
 
     private val sampleShop = Shop(
         id = ShopId("00000000-0000-4000-8000-000000000031"),
@@ -26,6 +28,7 @@ class FindShopsUsecaseTest {
         particular = null,
         shopUrl = "https://mametosho.example.com",
         prefecture = Prefecture.TOKYO,
+        publishStatus = PublishStatus.PUBLISHED,
         images = listOf(
             ShopImage(
                 id = ShopImageId("00000000-0000-4000-8000-000000000091"),
@@ -43,9 +46,15 @@ class FindShopsUsecaseTest {
             override fun save(shop: Shop) = Unit
             override fun findById(id: ShopId) = null
             override fun deleteById(id: ShopId) = Unit
-            override fun findAll(page: Int, size: Int, name: String?): Pair<List<Shop>, Long> {
+            override fun findAll(
+                page: Int,
+                size: Int,
+                name: String?,
+                publishStatus: PublishStatus?,
+            ): Pair<List<Shop>, Long> {
                 capturedPage = page
                 capturedSize = size
+                capturedPublishStatus = publishStatus
                 return Pair(shops, totalCount)
             }
         }
@@ -63,6 +72,15 @@ class FindShopsUsecaseTest {
             assertEquals(1, result.items.size)
             assertEquals(0, capturedPage)
             assertEquals(20, capturedSize)
+        }
+
+        @Test
+        fun `公開済みのみを取得するようpublishStatusがPUBLISHEDで渡される`() {
+            val usecase = createUsecase()
+
+            usecase.execute(page = 0, size = 20)
+
+            assertEquals(PublishStatus.PUBLISHED, capturedPublishStatus)
         }
 
         @Test

--- a/backend/cs-api/src/test/kotlin/com/mametosho/cs/presentation/controller/CoffeeBeanControllerTest.kt
+++ b/backend/cs-api/src/test/kotlin/com/mametosho/cs/presentation/controller/CoffeeBeanControllerTest.kt
@@ -71,6 +71,7 @@ class CoffeeBeanControllerTest {
         tasteId: String = "00000000-0000-4000-8000-000000000041",
         tasteName: String = "酸味",
         tasteEvalId: String = "00000000-0000-4000-8000-0000000000c1",
+        publishStatus: String = "PUBLISHED",
     ) {
         jdbcTemplate.execute(
             "INSERT INTO shops (id, shopify_shop_id, name, shop_url, prefecture) " +
@@ -79,11 +80,13 @@ class CoffeeBeanControllerTest {
         jdbcTemplate.execute(
             "INSERT INTO tastes (id, name) VALUES ('$tasteId', '$tasteName')",
         )
-        val cols = "id, shop_id, shopify_bean_id, name, description, origin, farm, roast_level, processing_method, is_specialty"
+        val cols = "id, shop_id, shopify_bean_id, name, description, origin, farm, " +
+            "roast_level, processing_method, is_specialty, publish_status"
         val desc = "フルーティーな香りと明るい酸味が特徴の豆です。"
         jdbcTemplate.execute(
             "INSERT INTO coffee_beans ($cols) " +
-                "VALUES ('$beanId', '$shopId', '$shopifyBeanId', '$beanName', '$desc', '$origin', '農園', '$roastLevel', 'WASHED', TRUE)",
+                "VALUES ('$beanId', '$shopId', '$shopifyBeanId', '$beanName', '$desc', '$origin', '農園', " +
+                "'$roastLevel', 'WASHED', TRUE, '$publishStatus')",
         )
         jdbcTemplate.execute(
             "INSERT INTO coffee_bean_images (id, coffee_bean_id, type, image_url) " +
@@ -205,6 +208,38 @@ class CoffeeBeanControllerTest {
             assertEquals(HttpStatus.OK, response.statusCode)
             assertEquals(1, response.body?.items?.size)
             assertEquals("エチオピア イルガチェフェ G1", response.body?.items?.first()?.name)
+        }
+
+        @Test
+        fun `下書き状態の珈琲豆は一覧に含まれない`() {
+            insertBeanWithDependencies(
+                shopId = "00000000-0000-4000-8000-000000000031", shopifyShopId = "shop-001",
+                beanId = "00000000-0000-4000-8000-000000000071", shopifyBeanId = "bean-001",
+                beanName = "エチオピア イルガチェフェ G1",
+                imageId = "00000000-0000-4000-8000-0000000000b1",
+                tasteId = "00000000-0000-4000-8000-000000000041", tasteName = "酸味",
+                tasteEvalId = "00000000-0000-4000-8000-0000000000c1",
+                publishStatus = "PUBLISHED",
+            )
+            insertBeanWithDependencies(
+                shopId = "00000000-0000-4000-8000-000000000032", shopifyShopId = "shop-002",
+                shopName = "下書き珈琲店",
+                beanId = "00000000-0000-4000-8000-000000000072", shopifyBeanId = "bean-002",
+                beanName = "下書きブラジル サントス",
+                imageId = "00000000-0000-4000-8000-0000000000b2",
+                tasteId = "00000000-0000-4000-8000-000000000042", tasteName = "苦味",
+                tasteEvalId = "00000000-0000-4000-8000-0000000000c2",
+                publishStatus = "DRAFT",
+            )
+
+            val response = coffeeBeanController.listCoffeeBeans(
+                page = 0, size = 20, origin = null, roastLevel = null, prefecture = null,
+            )
+
+            assertEquals(HttpStatus.OK, response.statusCode)
+            assertEquals(1, response.body?.items?.size)
+            assertEquals(1L, response.body?.totalCount)
+            assertEquals("00000000-0000-4000-8000-000000000071", response.body?.items?.first()?.id)
         }
 
         @Test

--- a/backend/cs-api/src/test/kotlin/com/mametosho/cs/presentation/controller/ShopControllerTest.kt
+++ b/backend/cs-api/src/test/kotlin/com/mametosho/cs/presentation/controller/ShopControllerTest.kt
@@ -62,10 +62,11 @@ class ShopControllerTest {
         shopUrl: String = "https://mametosho.example.com",
         prefecture: String = "TOKYO",
         logoImageUrl: String = "https://example.com/logo.png",
+        publishStatus: String = "PUBLISHED",
     ) {
         jdbcTemplate.execute(
-            "INSERT INTO shops (id, shopify_shop_id, name, introduction, shop_url, prefecture) " +
-                "VALUES ('$id', '$shopifyShopId', '$name', '$introduction', '$shopUrl', '$prefecture')",
+            "INSERT INTO shops (id, shopify_shop_id, name, introduction, shop_url, prefecture, publish_status) " +
+                "VALUES ('$id', '$shopifyShopId', '$name', '$introduction', '$shopUrl', '$prefecture', '$publishStatus')",
         )
         val imageId = id.take(24) + "9" + id.drop(25)
         jdbcTemplate.execute(
@@ -111,6 +112,28 @@ class ShopControllerTest {
             assertEquals(HttpStatus.OK, response.statusCode)
             assertEquals(0, response.body?.items?.size)
             assertEquals(0L, response.body?.totalCount)
+        }
+
+        @Test
+        fun `下書き状態の店舗は一覧に含まれない`() {
+            insertShopWithLogo(
+                id = "00000000-0000-4000-8000-000000000031",
+                shopifyShopId = "published-shop",
+                publishStatus = "PUBLISHED",
+            )
+            insertShopWithLogo(
+                id = "00000000-0000-4000-8000-000000000032",
+                shopifyShopId = "draft-shop",
+                publishStatus = "DRAFT",
+            )
+
+            val response = shopController.listShops(page = 0, size = 20)
+
+            assertEquals(HttpStatus.OK, response.statusCode)
+            assertEquals(1, response.body?.items?.size)
+            assertEquals(1L, response.body?.totalCount)
+            val ids = response.body?.items?.map { it.id }
+            assertEquals(listOf("00000000-0000-4000-8000-000000000031"), ids)
         }
 
         @Test

--- a/backend/docs/domainModel.md
+++ b/backend/docs/domainModel.md
@@ -136,6 +136,7 @@ classDiagram
       particular: String?
       shopUrl: String
       prefecture: Prefecture
+      publishStatus: PublishStatus
       images: List~ShopImage~
     }
 
@@ -177,6 +178,7 @@ classDiagram
       roastLevel: RoastLevel
       processingMethod: ProcessingMethod
       isSpecialty: Boolean
+      publishStatus: PublishStatus
       images: List~CoffeeBeanImage~
       tastes: List~CoffeeBeanTaste~
     }

--- a/backend/docs/domains/coffeeBean.md
+++ b/backend/docs/domains/coffeeBean.md
@@ -7,8 +7,9 @@ Shopifyの商品と1対1で紐づく。産地、焙煎度、精製方法、テ�
 
 ## ライフサイクル
 
-- **登録**: 管理者が管理画面から登録する
+- **登録**: 管理者が管理画面から登録する。初期状態は任意に選択でき、デフォルトは下書き（draft）
 - **更新**: 珈琲豆情報・画像・テイスト評価の変更
+- **公開状態の切り替え**: 管理者が draft ⇄ published を双方向に切り替えられる。draft の珈琲豆はCS（一般ユーザー向け）には公開されない
 
 ## CoffeeBean
 
@@ -26,6 +27,7 @@ Shopifyの商品と1対1で紐づく。産地、焙煎度、精製方法、テ�
 | roastLevel | RoastLevel | 焙煎度（light / medium / city / french） |
 | processingMethod | ProcessingMethod | 精製方法（fully_washed / washed / thermal_shock_natural / natural / wet_hulling / honey） |
 | isSpecialty | Boolean | スペシャルティコーヒーかどうか |
+| publishStatus | PublishStatus | 公開状態（draft / published） |
 | images | List\<CoffeeBeanImage\> | 珈琲豆画像一覧 |
 | tastes | List\<CoffeeBeanTaste\> | テイスト評価一覧 |
 
@@ -41,6 +43,13 @@ Shopifyの商品と1対1で紐づく。産地、焙煎度、精製方法、テ�
 - shopIdは存在するShopを参照しなければならない
 - **images は必須**。少なくとも1枚の画像を持たなければならない
 - **tastes は必須**。全テイスト種別（酸味・苦味・甘味・コク・香り）の評価値を持たなければならない
+
+## PublishStatus（Enum）
+
+公開状態を表すEnum。draft（下書き・非公開）と published（公開）の双方向の遷移が可能。
+draft の珈琲豆はCS（一般ユーザー向けAPI）には公開されない。Shop集約と共有する値オブジェクト。
+
+`DRAFT`, `PUBLISHED`
 
 ## CoffeeBeanImage（エンティティ）
 

--- a/backend/docs/domains/shop.md
+++ b/backend/docs/domains/shop.md
@@ -7,8 +7,9 @@ Shopifyのショップと1対1で紐づく。
 
 ## ライフサイクル
 
-- **登録**: 管理者が管理画面から登録する
+- **登録**: 管理者が管理画面から登録する。初期状態は任意に選択でき、デフォルトは下書き（draft）
 - **更新**: 店舗情報・画像の変更
+- **公開状態の切り替え**: 管理者が draft ⇄ published を双方向に切り替えられる。draft の店舗はCS（一般ユーザー向け）には公開されない
 
 ## Shop
 
@@ -23,6 +24,7 @@ Shopifyのショップと1対1で紐づく。
 | particular | String? | こだわり |
 | shopUrl | String | 店舗URL |
 | prefecture | Prefecture | 都道府県 |
+| publishStatus | PublishStatus | 公開状態（draft / published） |
 | images | List\<ShopImage\> | 店舗画像一覧 |
 
 ### 不変条件
@@ -34,6 +36,13 @@ Shopifyのショップと1対1で紐づく。
 - shopUrlは必須、空白不可（2048文字以内）
 - prefectureは必須
 - LOGO画像はちょうど1枚（必須）
+
+## PublishStatus（Enum）
+
+公開状態を表すEnum。draft（下書き・非公開）と published（公開）の双方向の遷移が可能。
+draft の店舗はCS（一般ユーザー向けAPI）には公開されない。
+
+`DRAFT`, `PUBLISHED`
 
 ## Prefecture（Enum）
 

--- a/docs/swagger/admin-api.yml
+++ b/docs/swagger/admin-api.yml
@@ -11,6 +11,8 @@ servers:
 security:
 - Bearer: []
 tags:
+- name: Taste
+  description: テイストAPI
 - name: Shop
   description: 店舗API
 - name: Auth
@@ -51,6 +53,8 @@ paths:
                     introduction: こだわりの珈琲をお届けします。
                     particular: 厳選された豆のみを使用しています。
                     shopUrl: https://example.com
+                    prefecture: TOKYO
+                    publishStatus: PUBLISHED
                     images:
                     - id: 00000000-0000-4000-8000-000000000010
                       type: MAIN
@@ -245,6 +249,7 @@ paths:
                     roastLevel: MEDIUM
                     processingMethod: WASHED
                     isSpecialty: true
+                    publishStatus: PUBLISHED
                     images:
                     - id: 00000000-0000-4000-8000-000000000010
                       type: MAIN
@@ -438,6 +443,8 @@ paths:
                       introduction: こだわりの珈琲をお届けします。
                       particular: 厳選された豆のみを使用しています。
                       shopUrl: https://example.com
+                      prefecture: TOKYO
+                      publishStatus: PUBLISHED
                     totalCount: 1
                     page: 0
                     size: 20
@@ -560,6 +567,7 @@ paths:
                       roastLevel: MEDIUM
                       processingMethod: WASHED
                       isSpecialty: true
+                      publishStatus: PUBLISHED
                     totalCount: 1
                     page: 0
                     size: 20
@@ -676,6 +684,33 @@ paths:
                     status: 401
                     error: Unauthorized
                     path: /api/admin/auth/login
+  /api/admin/tastes:
+    get:
+      tags:
+      - Taste
+      summary: テイスト一覧取得
+      description: テイスト（酸味・苦味・甘味・コク・香りなど）の一覧を取得します。
+      operationId: listTastes
+      responses:
+        "200":
+          description: 取得成功
+          content:
+            '*/*':
+              examples:
+                success:
+                  summary: 取得成功例
+                  description: success
+                  value:
+                  - id: 00000000-0000-4000-8000-000000000041
+                    name: 酸味
+                  - id: 00000000-0000-4000-8000-000000000042
+                    name: 苦味
+                  - id: 00000000-0000-4000-8000-000000000043
+                    name: 甘味
+                  - id: 00000000-0000-4000-8000-000000000044
+                    name: コク
+                  - id: 00000000-0000-4000-8000-000000000045
+                    name: 香り
 components:
   schemas:
     UpdateShopRequest:
@@ -706,6 +741,10 @@ components:
           type: string
           description: 都道府県
           example: TOKYO
+        publishStatus:
+          type: string
+          description: "公開状態（DRAFT: 下書き / PUBLISHED: 公開）"
+          example: PUBLISHED
     ShopResponse:
       type: object
       description: 店舗登録レスポンス
@@ -732,6 +771,10 @@ components:
           type: string
           description: エラー概要
           example: Not Found
+        message:
+          type: string
+          description: エラーメッセージ
+          example: tastes must not be empty
         path:
           type: string
           description: リクエストパス
@@ -785,6 +828,10 @@ components:
           type: string
           description: 精製方法
           example: WASHED
+        publishStatus:
+          type: string
+          description: "公開状態（DRAFT: 下書き / PUBLISHED: 公開）"
+          example: PUBLISHED
         tastes:
           type: array
           description: テイスト評価一覧
@@ -828,6 +875,10 @@ components:
           type: string
           description: 都道府県
           example: TOKYO
+        publishStatus:
+          type: string
+          description: "公開状態（DRAFT: 下書き / PUBLISHED: 公開）"
+          example: DRAFT
     CreateCoffeeBeanRequest:
       type: object
       description: コーヒー豆登録リクエスト
@@ -864,6 +915,10 @@ components:
           type: string
           description: 精製方法
           example: WASHED
+        publishStatus:
+          type: string
+          description: "公開状態（DRAFT: 下書き / PUBLISHED: 公開）"
+          example: DRAFT
         tastes:
           type: array
           description: テイスト評価一覧
@@ -948,6 +1003,10 @@ components:
           type: string
           description: 都道府県
           example: TOKYO
+        publishStatus:
+          type: string
+          description: "公開状態（DRAFT: 下書き / PUBLISHED: 公開）"
+          example: PUBLISHED
         images:
           type: array
           description: 画像一覧
@@ -993,6 +1052,10 @@ components:
           type: string
           description: 精製方法
           example: WASHED
+        publishStatus:
+          type: string
+          description: "公開状態（DRAFT: 下書き / PUBLISHED: 公開）"
+          example: PUBLISHED
         images:
           type: array
           description: 画像一覧
@@ -1013,6 +1076,10 @@ components:
           type: string
           description: テイスト評価ID
           example: 00000000-0000-4000-8000-000000000020
+        tasteId:
+          type: string
+          description: テイストマスタID
+          example: 00000000-0000-4000-8000-000000000041
         tasteName:
           type: string
           description: テイスト名

--- a/docs/swagger/admin-api.yml
+++ b/docs/swagger/admin-api.yml
@@ -745,6 +745,8 @@ components:
           type: string
           description: "公開状態（DRAFT: 下書き / PUBLISHED: 公開）"
           example: PUBLISHED
+      required:
+      - publishStatus
     ShopResponse:
       type: object
       description: 店舗登録レスポンス
@@ -839,6 +841,8 @@ components:
             $ref: "#/components/schemas/TasteRequest"
         specialty:
           type: boolean
+      required:
+      - publishStatus
     CoffeeBeanResponse:
       type: object
       description: コーヒー豆登録レスポンス
@@ -879,6 +883,8 @@ components:
           type: string
           description: "公開状態（DRAFT: 下書き / PUBLISHED: 公開）"
           example: DRAFT
+      required:
+      - publishStatus
     CreateCoffeeBeanRequest:
       type: object
       description: コーヒー豆登録リクエスト
@@ -926,6 +932,8 @@ components:
             $ref: "#/components/schemas/TasteRequest"
         specialty:
           type: boolean
+      required:
+      - publishStatus
     LoginRequest:
       type: object
       description: ログインリクエスト
@@ -1012,6 +1020,8 @@ components:
           description: 画像一覧
           items:
             $ref: "#/components/schemas/ImageDetail"
+      required:
+      - publishStatus
     CoffeeBeanDetailResponse:
       type: object
       description: コーヒー豆詳細レスポンス
@@ -1068,6 +1078,8 @@ components:
             $ref: "#/components/schemas/TasteDetail"
         specialty:
           type: boolean
+      required:
+      - publishStatus
     TasteDetail:
       type: object
       description: テイスト評価詳細

--- a/docs/swagger/cs-api.yml
+++ b/docs/swagger/cs-api.yml
@@ -44,9 +44,9 @@ paths:
         "200":
           description: 取得成功
           content:
-            '*/*':
+            application/json:
               schema:
-                $ref: "#/components/schemas/ShopListResponse"
+                $ref: "#/components/schemas/PagedResponseShopResponse"
               examples:
                 success:
                   summary: 取得成功例
@@ -83,7 +83,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/PlanListResponse"
+                  $ref: "#/components/schemas/PlanResponse"
               examples:
                 success:
                   summary: 取得成功例
@@ -206,7 +206,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/PagedResponseCoffeeBeanListResponse"
+                $ref: "#/components/schemas/PagedResponseCoffeeBeanResponse"
               examples:
                 success:
                   summary: 取得成功例
@@ -222,6 +222,8 @@ paths:
                       description: 花のような華やかなフレーバーと、柑橘系の明るい酸味が特徴。
                       imageUrl: https://example.com/images/ethiopia.jpg
                       shopName: 珈琲工房 まめとしょ
+                      shopPrefecture: TOKYO
+                      shopUrl: https://mametosho.example.com
                       tasteProfiles:
                       - name: 酸味
                         value: 5
@@ -238,42 +240,10 @@ paths:
                     size: 20
 components:
   schemas:
-    ShopListResponse:
-      type: object
-      description: 店舗一覧アイテム
-      properties:
-        id:
-          type: string
-          description: 店舗ID
-          example: 00000000-0000-4000-8000-000000000031
-        name:
-          type: string
-          description: 店舗名
-          example: 珈琲工房 まめとしょ
-        introduction:
-          type: string
-          description: 店舗紹介文
-          example: 東京都渋谷区にある自家焙煎珈琲店。厳選されたスペシャルティコーヒーをお届けします。
-        shopUrl:
-          type: string
-          description: 店舗URL
-          example: https://mametosho.example.com
-        prefecture:
-          type: string
-          description: 都道府県
-          example: TOKYO
-        logoImageUrl:
-          type: string
-          description: ロゴ画像URL
-          example: https://placehold.jp/100x100.png
-    PlanListResponse:
+    PlanResponse:
       type: object
       description: プラン一覧アイテム
       properties:
-        isRecommended:
-          type: boolean
-          description: おすすめバッジ
-          example: true
         id:
           type: string
           description: プランID
@@ -301,3 +271,5 @@ components:
           type: string
           description: プラン種別（SUBSCRIPTION / SINGLE）
           example: SUBSCRIPTION
+        recommended:
+          type: boolean

--- a/infrastructure/db/local-data.sql
+++ b/infrastructure/db/local-data.sql
@@ -50,10 +50,10 @@ INSERT IGNORE INTO plans (id, shopify_plan_id, label, gram_weight, bean_quantity
 -- ------------------------------------------------------------
 -- shops（店舗）
 -- ------------------------------------------------------------
-INSERT IGNORE INTO shops (id, shopify_shop_id, name, introduction, particular, shop_url, prefecture) VALUES
-('00000000-0000-4000-8000-000000000031', 'gid://shopify/Shop/300001', '珈琲工房 まめとしょ', '東京都渋谷区にある自家焙煎珈琲店。厳選されたスペシャルティコーヒーをお届けします。', 'シングルオリジンの豆を、注文後に焙煎してお届けします。', 'https://mametosho.example.com', 'TOKYO'),
-('00000000-0000-4000-8000-000000000032', 'gid://shopify/Shop/300002', 'CAFÉ LUMIÈRE', '京都の町家を改装した珈琲専門店。フレンチローストからライトローストまで幅広い焙煎度をご用意。', '契約農園から直接仕入れた高品質な生豆のみを使用しています。', 'https://cafe-lumiere.example.com', 'KYOTO'),
-('00000000-0000-4000-8000-000000000033', 'gid://shopify/Shop/300003', '豆蔵珈琲', '福岡の老舗珈琲焙煎所。創業以来変わらない焙煎技術で深みのある一杯を。', '炭火焙煎による独自の香ばしさが特徴です。', 'https://mamezou-coffee.example.com', 'FUKUOKA');
+INSERT IGNORE INTO shops (id, shopify_shop_id, name, introduction, particular, shop_url, prefecture, publish_status) VALUES
+('00000000-0000-4000-8000-000000000031', 'gid://shopify/Shop/300001', '珈琲工房 まめとしょ', '東京都渋谷区にある自家焙煎珈琲店。厳選されたスペシャルティコーヒーをお届けします。', 'シングルオリジンの豆を、注文後に焙煎してお届けします。', 'https://mametosho.example.com', 'TOKYO', 'PUBLISHED'),
+('00000000-0000-4000-8000-000000000032', 'gid://shopify/Shop/300002', 'CAFÉ LUMIÈRE', '京都の町家を改装した珈琲専門店。フレンチローストからライトローストまで幅広い焙煎度をご用意。', '契約農園から直接仕入れた高品質な生豆のみを使用しています。', 'https://cafe-lumiere.example.com', 'KYOTO', 'PUBLISHED'),
+('00000000-0000-4000-8000-000000000033', 'gid://shopify/Shop/300003', '豆蔵珈琲', '福岡の老舗珈琲焙煎所。創業以来変わらない焙煎技術で深みのある一杯を。', '炭火焙煎による独自の香ばしさが特徴です。', 'https://mamezou-coffee.example.com', 'FUKUOKA', 'DRAFT');
 
 -- ------------------------------------------------------------
 -- tastes（テイスト）
@@ -76,25 +76,25 @@ INSERT IGNORE INTO customer_subscriptions (id, customer_id, plan_id, status, con
 -- ------------------------------------------------------------
 -- coffee_beans（珈琲豆）各店舗2種ずつ
 -- ------------------------------------------------------------
-INSERT IGNORE INTO coffee_beans (id, shop_id, shopify_bean_id, name, description, origin, farm, roast_level, processing_method, is_specialty) VALUES
+INSERT IGNORE INTO coffee_beans (id, shop_id, shopify_bean_id, name, description, origin, farm, roast_level, processing_method, is_specialty, publish_status) VALUES
 ('00000000-0000-4000-8000-000000000071', '00000000-0000-4000-8000-000000000031', 'gid://shopify/Product/400001', 'エチオピア イルガチェフェ G1',
  '花のような華やかなフレーバーと、柑橘系の明るい酸味が特徴。クリーンカップで後味もすっきり。',
- 'エチオピア', 'イルガチェフェ コチャレ地区', 'LIGHT', 'WASHED', TRUE),
+ 'エチオピア', 'イルガチェフェ コチャレ地区', 'LIGHT', 'WASHED', TRUE, 'PUBLISHED'),
 ('00000000-0000-4000-8000-000000000072', '00000000-0000-4000-8000-000000000031', 'gid://shopify/Product/400002', 'グアテマラ アンティグア',
  'チョコレートのような甘いコクと、スパイシーな余韻。バランスの良い味わいが楽しめます。',
- 'グアテマラ', 'アンティグア農園', 'CITY', 'FULLY_WASHED', FALSE),
+ 'グアテマラ', 'アンティグア農園', 'CITY', 'FULLY_WASHED', FALSE, 'DRAFT'),
 ('00000000-0000-4000-8000-000000000073', '00000000-0000-4000-8000-000000000032', 'gid://shopify/Product/400003', 'ケニア AA ニエリ',
  'ブラックカラントのような濃厚な果実感と、しっかりとしたボディ。力強い味わいの一杯。',
- 'ケニア', 'ニエリ地区', 'MEDIUM', 'FULLY_WASHED', TRUE),
+ 'ケニア', 'ニエリ地区', 'MEDIUM', 'FULLY_WASHED', TRUE, 'PUBLISHED'),
 ('00000000-0000-4000-8000-000000000074', '00000000-0000-4000-8000-000000000032', 'gid://shopify/Product/400004', 'コスタリカ ハニー',
  'はちみつのような甘みとトロピカルフルーツのフレーバー。ハニープロセスならではの複雑な味わい。',
- 'コスタリカ', 'タラス地区 ラ・ミニータ農園', 'MEDIUM', 'HONEY', TRUE),
+ 'コスタリカ', 'タラス地区 ラ・ミニータ農園', 'MEDIUM', 'HONEY', TRUE, 'PUBLISHED'),
 ('00000000-0000-4000-8000-000000000075', '00000000-0000-4000-8000-000000000033', 'gid://shopify/Product/400005', 'ブラジル サントス No.2',
  '定番のブラジル豆。ナッツのような香ばしさと、まろやかなコク。どなたでも飲みやすい一杯。',
- 'ブラジル', 'サントス地区', 'CITY', 'NATURAL', FALSE),
+ 'ブラジル', 'サントス地区', 'CITY', 'NATURAL', FALSE, 'PUBLISHED'),
 ('00000000-0000-4000-8000-000000000076', '00000000-0000-4000-8000-000000000033', 'gid://shopify/Product/400006', 'インドネシア マンデリン G1',
  '大地を思わせる深いコクと、ハーブのような独特の風味。深煎り好きにおすすめの個性派。',
- 'インドネシア', 'リントン地区', 'FRENCH', 'WET_HULLING', FALSE);
+ 'インドネシア', 'リントン地区', 'FRENCH', 'WET_HULLING', FALSE, 'DRAFT');
 
 -- ------------------------------------------------------------
 -- monthly_subscription_details（月次サブスクリプション詳細）

--- a/infrastructure/db/schema.sql
+++ b/infrastructure/db/schema.sql
@@ -43,6 +43,7 @@ CREATE TABLE IF NOT EXISTS shops (
     particular      TEXT                                                       COMMENT 'こだわり',
     shop_url        VARCHAR(2048)  NOT NULL                                     COMMENT '店舗URL',
     prefecture      VARCHAR(255)  NOT NULL                                       COMMENT '都道府県',
+    publish_status  ENUM('DRAFT', 'PUBLISHED') NOT NULL DEFAULT 'DRAFT'          COMMENT '公開状態',
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP                             COMMENT '作成日時',
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新日時'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='店舗マスタテーブル';
@@ -78,6 +79,7 @@ CREATE TABLE IF NOT EXISTS coffee_beans (
     roast_level       ENUM('LIGHT', 'MEDIUM', 'CITY', 'FRENCH') NOT NULL       COMMENT '焙煎度',
     processing_method ENUM('FULLY_WASHED', 'WASHED', 'THERMAL_SHOCK_NATURAL', 'NATURAL', 'WET_HULLING', 'HONEY') NOT NULL COMMENT '精製方法',
     is_specialty      BOOLEAN       NOT NULL DEFAULT FALSE                     COMMENT 'スペシャルティコーヒーかどうか',
+    publish_status    ENUM('DRAFT', 'PUBLISHED') NOT NULL DEFAULT 'DRAFT'       COMMENT '公開状態',
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP                             COMMENT '作成日時',
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新日時',
     FOREIGN KEY (shop_id) REFERENCES shops (id)


### PR DESCRIPTION
## 概要

管理画面で店舗(Shop)・珈琲豆(CoffeeBean)の**公開/非公開(下書き)を選べる**ようにし、**下書き状態のデータはCS(一般ユーザー向けAPI)に公開しない**ようにします。

- データモデル: `PublishStatus` enum(`DRAFT` / `PUBLISHED`)
- 新規作成時の既定は **下書き(DRAFT)**。作成・編集フォームで明示的に選択可能
- 切替UIは作成・編集フォーム内に配置

## 変更内容

### ドキュメント
- `docs/domains/{shop,coffeeBean}.md`・`docs/domainModel.md` に `publishStatus` と状態遷移(draft ⇄ published)を追記

### ドメイン / 永続化 (common)
- **新規** `PublishStatus` enum(`shared/`)、`Shop`・`CoffeeBean` に `publishStatus` を追加
- 既存の enum 永続化方式(`roast_level` と同様、Entityは`String`・`.name`/`valueOf`・DB ENUMはUPPERCASE)に統一
- 共有の `ShopMapper`/`ShopRepository.findAll` に nullable な `publishStatus` フィルタを追加し admin/cs で出し分け

### Admin API (全状態を扱う)
- 作成/更新リクエスト・一覧/詳細レスポンス・QueryResult・Controller例に `publishStatus` を反映
- OpenAPIスペック・TypeScript APIクライアントを再生成

### CS API (下書き除外) ★中核
- 店舗: `findAll(publishStatus = PUBLISHED)` で公開のみ取得
- 珈琲豆: cs専用 `CoffeeBeanQueryMapper` に `publish_status = 'PUBLISHED'` フィルタを追加(adminへ影響なし)

### Admin Frontend
- 作成/編集フォームに「公開状態」セレクト(既定=下書き、編集時は既存値)
- 一覧テーブル・詳細画面に「公開/下書き」バッジを追加

### DB・テスト
- `schema.sql`・`local-data.sql` に `publish_status` を追加(動作確認用に公開/下書きを混在)
- CS下書き除外の新規テスト(Shop/CoffeeBean Controller)を追加

## 動作確認

- backend: `./gradlew :common:test :cs-api:test :admin-api:test`・`detekt` 通過
- frontend: `pnpm lint`・`pnpm build` 通過

## ⚠️ デプロイ時の注意(申し送り)

本リポジトリにDBマイグレーション基盤(Flyway等)が無く、`schema.sql` は local プロファイルの新規DB初期化専用です。**dev/本番環境(既存テーブル)へは自動でカラムが追加されません**。以下を手動実行してください:

\`\`\`sql
ALTER TABLE shops
  ADD COLUMN publish_status ENUM('DRAFT','PUBLISHED') NOT NULL DEFAULT 'DRAFT';
ALTER TABLE coffee_beans
  ADD COLUMN publish_status ENUM('DRAFT','PUBLISHED') NOT NULL DEFAULT 'DRAFT';
-- 既存データを公開扱いにしたい場合は別途 UPDATE が必要
\`\`\`

既存データは既定で `DRAFT`(非公開)になるため、公開状態を維持したいレコードは `UPDATE ... SET publish_status = 'PUBLISHED'` が必要です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)