### PR TITLE
feat: 管理画面にプラン閲覧・更新機能を追加

### DIFF
--- a/admin-frontend/src/api/coffee-beans.ts
+++ b/admin-frontend/src/api/coffee-beans.ts
@@ -2,36 +2,19 @@ import "server-only";
 
 import { notFound } from "next/navigation";
 import { createAuthenticatedApiClient } from "@/api/client";
-import type { PagedResponse } from "@/api/types";
+import type { components } from "@/api/generated/admin-api";
 
-export type CoffeeBeanListItem = {
-  id: string;
-  shopId: string;
-  shopifyBeanId: string;
-  name: string;
-  description: string;
-  origin: string;
-  farm: string | null;
-  roastLevel: string;
-  processingMethod: string;
-  isSpecialty: boolean;
-  publishStatus: "DRAFT" | "PUBLISHED";
-};
-
-export type CoffeeBeanDetail = CoffeeBeanListItem & {
-  images: { id: string; type: string; imageUrl: string }[];
-  tastes: {
-    id: string;
-    tasteId: string;
-    tasteName: string;
-    evaluationValue: number;
-  }[];
-};
+export type CoffeeBeanListItem =
+  components["schemas"]["CoffeeBeanSummaryResponse"];
+export type CoffeeBeanDetail =
+  components["schemas"]["CoffeeBeanDetailResponse"];
+export type CoffeeBeanListResponse =
+  components["schemas"]["CoffeeBeanListResponse"];
 
 export async function fetchCoffeeBeans(
   page = 0,
   size = 20,
-): Promise<PagedResponse<CoffeeBeanListItem>> {
+): Promise<CoffeeBeanListResponse> {
   const client = await createAuthenticatedApiClient();
   const { data, error } = await client.GET("/api/admin/coffee-beans", {
     params: { query: { page, size } },
@@ -41,7 +24,7 @@ export async function fetchCoffeeBeans(
     throw new Error("コーヒー豆一覧の取得に失敗しました");
   }
 
-  return data as PagedResponse<CoffeeBeanListItem>;
+  return data;
 }
 
 export async function fetchCoffeeBean(id: string): Promise<CoffeeBeanDetail> {
@@ -58,5 +41,5 @@ export async function fetchCoffeeBean(id: string): Promise<CoffeeBeanDetail> {
     throw new Error("コーヒー豆の取得に失敗しました");
   }
 
-  return data as CoffeeBeanDetail;
+  return data;
 }

--- a/admin-frontend/src/api/generated/admin-api.ts
+++ b/admin-frontend/src/api/generated/admin-api.ts
@@ -32,6 +32,30 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/api/admin/plans/{id}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * プラン詳細取得
+     * @description 指定されたIDのプランの詳細情報を取得します。
+     */
+    get: operations["getPlan"];
+    /**
+     * プラン編集
+     * @description 指定されたIDのプランを編集します。全項目を置換します。
+     */
+    put: operations["updatePlan"];
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   "/api/admin/coffee-beans/{id}": {
     parameters: {
       query?: never;
@@ -128,6 +152,46 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/api/admin/tastes": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * テイスト一覧取得
+     * @description テイスト（酸味・苦味・甘味・コク・香りなど）の一覧を取得します。
+     */
+    get: operations["listTastes"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/admin/plans": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * プラン一覧取得
+     * @description プランの一覧をページネーション付きで取得します。プラン表示名による部分一致検索が可能です。
+     */
+    get: operations["listPlans"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -193,10 +257,60 @@ export interface components {
        */
       error?: string;
       /**
+       * @description エラーメッセージ
+       * @example tastes must not be empty
+       */
+      message?: string;
+      /**
        * @description リクエストパス
        * @example /api/admin/resources/00000000-0000-4000-8000-000000000099
        */
       path?: string;
+    };
+    /** @description プラン編集リクエスト */
+    UpdatePlanRequest: {
+      /**
+       * @description ShopifyのプランID
+       * @example test-plan-001
+       */
+      shopifyPlanId?: string;
+      /**
+       * @description プラン表示名
+       * @example 定番
+       */
+      label?: string;
+      /**
+       * Format: int32
+       * @description 1種あたりのグラム数（30 / 60 / 90）
+       * @example 60
+       */
+      gramWeight?: number;
+      /**
+       * Format: int32
+       * @description 豆の種類数（3 / 4 / 5）
+       * @example 4
+       */
+      beanQuantity?: number;
+      /**
+       * Format: int32
+       * @description 価格
+       * @example 3800
+       */
+      price?: number;
+      /**
+       * @description プラン種別（SUBSCRIPTION / SINGLE）
+       * @example SUBSCRIPTION
+       */
+      type?: string;
+      recommended?: boolean;
+    };
+    /** @description プラン編集レスポンス */
+    PlanResponse: {
+      /**
+       * @description プランID
+       * @example 00000000-0000-4000-8000-000000000024
+       */
+      id?: string;
     };
     /** @description テイスト評価リクエスト */
     TasteRequest: {
@@ -207,7 +321,7 @@ export interface components {
       tasteId?: string;
       /**
        * Format: int32
-       * @description 評価値
+       * @description 評価値（0-5）
        * @example 3
        */
       evaluationValue?: number;
@@ -435,6 +549,48 @@ export interface components {
       /** @description 画像一覧 */
       images?: components["schemas"]["ImageDetail"][];
     };
+    /** @description プラン詳細レスポンス */
+    PlanDetailResponse: {
+      /**
+       * @description プランID
+       * @example 00000000-0000-4000-8000-000000000024
+       */
+      id?: string;
+      /**
+       * @description ShopifyのプランID
+       * @example test-plan-001
+       */
+      shopifyPlanId?: string;
+      /**
+       * @description プラン表示名
+       * @example 定番
+       */
+      label?: string;
+      /**
+       * Format: int32
+       * @description 1種あたりのグラム数
+       * @example 60
+       */
+      gramWeight?: number;
+      /**
+       * Format: int32
+       * @description 豆の種類数
+       * @example 4
+       */
+      beanQuantity?: number;
+      /**
+       * Format: int32
+       * @description 価格
+       * @example 3800
+       */
+      price?: number;
+      /**
+       * @description プラン種別（SUBSCRIPTION / SINGLE）
+       * @example SUBSCRIPTION
+       */
+      type?: string;
+      recommended?: boolean;
+    };
     /** @description コーヒー豆詳細レスポンス */
     CoffeeBeanDetailResponse: {
       /**
@@ -495,6 +651,11 @@ export interface components {
        * @example 00000000-0000-4000-8000-000000000020
        */
       id?: string;
+      /**
+       * @description テイストマスタID
+       * @example 00000000-0000-4000-8000-000000000041
+       */
+      tasteId?: string;
       /**
        * @description テイスト名
        * @example 酸味
@@ -645,6 +806,98 @@ export interface operations {
         };
       };
       /** @description 関連するコーヒー豆が存在するため削除できません */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["ErrorResponse"];
+        };
+      };
+    };
+  };
+  getPlan: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /**
+         * @description プランID
+         * @example 00000000-0000-4000-8000-000000000024
+         */
+        id: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 取得成功 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["PlanDetailResponse"];
+        };
+      };
+      /** @description プランが見つかりません */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": unknown;
+        };
+      };
+    };
+  };
+  updatePlan: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /**
+         * @description プランID
+         * @example 00000000-0000-4000-8000-000000000024
+         */
+        id: string;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["UpdatePlanRequest"];
+      };
+    };
+    responses: {
+      /** @description 編集成功 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["PlanResponse"];
+        };
+      };
+      /** @description バリデーションエラー */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": components["schemas"]["ErrorResponse"];
+        };
+      };
+      /** @description プランが見つかりません */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": unknown;
+        };
+      };
+      /** @description ShopifyプランIDが重複しています */
       409: {
         headers: {
           [name: string]: unknown;
@@ -970,6 +1223,62 @@ export interface operations {
       };
       /** @description 認証失敗 */
       401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": unknown;
+        };
+      };
+    };
+  };
+  listTastes: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 取得成功 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": unknown;
+        };
+      };
+    };
+  };
+  listPlans: {
+    parameters: {
+      query?: {
+        /**
+         * @description ページ番号（0始まり）
+         * @example 0
+         */
+        page?: number;
+        /**
+         * @description 1ページあたりの件数
+         * @example 20
+         */
+        size?: number;
+        /**
+         * @description プラン表示名（部分一致検索）
+         * @example 定番
+         */
+        keyword?: string;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 取得成功 */
+      200: {
         headers: {
           [name: string]: unknown;
         };

--- a/admin-frontend/src/api/generated/admin-api.ts
+++ b/admin-frontend/src/api/generated/admin-api.ts
@@ -677,7 +677,7 @@ export interface components {
       images?: components["schemas"]["ImageDetail"][];
       /** @description テイスト評価一覧 */
       tastes?: components["schemas"]["TasteDetail"][];
-      specialty?: boolean;
+      isSpecialty?: boolean;
     };
     /** @description テイスト評価詳細 */
     TasteDetail: {

--- a/admin-frontend/src/api/generated/admin-api.ts
+++ b/admin-frontend/src/api/generated/admin-api.ts
@@ -339,6 +339,11 @@ export interface components {
     /** @description コーヒー豆更新リクエスト */
     UpdateCoffeeBeanRequest: {
       /**
+       * @description スペシャルティコーヒーかどうか
+       * @example true
+       */
+      isSpecialty?: boolean;
+      /**
        * @description 店舗ID
        * @example 00000000-0000-4000-8000-000000000001
        */
@@ -435,6 +440,11 @@ export interface components {
     };
     /** @description コーヒー豆登録リクエスト */
     CreateCoffeeBeanRequest: {
+      /**
+       * @description スペシャルティコーヒーかどうか
+       * @example true
+       */
+      isSpecialty?: boolean;
       /**
        * @description 店舗ID
        * @example 00000000-0000-4000-8000-000000000031

--- a/admin-frontend/src/api/generated/admin-api.ts
+++ b/admin-frontend/src/api/generated/admin-api.ts
@@ -312,6 +312,7 @@ export interface components {
        * @example SUBSCRIPTION
        */
       type?: string;
+      recommended?: boolean;
     };
     /** @description プラン編集レスポンス */
     PlanResponse: {
@@ -581,11 +582,6 @@ export interface components {
     /** @description プラン詳細レスポンス */
     PlanDetailResponse: {
       /**
-       * @description おすすめバッジ
-       * @example true
-       */
-      isRecommended?: boolean;
-      /**
        * @description プランID
        * @example 00000000-0000-4000-8000-000000000024
        */
@@ -623,6 +619,7 @@ export interface components {
        * @example SUBSCRIPTION
        */
       type?: string;
+      isRecommended?: boolean;
     };
     /** @description コーヒー豆詳細レスポンス */
     CoffeeBeanDetailResponse: {

--- a/admin-frontend/src/api/generated/admin-api.ts
+++ b/admin-frontend/src/api/generated/admin-api.ts
@@ -275,6 +275,11 @@ export interface components {
     /** @description プラン編集リクエスト */
     UpdatePlanRequest: {
       /**
+       * @description おすすめバッジ
+       * @example true
+       */
+      isRecommended?: boolean;
+      /**
        * @description ShopifyのプランID
        * @example test-plan-001
        */
@@ -307,7 +312,6 @@ export interface components {
        * @example SUBSCRIPTION
        */
       type?: string;
-      recommended?: boolean;
     };
     /** @description プラン編集レスポンス */
     PlanResponse: {
@@ -577,6 +581,11 @@ export interface components {
     /** @description プラン詳細レスポンス */
     PlanDetailResponse: {
       /**
+       * @description おすすめバッジ
+       * @example true
+       */
+      isRecommended?: boolean;
+      /**
        * @description プランID
        * @example 00000000-0000-4000-8000-000000000024
        */
@@ -614,7 +623,6 @@ export interface components {
        * @example SUBSCRIPTION
        */
       type?: string;
-      recommended?: boolean;
     };
     /** @description コーヒー豆詳細レスポンス */
     CoffeeBeanDetailResponse: {

--- a/admin-frontend/src/api/generated/admin-api.ts
+++ b/admin-frontend/src/api/generated/admin-api.ts
@@ -202,12 +202,12 @@ export interface components {
        * @description ShopifyのショップID
        * @example test-shop-001
        */
-      shopifyShopId?: string;
+      shopifyShopId: string;
       /**
        * @description 店舗名
        * @example テスト店舗
        */
-      name?: string;
+      name: string;
       /**
        * @description 店舗紹介
        * @example テスト紹介文
@@ -222,12 +222,12 @@ export interface components {
        * @description 店舗URL
        * @example https://example.com
        */
-      shopUrl?: string;
+      shopUrl: string;
       /**
        * @description 都道府県
        * @example TOKYO
        */
-      prefecture?: string;
+      prefecture: string;
       /**
        * @description 公開状態（DRAFT: 下書き / PUBLISHED: 公開）
        * @example PUBLISHED
@@ -240,7 +240,7 @@ export interface components {
        * @description 店舗ID
        * @example 00000000-0000-4000-8000-000000000001
        */
-      id?: string;
+      id: string;
     };
     /** @description エラーレスポンス */
     ErrorResponse: {
@@ -249,18 +249,18 @@ export interface components {
        * @description エラー発生日時
        * @example 2026-02-23T12:00:00.000+00:00
        */
-      timestamp?: string;
+      timestamp: string;
       /**
        * Format: int32
        * @description HTTPステータスコード
        * @example 404
        */
-      status?: number;
+      status: number;
       /**
        * @description エラー概要
        * @example Not Found
        */
-      error?: string;
+      error: string;
       /**
        * @description エラーメッセージ
        * @example tastes must not be empty
@@ -270,49 +270,48 @@ export interface components {
        * @description リクエストパス
        * @example /api/admin/resources/00000000-0000-4000-8000-000000000099
        */
-      path?: string;
+      path: string;
     };
     /** @description プラン編集リクエスト */
     UpdatePlanRequest: {
       /**
-       * @description おすすめバッジ
-       * @example true
-       */
-      isRecommended?: boolean;
-      /**
        * @description ShopifyのプランID
        * @example test-plan-001
        */
-      shopifyPlanId?: string;
+      shopifyPlanId: string;
       /**
        * @description プラン表示名
        * @example 定番
        */
-      label?: string;
+      label: string;
       /**
        * Format: int32
        * @description 1種あたりのグラム数（30 / 60 / 90）
        * @example 60
        */
-      gramWeight?: number;
+      gramWeight: number;
       /**
        * Format: int32
        * @description 豆の種類数（3 / 4 / 5）
        * @example 4
        */
-      beanQuantity?: number;
+      beanQuantity: number;
       /**
        * Format: int32
        * @description 価格
        * @example 3800
        */
-      price?: number;
+      price: number;
       /**
        * @description プラン種別（SUBSCRIPTION / SINGLE）
        * @example SUBSCRIPTION
        */
-      type?: string;
-      recommended?: boolean;
+      type: string;
+      /**
+       * @description おすすめバッジ
+       * @example true
+       */
+      isRecommended: boolean;
     };
     /** @description プラン編集レスポンス */
     PlanResponse: {
@@ -320,7 +319,7 @@ export interface components {
        * @description プランID
        * @example 00000000-0000-4000-8000-000000000024
        */
-      id?: string;
+      id: string;
     };
     /** @description テイスト評価リクエスト */
     TasteRequest: {
@@ -328,46 +327,41 @@ export interface components {
        * @description テイストID
        * @example 00000000-0000-4000-8000-000000000041
        */
-      tasteId?: string;
+      tasteId: string;
       /**
        * Format: int32
        * @description 評価値（0-5）
        * @example 3
        */
-      evaluationValue?: number;
+      evaluationValue: number;
     };
     /** @description コーヒー豆更新リクエスト */
     UpdateCoffeeBeanRequest: {
       /**
-       * @description スペシャルティコーヒーかどうか
-       * @example true
-       */
-      isSpecialty?: boolean;
-      /**
        * @description 店舗ID
        * @example 00000000-0000-4000-8000-000000000001
        */
-      shopId?: string;
+      shopId: string;
       /**
        * @description Shopifyの商品ID
        * @example test-bean-001
        */
-      shopifyBeanId?: string;
+      shopifyBeanId: string;
       /**
        * @description 豆の名前
        * @example テストコーヒー豆
        */
-      name?: string;
+      name: string;
       /**
        * @description 説明
        * @example テスト説明文
        */
-      description?: string;
+      description: string;
       /**
        * @description 産地
        * @example エチオピア
        */
-      origin?: string;
+      origin: string;
       /**
        * @description 農園名
        * @example テスト農園
@@ -377,20 +371,24 @@ export interface components {
        * @description 焙煎度
        * @example MEDIUM
        */
-      roastLevel?: string;
+      roastLevel: string;
       /**
        * @description 精製方法
        * @example WASHED
        */
-      processingMethod?: string;
+      processingMethod: string;
       /**
        * @description 公開状態（DRAFT: 下書き / PUBLISHED: 公開）
        * @example PUBLISHED
        */
       publishStatus: string;
       /** @description テイスト評価一覧 */
-      tastes?: components["schemas"]["TasteRequest"][];
-      specialty?: boolean;
+      tastes: components["schemas"]["TasteRequest"][];
+      /**
+       * @description スペシャルティコーヒーかどうか
+       * @example true
+       */
+      isSpecialty: boolean;
     };
     /** @description コーヒー豆登録レスポンス */
     CoffeeBeanResponse: {
@@ -398,7 +396,7 @@ export interface components {
        * @description コーヒー豆ID
        * @example 00000000-0000-4000-8000-000000000001
        */
-      id?: string;
+      id: string;
     };
     /** @description 店舗登録リクエスト */
     CreateShopRequest: {
@@ -406,12 +404,12 @@ export interface components {
        * @description ShopifyのショップID
        * @example test-shop-001
        */
-      shopifyShopId?: string;
+      shopifyShopId: string;
       /**
        * @description 店舗名
        * @example テスト店舗
        */
-      name?: string;
+      name: string;
       /**
        * @description 店舗紹介
        * @example テスト紹介文
@@ -426,12 +424,12 @@ export interface components {
        * @description 店舗URL
        * @example https://example.com
        */
-      shopUrl?: string;
+      shopUrl: string;
       /**
        * @description 都道府県
        * @example TOKYO
        */
-      prefecture?: string;
+      prefecture: string;
       /**
        * @description 公開状態（DRAFT: 下書き / PUBLISHED: 公開）
        * @example DRAFT
@@ -441,35 +439,30 @@ export interface components {
     /** @description コーヒー豆登録リクエスト */
     CreateCoffeeBeanRequest: {
       /**
-       * @description スペシャルティコーヒーかどうか
-       * @example true
-       */
-      isSpecialty?: boolean;
-      /**
        * @description 店舗ID
        * @example 00000000-0000-4000-8000-000000000031
        */
-      shopId?: string;
+      shopId: string;
       /**
        * @description Shopifyの商品ID
        * @example gid://shopify/Product/999999
        */
-      shopifyBeanId?: string;
+      shopifyBeanId: string;
       /**
        * @description 豆の名前
        * @example テストコーヒー豆
        */
-      name?: string;
+      name: string;
       /**
        * @description 説明
        * @example テスト説明文
        */
-      description?: string;
+      description: string;
       /**
        * @description 産地
        * @example エチオピア
        */
-      origin?: string;
+      origin: string;
       /**
        * @description 農園名
        * @example テスト農園
@@ -479,20 +472,24 @@ export interface components {
        * @description 焙煎度
        * @example MEDIUM
        */
-      roastLevel?: string;
+      roastLevel: string;
       /**
        * @description 精製方法
        * @example WASHED
        */
-      processingMethod?: string;
+      processingMethod: string;
       /**
        * @description 公開状態（DRAFT: 下書き / PUBLISHED: 公開）
        * @example DRAFT
        */
       publishStatus: string;
       /** @description テイスト評価一覧 */
-      tastes?: components["schemas"]["TasteRequest"][];
-      specialty?: boolean;
+      tastes: components["schemas"]["TasteRequest"][];
+      /**
+       * @description スペシャルティコーヒーかどうか
+       * @example true
+       */
+      isSpecialty: boolean;
     };
     /** @description ログインリクエスト */
     LoginRequest: {
@@ -513,18 +510,84 @@ export interface components {
        * @description アクセストークン
        * @example eyJhbGciOiJIUzI1NiJ9...
        */
-      accessToken?: string;
+      accessToken: string;
       /**
        * @description トークンタイプ
        * @example Bearer
        */
-      tokenType?: string;
+      tokenType: string;
       /**
        * Format: int64
        * @description 有効期限（秒）
        * @example 3600
        */
-      expiresIn?: number;
+      expiresIn: number;
+    };
+    /** @description 店舗一覧レスポンス */
+    ShopListResponse: {
+      /** @description アイテム一覧 */
+      items: components["schemas"]["ShopSummaryResponse"][];
+      /**
+       * Format: int64
+       * @description 全件数
+       * @example 42
+       */
+      totalCount: number;
+      /**
+       * Format: int32
+       * @description 現在のページ番号（0始まり）
+       * @example 0
+       */
+      page: number;
+      /**
+       * Format: int32
+       * @description 1ページあたりの件数
+       * @example 20
+       */
+      size: number;
+    };
+    /** @description 店舗一覧アイテム */
+    ShopSummaryResponse: {
+      /**
+       * @description 店舗ID
+       * @example 00000000-0000-4000-8000-000000000001
+       */
+      id: string;
+      /**
+       * @description ShopifyショップID
+       * @example test-shop-001
+       */
+      shopifyShopId: string;
+      /**
+       * @description 店舗名
+       * @example テスト珈琲店
+       */
+      name: string;
+      /**
+       * @description 紹介文
+       * @example こだわりの珈琲をお届けします。
+       */
+      introduction?: string;
+      /**
+       * @description こだわり
+       * @example 厳選された豆のみを使用しています。
+       */
+      particular?: string;
+      /**
+       * @description 店舗URL
+       * @example https://example.com
+       */
+      shopUrl: string;
+      /**
+       * @description 都道府県
+       * @example TOKYO
+       */
+      prefecture: string;
+      /**
+       * @description 公開状態（DRAFT: 下書き / PUBLISHED: 公開）
+       * @example PUBLISHED
+       */
+      publishStatus: string;
     };
     /** @description 画像詳細 */
     ImageDetail: {
@@ -532,17 +595,17 @@ export interface components {
        * @description 画像ID
        * @example 00000000-0000-4000-8000-000000000010
        */
-      id?: string;
+      id: string;
       /**
        * @description 画像種別
        * @example MAIN
        */
-      type?: string;
+      type: string;
       /**
        * @description 画像URL
        * @example https://example.com/image.jpg
        */
-      imageUrl?: string;
+      imageUrl: string;
     };
     /** @description 店舗詳細レスポンス */
     ShopDetailResponse: {
@@ -550,17 +613,17 @@ export interface components {
        * @description 店舗ID
        * @example 00000000-0000-4000-8000-000000000001
        */
-      id?: string;
+      id: string;
       /**
        * @description ShopifyショップID
        * @example test-shop-001
        */
-      shopifyShopId?: string;
+      shopifyShopId: string;
       /**
        * @description 店舗名
        * @example テスト珈琲店
        */
-      name?: string;
+      name: string;
       /**
        * @description 店舗紹介
        * @example こだわりの珈琲をお届けします。
@@ -575,19 +638,88 @@ export interface components {
        * @description 店舗URL
        * @example https://example.com
        */
-      shopUrl?: string;
+      shopUrl: string;
       /**
        * @description 都道府県
        * @example TOKYO
        */
-      prefecture?: string;
+      prefecture: string;
       /**
        * @description 公開状態（DRAFT: 下書き / PUBLISHED: 公開）
        * @example PUBLISHED
        */
       publishStatus: string;
       /** @description 画像一覧 */
-      images?: components["schemas"]["ImageDetail"][];
+      images: components["schemas"]["ImageDetail"][];
+    };
+    /** @description プラン一覧レスポンス */
+    PlanListResponse: {
+      /** @description アイテム一覧 */
+      items: components["schemas"]["PlanSummaryResponse"][];
+      /**
+       * Format: int64
+       * @description 全件数
+       * @example 42
+       */
+      totalCount: number;
+      /**
+       * Format: int32
+       * @description 現在のページ番号（0始まり）
+       * @example 0
+       */
+      page: number;
+      /**
+       * Format: int32
+       * @description 1ページあたりの件数
+       * @example 20
+       */
+      size: number;
+    };
+    /** @description プラン一覧アイテム */
+    PlanSummaryResponse: {
+      /**
+       * @description プランID
+       * @example 00000000-0000-4000-8000-000000000024
+       */
+      id: string;
+      /**
+       * @description ShopifyのプランID
+       * @example test-plan-001
+       */
+      shopifyPlanId: string;
+      /**
+       * @description プラン表示名
+       * @example 定番
+       */
+      label: string;
+      /**
+       * Format: int32
+       * @description 1種あたりのグラム数
+       * @example 60
+       */
+      gramWeight: number;
+      /**
+       * Format: int32
+       * @description 豆の種類数
+       * @example 4
+       */
+      beanQuantity: number;
+      /**
+       * Format: int32
+       * @description 価格
+       * @example 3800
+       */
+      price: number;
+      /**
+       * @description プラン種別（SUBSCRIPTION / SINGLE）
+       * @example SUBSCRIPTION
+       */
+      type: string;
+      /**
+       * @description おすすめバッジ
+       * @example true
+       */
+      isRecommended: boolean;
     };
     /** @description プラン詳細レスポンス */
     PlanDetailResponse: {
@@ -595,74 +727,101 @@ export interface components {
        * @description プランID
        * @example 00000000-0000-4000-8000-000000000024
        */
-      id?: string;
+      id: string;
       /**
        * @description ShopifyのプランID
        * @example test-plan-001
        */
-      shopifyPlanId?: string;
+      shopifyPlanId: string;
       /**
        * @description プラン表示名
        * @example 定番
        */
-      label?: string;
+      label: string;
       /**
        * Format: int32
        * @description 1種あたりのグラム数
        * @example 60
        */
-      gramWeight?: number;
+      gramWeight: number;
       /**
        * Format: int32
        * @description 豆の種類数
        * @example 4
        */
-      beanQuantity?: number;
+      beanQuantity: number;
       /**
        * Format: int32
        * @description 価格
        * @example 3800
        */
-      price?: number;
+      price: number;
       /**
        * @description プラン種別（SUBSCRIPTION / SINGLE）
        * @example SUBSCRIPTION
        */
-      type?: string;
-      isRecommended?: boolean;
+      type: string;
+      /**
+       * @description おすすめバッジ
+       * @example true
+       */
+      isRecommended: boolean;
     };
-    /** @description コーヒー豆詳細レスポンス */
-    CoffeeBeanDetailResponse: {
+    /** @description コーヒー豆一覧レスポンス */
+    CoffeeBeanListResponse: {
+      /** @description アイテム一覧 */
+      items: components["schemas"]["CoffeeBeanSummaryResponse"][];
+      /**
+       * Format: int64
+       * @description 全件数
+       * @example 42
+       */
+      totalCount: number;
+      /**
+       * Format: int32
+       * @description 現在のページ番号（0始まり）
+       * @example 0
+       */
+      page: number;
+      /**
+       * Format: int32
+       * @description 1ページあたりの件数
+       * @example 20
+       */
+      size: number;
+    };
+    /** @description コーヒー豆一覧アイテム */
+    CoffeeBeanSummaryResponse: {
       /**
        * @description コーヒー豆ID
        * @example 00000000-0000-4000-8000-000000000001
        */
-      id?: string;
+      id: string;
       /**
        * @description ショップID
        * @example 00000000-0000-4000-8000-000000000002
        */
-      shopId?: string;
+      shopId: string;
       /**
        * @description Shopify商品ID
        * @example test-bean-001
        */
-      shopifyBeanId?: string;
+      shopifyBeanId: string;
       /**
        * @description 豆の名前
        * @example エチオピア イルガチェフェ
        */
-      name?: string;
+      name: string;
       /**
        * @description 説明
        * @example フルーティーな香りが特徴的なコーヒー豆です。
        */
-      description?: string;
+      description: string;
       /**
        * @description 産地
        * @example エチオピア
        */
-      origin?: string;
+      origin: string;
       /**
        * @description 農園名
        * @example イルガチェフェ農園
@@ -672,22 +831,84 @@ export interface components {
        * @description 焙煎度
        * @example MEDIUM
        */
-      roastLevel?: string;
+      roastLevel: string;
       /**
        * @description 精製方法
        * @example WASHED
        */
-      processingMethod?: string;
+      processingMethod: string;
+      /**
+       * @description 公開状態（DRAFT: 下書き / PUBLISHED: 公開）
+       * @example PUBLISHED
+       */
+      publishStatus: string;
+      /**
+       * @description スペシャルティコーヒーかどうか
+       * @example true
+       */
+      isSpecialty: boolean;
+    };
+    /** @description コーヒー豆詳細レスポンス */
+    CoffeeBeanDetailResponse: {
+      /**
+       * @description コーヒー豆ID
+       * @example 00000000-0000-4000-8000-000000000001
+       */
+      id: string;
+      /**
+       * @description ショップID
+       * @example 00000000-0000-4000-8000-000000000002
+       */
+      shopId: string;
+      /**
+       * @description Shopify商品ID
+       * @example test-bean-001
+       */
+      shopifyBeanId: string;
+      /**
+       * @description 豆の名前
+       * @example エチオピア イルガチェフェ
+       */
+      name: string;
+      /**
+       * @description 説明
+       * @example フルーティーな香りが特徴的なコーヒー豆です。
+       */
+      description: string;
+      /**
+       * @description 産地
+       * @example エチオピア
+       */
+      origin: string;
+      /**
+       * @description 農園名
+       * @example イルガチェフェ農園
+       */
+      farm?: string;
+      /**
+       * @description 焙煎度
+       * @example MEDIUM
+       */
+      roastLevel: string;
+      /**
+       * @description 精製方法
+       * @example WASHED
+       */
+      processingMethod: string;
       /**
        * @description 公開状態（DRAFT: 下書き / PUBLISHED: 公開）
        * @example PUBLISHED
        */
       publishStatus: string;
       /** @description 画像一覧 */
-      images?: components["schemas"]["ImageDetail"][];
+      images: components["schemas"]["ImageDetail"][];
       /** @description テイスト評価一覧 */
-      tastes?: components["schemas"]["TasteDetail"][];
-      isSpecialty?: boolean;
+      tastes: components["schemas"]["TasteDetail"][];
+      /**
+       * @description スペシャルティコーヒーかどうか
+       * @example true
+       */
+      isSpecialty: boolean;
     };
     /** @description テイスト評価詳細 */
     TasteDetail: {
@@ -695,23 +916,23 @@ export interface components {
        * @description テイスト評価ID
        * @example 00000000-0000-4000-8000-000000000020
        */
-      id?: string;
+      id: string;
       /**
        * @description テイストマスタID
        * @example 00000000-0000-4000-8000-000000000041
        */
-      tasteId?: string;
+      tasteId: string;
       /**
        * @description テイスト名
        * @example 酸味
        */
-      tasteName?: string;
+      tasteName: string;
       /**
        * Format: int32
        * @description 評価値（0-5）
        * @example 4
        */
-      evaluationValue?: number;
+      evaluationValue: number;
     };
   };
   responses: never;
@@ -1114,7 +1335,7 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
-          "*/*": unknown;
+          "*/*": components["schemas"]["ShopListResponse"];
         };
       };
     };
@@ -1192,7 +1413,7 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
-          "*/*": unknown;
+          "*/*": components["schemas"]["CoffeeBeanListResponse"];
         };
       };
     };
@@ -1328,7 +1549,7 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
-          "*/*": unknown;
+          "*/*": components["schemas"]["PlanListResponse"];
         };
       };
     };

--- a/admin-frontend/src/api/plans.ts
+++ b/admin-frontend/src/api/plans.ts
@@ -1,0 +1,56 @@
+import "server-only";
+
+import { notFound } from "next/navigation";
+import { createAuthenticatedApiClient } from "@/api/client";
+import type { PagedResponse } from "@/api/types";
+
+export type { PagedResponse } from "@/api/types";
+
+export type PlanType = "SUBSCRIPTION" | "SINGLE";
+
+export type PlanListItem = {
+  id: string;
+  shopifyPlanId: string;
+  label: string;
+  gramWeight: number;
+  beanQuantity: number;
+  price: number;
+  type: PlanType;
+  isRecommended: boolean;
+};
+
+export type PlanDetail = PlanListItem;
+
+export async function fetchPlans(
+  page = 0,
+  size = 20,
+  keyword?: string,
+): Promise<PagedResponse<PlanListItem>> {
+  const client = await createAuthenticatedApiClient();
+  const { data, error } = await client.GET("/api/admin/plans", {
+    params: { query: { page, size, keyword } },
+  });
+
+  if (error) {
+    throw new Error("プラン一覧の取得に失敗しました");
+  }
+
+  return data as PagedResponse<PlanListItem>;
+}
+
+export async function fetchPlan(id: string): Promise<PlanDetail> {
+  const client = await createAuthenticatedApiClient();
+  const { data, response } = await client.GET("/api/admin/plans/{id}", {
+    params: { path: { id } },
+  });
+
+  if (response.status === 404) {
+    notFound();
+  }
+
+  if (!data) {
+    throw new Error("プランの取得に失敗しました");
+  }
+
+  return data as PlanDetail;
+}

--- a/admin-frontend/src/api/plans.ts
+++ b/admin-frontend/src/api/plans.ts
@@ -2,30 +2,19 @@ import "server-only";
 
 import { notFound } from "next/navigation";
 import { createAuthenticatedApiClient } from "@/api/client";
-import type { PagedResponse } from "@/api/types";
+import type { components } from "@/api/generated/admin-api";
 
-export type { PagedResponse } from "@/api/types";
+export type PlanListItem = components["schemas"]["PlanSummaryResponse"];
+export type PlanDetail = components["schemas"]["PlanDetailResponse"];
+export type PlanListResponse = components["schemas"]["PlanListResponse"];
 
 export type PlanType = "SUBSCRIPTION" | "SINGLE";
-
-export type PlanListItem = {
-  id: string;
-  shopifyPlanId: string;
-  label: string;
-  gramWeight: number;
-  beanQuantity: number;
-  price: number;
-  type: PlanType;
-  isRecommended: boolean;
-};
-
-export type PlanDetail = PlanListItem;
 
 export async function fetchPlans(
   page = 0,
   size = 20,
   keyword?: string,
-): Promise<PagedResponse<PlanListItem>> {
+): Promise<PlanListResponse> {
   const client = await createAuthenticatedApiClient();
   const { data, error } = await client.GET("/api/admin/plans", {
     params: { query: { page, size, keyword } },
@@ -35,7 +24,7 @@ export async function fetchPlans(
     throw new Error("プラン一覧の取得に失敗しました");
   }
 
-  return data as PagedResponse<PlanListItem>;
+  return data;
 }
 
 export async function fetchPlan(id: string): Promise<PlanDetail> {
@@ -52,5 +41,5 @@ export async function fetchPlan(id: string): Promise<PlanDetail> {
     throw new Error("プランの取得に失敗しました");
   }
 
-  return data as PlanDetail;
+  return data;
 }

--- a/admin-frontend/src/api/shops.ts
+++ b/admin-frontend/src/api/shops.ts
@@ -2,36 +2,19 @@ import "server-only";
 
 import { notFound } from "next/navigation";
 import { createAuthenticatedApiClient } from "@/api/client";
-import type { PagedResponse } from "@/api/types";
+import type { components } from "@/api/generated/admin-api";
 
-export type { PagedResponse } from "@/api/types";
+export type ShopListItem = components["schemas"]["ShopSummaryResponse"];
+export type ShopDetail = components["schemas"]["ShopDetailResponse"];
+export type ShopListResponse = components["schemas"]["ShopListResponse"];
 
-export type ShopListItem = {
-  id: string;
-  shopifyShopId: string;
-  name: string;
-  introduction: string | null;
-  particular: string | null;
-  shopUrl: string;
-  prefecture: string;
-  publishStatus: "DRAFT" | "PUBLISHED";
-};
-
-export type ImageDetail = {
-  id: string;
-  type: "MAIN" | "LOGO";
-  imageUrl: string;
-};
-
-export type ShopDetail = ShopListItem & {
-  images: ImageDetail[];
-};
+export type ImageDetail = NonNullable<ShopDetail["images"]>[number];
 
 export async function fetchShops(
   page = 0,
   size = 20,
   name?: string,
-): Promise<PagedResponse<ShopListItem>> {
+): Promise<ShopListResponse> {
   const client = await createAuthenticatedApiClient();
   const { data, error } = await client.GET("/api/admin/shops", {
     params: { query: { page, size, name } },
@@ -41,7 +24,7 @@ export async function fetchShops(
     throw new Error("店舗一覧の取得に失敗しました");
   }
 
-  return data as PagedResponse<ShopListItem>;
+  return data;
 }
 
 export async function fetchShop(id: string): Promise<ShopDetail> {
@@ -58,5 +41,5 @@ export async function fetchShop(id: string): Promise<ShopDetail> {
     throw new Error("店舗の取得に失敗しました");
   }
 
-  return data as ShopDetail;
+  return data;
 }

--- a/admin-frontend/src/app/(admin)/coffee-beans/[id]/_components/EditCoffeeBeanModal.tsx
+++ b/admin-frontend/src/app/(admin)/coffee-beans/[id]/_components/EditCoffeeBeanModal.tsx
@@ -18,6 +18,7 @@ import {
 import { ImageUploadField } from "@/components/ImageUploadField";
 import modalStyles from "@/components/modal.module.css";
 import { ShopSearchSelect } from "@/components/ShopSearchSelect";
+import { ToggleField } from "@/components/ToggleField";
 import {
   type EditCoffeeBeanState,
   editCoffeeBeanAction,
@@ -258,53 +259,29 @@ export function EditCoffeeBeanModal({
           ))}
         </div>
 
-        <div className={modalStyles.toggleField}>
-          <label htmlFor={isSpecialtyId} className={modalStyles.label}>
-            スペシャルティ
-            <span className={modalStyles.required}>*</span>
-          </label>
-          <label className={modalStyles.toggleSwitch}>
-            <input
-              id={isSpecialtyId}
-              name="isSpecialty"
-              type="checkbox"
-              defaultChecked={
-                (state.values?.isSpecialty ??
-                  (coffeeBean.isSpecialty ? "true" : "false")) === "true"
-              }
-            />
-            <span className={modalStyles.toggleSlider} />
-          </label>
-          {state.fieldErrors?.isSpecialty?.map((msg) => (
-            <span key={msg} className={modalStyles.fieldError}>
-              {msg}
-            </span>
-          ))}
-        </div>
+        <ToggleField
+          id={isSpecialtyId}
+          name="isSpecialty"
+          label="スペシャルティ"
+          required
+          defaultChecked={
+            (state.values?.isSpecialty ??
+              (coffeeBean.isSpecialty ? "true" : "false")) === "true"
+          }
+          errors={state.fieldErrors?.isSpecialty}
+        />
 
-        <div className={modalStyles.toggleField}>
-          <label htmlFor={publishStatusId} className={modalStyles.label}>
-            公開状態
-            <span className={modalStyles.required}>*</span>
-          </label>
-          <label className={modalStyles.toggleSwitch}>
-            <input
-              id={publishStatusId}
-              name="publishStatus"
-              type="checkbox"
-              defaultChecked={
-                (state.values?.publishStatus ?? coffeeBean.publishStatus) ===
-                "PUBLISHED"
-              }
-            />
-            <span className={modalStyles.toggleSlider} />
-          </label>
-          {state.fieldErrors?.publishStatus?.map((msg) => (
-            <span key={msg} className={modalStyles.fieldError}>
-              {msg}
-            </span>
-          ))}
-        </div>
+        <ToggleField
+          id={publishStatusId}
+          name="publishStatus"
+          label="公開状態"
+          required
+          defaultChecked={
+            (state.values?.publishStatus ?? coffeeBean.publishStatus) ===
+            "PUBLISHED"
+          }
+          errors={state.fieldErrors?.publishStatus}
+        />
 
         <TasteProfileField
           tastes={tastes}

--- a/admin-frontend/src/app/(admin)/coffee-beans/[id]/_components/EditCoffeeBeanModal.tsx
+++ b/admin-frontend/src/app/(admin)/coffee-beans/[id]/_components/EditCoffeeBeanModal.tsx
@@ -17,7 +17,6 @@ import {
 } from "@/app/(admin)/coffee-beans/_lib/coffeeBeanLabels";
 import { ImageUploadField } from "@/components/ImageUploadField";
 import modalStyles from "@/components/modal.module.css";
-import { PUBLISH_STATUS_OPTIONS } from "@/components/publishStatus";
 import { ShopSearchSelect } from "@/components/ShopSearchSelect";
 import {
   type EditCoffeeBeanState,
@@ -259,23 +258,23 @@ export function EditCoffeeBeanModal({
           ))}
         </div>
 
-        <div className={modalStyles.field}>
+        <div className={modalStyles.toggleField}>
           <label htmlFor={isSpecialtyId} className={modalStyles.label}>
             スペシャルティ
             <span className={modalStyles.required}>*</span>
           </label>
-          <select
-            id={isSpecialtyId}
-            name="isSpecialty"
-            defaultValue={
-              state.values?.isSpecialty ??
-              (coffeeBean.isSpecialty ? "true" : "false")
-            }
-            className={modalStyles.select}
-          >
-            <option value="true">あり</option>
-            <option value="false">なし</option>
-          </select>
+          <label className={modalStyles.toggleSwitch}>
+            <input
+              id={isSpecialtyId}
+              name="isSpecialty"
+              type="checkbox"
+              defaultChecked={
+                (state.values?.isSpecialty ??
+                  (coffeeBean.isSpecialty ? "true" : "false")) === "true"
+              }
+            />
+            <span className={modalStyles.toggleSlider} />
+          </label>
           {state.fieldErrors?.isSpecialty?.map((msg) => (
             <span key={msg} className={modalStyles.fieldError}>
               {msg}
@@ -283,25 +282,23 @@ export function EditCoffeeBeanModal({
           ))}
         </div>
 
-        <div className={modalStyles.field}>
+        <div className={modalStyles.toggleField}>
           <label htmlFor={publishStatusId} className={modalStyles.label}>
             公開状態
             <span className={modalStyles.required}>*</span>
           </label>
-          <select
-            id={publishStatusId}
-            name="publishStatus"
-            defaultValue={
-              state.values?.publishStatus ?? coffeeBean.publishStatus
-            }
-            className={modalStyles.select}
-          >
-            {PUBLISH_STATUS_OPTIONS.map((option) => (
-              <option key={option.value} value={option.value}>
-                {option.label}
-              </option>
-            ))}
-          </select>
+          <label className={modalStyles.toggleSwitch}>
+            <input
+              id={publishStatusId}
+              name="publishStatus"
+              type="checkbox"
+              defaultChecked={
+                (state.values?.publishStatus ?? coffeeBean.publishStatus) ===
+                "PUBLISHED"
+              }
+            />
+            <span className={modalStyles.toggleSlider} />
+          </label>
           {state.fieldErrors?.publishStatus?.map((msg) => (
             <span key={msg} className={modalStyles.fieldError}>
               {msg}

--- a/admin-frontend/src/app/(admin)/coffee-beans/[id]/_components/editCoffeeBeanAction.ts
+++ b/admin-frontend/src/app/(admin)/coffee-beans/[id]/_components/editCoffeeBeanAction.ts
@@ -28,8 +28,9 @@ export async function editCoffeeBeanAction(
     farm: (formData.get("farm") as string) ?? "",
     roastLevel: (formData.get("roastLevel") as string) ?? "",
     processingMethod: (formData.get("processingMethod") as string) ?? "",
-    isSpecialty: (formData.get("isSpecialty") as string) ?? "false",
-    publishStatus: (formData.get("publishStatus") as string) ?? "",
+    isSpecialty: formData.get("isSpecialty") === "on" ? "true" : "false",
+    publishStatus:
+      formData.get("publishStatus") === "on" ? "PUBLISHED" : "DRAFT",
   };
 
   const result = editCoffeeBeanSchema.safeParse({

--- a/admin-frontend/src/app/(admin)/coffee-beans/[id]/_components/editCoffeeBeanAction.ts
+++ b/admin-frontend/src/app/(admin)/coffee-beans/[id]/_components/editCoffeeBeanAction.ts
@@ -7,8 +7,8 @@ import {
   type CoffeeBeanFormState,
   coffeeBeanFieldsSchema,
 } from "@/app/(admin)/coffee-beans/_lib/coffeeBeanFormSchema";
-import { isChecked } from "@/lib/formData";
 import { parseTastesFromFormData } from "@/app/(admin)/coffee-beans/_lib/parseTastes";
+import { isChecked } from "@/lib/formData";
 
 const editCoffeeBeanSchema = coffeeBeanFieldsSchema.extend({
   id: z.string(),

--- a/admin-frontend/src/app/(admin)/coffee-beans/[id]/_components/editCoffeeBeanAction.ts
+++ b/admin-frontend/src/app/(admin)/coffee-beans/[id]/_components/editCoffeeBeanAction.ts
@@ -7,6 +7,7 @@ import {
   type CoffeeBeanFormState,
   coffeeBeanFieldsSchema,
 } from "@/app/(admin)/coffee-beans/_lib/coffeeBeanFormSchema";
+import { isChecked } from "@/lib/formData";
 import { parseTastesFromFormData } from "@/app/(admin)/coffee-beans/_lib/parseTastes";
 
 const editCoffeeBeanSchema = coffeeBeanFieldsSchema.extend({
@@ -28,9 +29,8 @@ export async function editCoffeeBeanAction(
     farm: (formData.get("farm") as string) ?? "",
     roastLevel: (formData.get("roastLevel") as string) ?? "",
     processingMethod: (formData.get("processingMethod") as string) ?? "",
-    isSpecialty: formData.get("isSpecialty") === "on" ? "true" : "false",
-    publishStatus:
-      formData.get("publishStatus") === "on" ? "PUBLISHED" : "DRAFT",
+    isSpecialty: isChecked(formData, "isSpecialty") ? "true" : "false",
+    publishStatus: isChecked(formData, "publishStatus") ? "PUBLISHED" : "DRAFT",
   };
 
   const result = editCoffeeBeanSchema.safeParse({

--- a/admin-frontend/src/app/(admin)/coffee-beans/_components/CoffeeBeanListTable.tsx
+++ b/admin-frontend/src/app/(admin)/coffee-beans/_components/CoffeeBeanListTable.tsx
@@ -1,6 +1,5 @@
 import Link from "next/link";
-import type { CoffeeBeanListItem } from "@/api/coffee-beans";
-import type { PagedResponse } from "@/api/types";
+import type { CoffeeBeanListResponse } from "@/api/coffee-beans";
 import styles from "@/components/list-page.module.css";
 import { Pagination } from "@/components/Pagination";
 import { PublishStatusBadge } from "@/components/PublishStatusBadge";
@@ -14,7 +13,7 @@ export function CoffeeBeanListTable({
   coffeeBeans,
   currentPage,
 }: {
-  coffeeBeans: PagedResponse<CoffeeBeanListItem>;
+  coffeeBeans: CoffeeBeanListResponse;
   currentPage: number;
 }) {
   const totalPages = Math.ceil(coffeeBeans.totalCount / coffeeBeans.size);

--- a/admin-frontend/src/app/(admin)/coffee-beans/_components/CreateCoffeeBeanModal.tsx
+++ b/admin-frontend/src/app/(admin)/coffee-beans/_components/CreateCoffeeBeanModal.tsx
@@ -20,6 +20,7 @@ import {
 import { ImageUploadField } from "@/components/ImageUploadField";
 import modalStyles from "@/components/modal.module.css";
 import { ShopSearchSelect } from "@/components/ShopSearchSelect";
+import { ToggleField } from "@/components/ToggleField";
 import {
   type CreateCoffeeBeanState,
   createCoffeeBeanAction,
@@ -267,49 +268,25 @@ export function CreateCoffeeBeanModal({
           ))}
         </div>
 
-        <div className={modalStyles.toggleField}>
-          <label htmlFor={isSpecialtyId} className={modalStyles.label}>
-            スペシャルティ
-            <span className={modalStyles.required}>*</span>
-          </label>
-          <label className={modalStyles.toggleSwitch}>
-            <input
-              id={isSpecialtyId}
-              name="isSpecialty"
-              type="checkbox"
-              defaultChecked={(state.values?.isSpecialty ?? "false") === "true"}
-            />
-            <span className={modalStyles.toggleSlider} />
-          </label>
-          {state.fieldErrors?.isSpecialty?.map((msg) => (
-            <span key={msg} className={modalStyles.fieldError}>
-              {msg}
-            </span>
-          ))}
-        </div>
+        <ToggleField
+          id={isSpecialtyId}
+          name="isSpecialty"
+          label="スペシャルティ"
+          required
+          defaultChecked={(state.values?.isSpecialty ?? "false") === "true"}
+          errors={state.fieldErrors?.isSpecialty}
+        />
 
-        <div className={modalStyles.toggleField}>
-          <label htmlFor={publishStatusId} className={modalStyles.label}>
-            公開状態
-            <span className={modalStyles.required}>*</span>
-          </label>
-          <label className={modalStyles.toggleSwitch}>
-            <input
-              id={publishStatusId}
-              name="publishStatus"
-              type="checkbox"
-              defaultChecked={
-                (state.values?.publishStatus ?? "DRAFT") === "PUBLISHED"
-              }
-            />
-            <span className={modalStyles.toggleSlider} />
-          </label>
-          {state.fieldErrors?.publishStatus?.map((msg) => (
-            <span key={msg} className={modalStyles.fieldError}>
-              {msg}
-            </span>
-          ))}
-        </div>
+        <ToggleField
+          id={publishStatusId}
+          name="publishStatus"
+          label="公開状態"
+          required
+          defaultChecked={
+            (state.values?.publishStatus ?? "DRAFT") === "PUBLISHED"
+          }
+          errors={state.fieldErrors?.publishStatus}
+        />
 
         <TasteProfileField tastes={tastes} />
 

--- a/admin-frontend/src/app/(admin)/coffee-beans/_components/CreateCoffeeBeanModal.tsx
+++ b/admin-frontend/src/app/(admin)/coffee-beans/_components/CreateCoffeeBeanModal.tsx
@@ -19,7 +19,6 @@ import {
 } from "@/app/(admin)/coffee-beans/_lib/coffeeBeanLabels";
 import { ImageUploadField } from "@/components/ImageUploadField";
 import modalStyles from "@/components/modal.module.css";
-import { PUBLISH_STATUS_OPTIONS } from "@/components/publishStatus";
 import { ShopSearchSelect } from "@/components/ShopSearchSelect";
 import {
   type CreateCoffeeBeanState,
@@ -268,20 +267,20 @@ export function CreateCoffeeBeanModal({
           ))}
         </div>
 
-        <div className={modalStyles.field}>
+        <div className={modalStyles.toggleField}>
           <label htmlFor={isSpecialtyId} className={modalStyles.label}>
             スペシャルティ
             <span className={modalStyles.required}>*</span>
           </label>
-          <select
-            id={isSpecialtyId}
-            name="isSpecialty"
-            defaultValue={state.values?.isSpecialty ?? "false"}
-            className={modalStyles.select}
-          >
-            <option value="true">あり</option>
-            <option value="false">なし</option>
-          </select>
+          <label className={modalStyles.toggleSwitch}>
+            <input
+              id={isSpecialtyId}
+              name="isSpecialty"
+              type="checkbox"
+              defaultChecked={(state.values?.isSpecialty ?? "false") === "true"}
+            />
+            <span className={modalStyles.toggleSlider} />
+          </label>
           {state.fieldErrors?.isSpecialty?.map((msg) => (
             <span key={msg} className={modalStyles.fieldError}>
               {msg}
@@ -289,23 +288,22 @@ export function CreateCoffeeBeanModal({
           ))}
         </div>
 
-        <div className={modalStyles.field}>
+        <div className={modalStyles.toggleField}>
           <label htmlFor={publishStatusId} className={modalStyles.label}>
             公開状態
             <span className={modalStyles.required}>*</span>
           </label>
-          <select
-            id={publishStatusId}
-            name="publishStatus"
-            defaultValue={state.values?.publishStatus ?? "DRAFT"}
-            className={modalStyles.select}
-          >
-            {PUBLISH_STATUS_OPTIONS.map((option) => (
-              <option key={option.value} value={option.value}>
-                {option.label}
-              </option>
-            ))}
-          </select>
+          <label className={modalStyles.toggleSwitch}>
+            <input
+              id={publishStatusId}
+              name="publishStatus"
+              type="checkbox"
+              defaultChecked={
+                (state.values?.publishStatus ?? "DRAFT") === "PUBLISHED"
+              }
+            />
+            <span className={modalStyles.toggleSlider} />
+          </label>
           {state.fieldErrors?.publishStatus?.map((msg) => (
             <span key={msg} className={modalStyles.fieldError}>
               {msg}

--- a/admin-frontend/src/app/(admin)/coffee-beans/_components/createCoffeeBeanAction.ts
+++ b/admin-frontend/src/app/(admin)/coffee-beans/_components/createCoffeeBeanAction.ts
@@ -7,6 +7,7 @@ import {
   coffeeBeanFieldsSchema,
 } from "@/app/(admin)/coffee-beans/_lib/coffeeBeanFormSchema";
 import { parseTastesFromFormData } from "@/app/(admin)/coffee-beans/_lib/parseTastes";
+import { isChecked } from "@/lib/formData";
 
 export type CreateCoffeeBeanState = CoffeeBeanFormState;
 
@@ -23,9 +24,8 @@ export async function createCoffeeBeanAction(
     farm: (formData.get("farm") as string) ?? "",
     roastLevel: (formData.get("roastLevel") as string) ?? "",
     processingMethod: (formData.get("processingMethod") as string) ?? "",
-    isSpecialty: formData.get("isSpecialty") === "on" ? "true" : "false",
-    publishStatus:
-      formData.get("publishStatus") === "on" ? "PUBLISHED" : "DRAFT",
+    isSpecialty: isChecked(formData, "isSpecialty") ? "true" : "false",
+    publishStatus: isChecked(formData, "publishStatus") ? "PUBLISHED" : "DRAFT",
   };
 
   const result = coffeeBeanFieldsSchema.safeParse(values);

--- a/admin-frontend/src/app/(admin)/coffee-beans/_components/createCoffeeBeanAction.ts
+++ b/admin-frontend/src/app/(admin)/coffee-beans/_components/createCoffeeBeanAction.ts
@@ -23,8 +23,9 @@ export async function createCoffeeBeanAction(
     farm: (formData.get("farm") as string) ?? "",
     roastLevel: (formData.get("roastLevel") as string) ?? "",
     processingMethod: (formData.get("processingMethod") as string) ?? "",
-    isSpecialty: (formData.get("isSpecialty") as string) ?? "false",
-    publishStatus: (formData.get("publishStatus") as string) ?? "",
+    isSpecialty: formData.get("isSpecialty") === "on" ? "true" : "false",
+    publishStatus:
+      formData.get("publishStatus") === "on" ? "PUBLISHED" : "DRAFT",
   };
 
   const result = coffeeBeanFieldsSchema.safeParse(values);

--- a/admin-frontend/src/app/(admin)/plans/[id]/_components/EditPlanModal.tsx
+++ b/admin-frontend/src/app/(admin)/plans/[id]/_components/EditPlanModal.tsx
@@ -189,16 +189,19 @@ export function EditPlanModal({
           ))}
         </div>
 
-        <div className={modalStyles.field}>
+        <div className={modalStyles.toggleField}>
           <label htmlFor={isRecommendedId} className={modalStyles.label}>
             おすすめバッジ
           </label>
-          <input
-            id={isRecommendedId}
-            name="isRecommended"
-            type="checkbox"
-            defaultChecked={plan.isRecommended}
-          />
+          <label className={modalStyles.toggleSwitch}>
+            <input
+              id={isRecommendedId}
+              name="isRecommended"
+              type="checkbox"
+              defaultChecked={plan.isRecommended}
+            />
+            <span className={modalStyles.toggleSlider} />
+          </label>
         </div>
 
         <div className={modalStyles.actions}>

--- a/admin-frontend/src/app/(admin)/plans/[id]/_components/EditPlanModal.tsx
+++ b/admin-frontend/src/app/(admin)/plans/[id]/_components/EditPlanModal.tsx
@@ -3,6 +3,7 @@
 import { useActionState, useEffect, useId, useRef } from "react";
 import type { PlanDetail } from "@/api/plans";
 import modalStyles from "@/components/modal.module.css";
+import { ToggleField } from "@/components/ToggleField";
 import {
   BEAN_QUANTITY_OPTIONS,
   GRAM_WEIGHT_OPTIONS,
@@ -189,20 +190,12 @@ export function EditPlanModal({
           ))}
         </div>
 
-        <div className={modalStyles.toggleField}>
-          <label htmlFor={isRecommendedId} className={modalStyles.label}>
-            おすすめバッジ
-          </label>
-          <label className={modalStyles.toggleSwitch}>
-            <input
-              id={isRecommendedId}
-              name="isRecommended"
-              type="checkbox"
-              defaultChecked={plan.isRecommended}
-            />
-            <span className={modalStyles.toggleSlider} />
-          </label>
-        </div>
+        <ToggleField
+          id={isRecommendedId}
+          name="isRecommended"
+          label="おすすめバッジ"
+          defaultChecked={plan.isRecommended}
+        />
 
         <div className={modalStyles.actions}>
           <button

--- a/admin-frontend/src/app/(admin)/plans/[id]/_components/EditPlanModal.tsx
+++ b/admin-frontend/src/app/(admin)/plans/[id]/_components/EditPlanModal.tsx
@@ -1,0 +1,223 @@
+"use client";
+
+import { useActionState, useEffect, useId, useRef } from "react";
+import type { PlanDetail } from "@/api/plans";
+import modalStyles from "@/components/modal.module.css";
+import {
+  BEAN_QUANTITY_OPTIONS,
+  GRAM_WEIGHT_OPTIONS,
+  PLAN_TYPE_OPTIONS,
+} from "../../_lib/planLabels";
+import { editPlanAction } from "./editPlanAction";
+
+export function EditPlanModal({
+  plan,
+  isOpen,
+  onClose,
+}: {
+  plan: PlanDetail;
+  isOpen: boolean;
+  onClose: () => void;
+}) {
+  const [state, formAction, isPending] = useActionState(editPlanAction, {});
+  const dialogRef = useRef<HTMLDialogElement>(null);
+
+  const shopifyPlanIdId = useId();
+  const labelId = useId();
+  const typeId = useId();
+  const gramWeightId = useId();
+  const beanQuantityId = useId();
+  const priceId = useId();
+  const isRecommendedId = useId();
+
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    if (isOpen && !dialog.open) {
+      dialog.showModal();
+    } else if (!isOpen && dialog.open) {
+      dialog.close();
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (state.success) {
+      onClose();
+    }
+  }, [state.success, onClose]);
+
+  return (
+    <dialog ref={dialogRef} className={modalStyles.dialog} onClose={onClose}>
+      <div className={modalStyles.dialogHeader}>
+        <h2 className={modalStyles.dialogTitle}>プランを編集</h2>
+        <button
+          type="button"
+          onClick={onClose}
+          className={modalStyles.closeButton}
+          aria-label="閉じる"
+        >
+          &times;
+        </button>
+      </div>
+      <form action={formAction} className={modalStyles.form}>
+        <input type="hidden" name="id" value={plan.id} />
+        {state.error && <div className={modalStyles.error}>{state.error}</div>}
+
+        <div className={modalStyles.field}>
+          <label htmlFor={shopifyPlanIdId} className={modalStyles.label}>
+            ShopifyプランID<span className={modalStyles.required}>*</span>
+          </label>
+          <input
+            id={shopifyPlanIdId}
+            name="shopifyPlanId"
+            type="text"
+            maxLength={255}
+            defaultValue={plan.shopifyPlanId}
+            className={modalStyles.input}
+          />
+          {state.fieldErrors?.shopifyPlanId?.map((msg) => (
+            <span key={msg} className={modalStyles.fieldError}>
+              {msg}
+            </span>
+          ))}
+        </div>
+
+        <div className={modalStyles.field}>
+          <label htmlFor={labelId} className={modalStyles.label}>
+            プラン表示名<span className={modalStyles.required}>*</span>
+          </label>
+          <input
+            id={labelId}
+            name="label"
+            type="text"
+            maxLength={50}
+            defaultValue={plan.label}
+            className={modalStyles.input}
+          />
+          {state.fieldErrors?.label?.map((msg) => (
+            <span key={msg} className={modalStyles.fieldError}>
+              {msg}
+            </span>
+          ))}
+        </div>
+
+        <div className={modalStyles.field}>
+          <label htmlFor={typeId} className={modalStyles.label}>
+            プラン種別<span className={modalStyles.required}>*</span>
+          </label>
+          <select
+            id={typeId}
+            name="type"
+            defaultValue={plan.type}
+            className={modalStyles.select}
+          >
+            {PLAN_TYPE_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+          {state.fieldErrors?.type?.map((msg) => (
+            <span key={msg} className={modalStyles.fieldError}>
+              {msg}
+            </span>
+          ))}
+        </div>
+
+        <div className={modalStyles.field}>
+          <label htmlFor={gramWeightId} className={modalStyles.label}>
+            1種あたりのグラム数<span className={modalStyles.required}>*</span>
+          </label>
+          <select
+            id={gramWeightId}
+            name="gramWeight"
+            defaultValue={plan.gramWeight}
+            className={modalStyles.select}
+          >
+            {GRAM_WEIGHT_OPTIONS.map((gram) => (
+              <option key={gram} value={gram}>
+                {gram}g
+              </option>
+            ))}
+          </select>
+          {state.fieldErrors?.gramWeight?.map((msg) => (
+            <span key={msg} className={modalStyles.fieldError}>
+              {msg}
+            </span>
+          ))}
+        </div>
+
+        <div className={modalStyles.field}>
+          <label htmlFor={beanQuantityId} className={modalStyles.label}>
+            豆の種類数<span className={modalStyles.required}>*</span>
+          </label>
+          <select
+            id={beanQuantityId}
+            name="beanQuantity"
+            defaultValue={plan.beanQuantity}
+            className={modalStyles.select}
+          >
+            {BEAN_QUANTITY_OPTIONS.map((quantity) => (
+              <option key={quantity} value={quantity}>
+                {quantity}種
+              </option>
+            ))}
+          </select>
+          {state.fieldErrors?.beanQuantity?.map((msg) => (
+            <span key={msg} className={modalStyles.fieldError}>
+              {msg}
+            </span>
+          ))}
+        </div>
+
+        <div className={modalStyles.field}>
+          <label htmlFor={priceId} className={modalStyles.label}>
+            価格<span className={modalStyles.required}>*</span>
+          </label>
+          <input
+            id={priceId}
+            name="price"
+            type="number"
+            min="0"
+            defaultValue={plan.price}
+            className={modalStyles.input}
+          />
+          {state.fieldErrors?.price?.map((msg) => (
+            <span key={msg} className={modalStyles.fieldError}>
+              {msg}
+            </span>
+          ))}
+        </div>
+
+        <div className={modalStyles.field}>
+          <label htmlFor={isRecommendedId} className={modalStyles.label}>
+            おすすめバッジ
+          </label>
+          <input
+            id={isRecommendedId}
+            name="isRecommended"
+            type="checkbox"
+            defaultChecked={plan.isRecommended}
+          />
+        </div>
+
+        <div className={modalStyles.actions}>
+          <button
+            type="button"
+            onClick={onClose}
+            className={modalStyles.cancelButton}
+          >
+            キャンセル
+          </button>
+          <button
+            type="submit"
+            disabled={isPending}
+            className={modalStyles.submitButton}
+          >
+            {isPending ? "保存中..." : "保存"}
+          </button>
+        </div>
+      </form>
+    </dialog>
+  );
+}

--- a/admin-frontend/src/app/(admin)/plans/[id]/_components/EditPlanModal.tsx
+++ b/admin-frontend/src/app/(admin)/plans/[id]/_components/EditPlanModal.tsx
@@ -73,7 +73,7 @@ export function EditPlanModal({
             name="shopifyPlanId"
             type="text"
             maxLength={255}
-            defaultValue={plan.shopifyPlanId}
+            defaultValue={state.values?.shopifyPlanId ?? plan.shopifyPlanId}
             className={modalStyles.input}
           />
           {state.fieldErrors?.shopifyPlanId?.map((msg) => (
@@ -92,7 +92,7 @@ export function EditPlanModal({
             name="label"
             type="text"
             maxLength={50}
-            defaultValue={plan.label}
+            defaultValue={state.values?.label ?? plan.label}
             className={modalStyles.input}
           />
           {state.fieldErrors?.label?.map((msg) => (
@@ -109,7 +109,7 @@ export function EditPlanModal({
           <select
             id={typeId}
             name="type"
-            defaultValue={plan.type}
+            defaultValue={state.values?.type ?? plan.type}
             className={modalStyles.select}
           >
             {PLAN_TYPE_OPTIONS.map((option) => (
@@ -132,7 +132,7 @@ export function EditPlanModal({
           <select
             id={gramWeightId}
             name="gramWeight"
-            defaultValue={plan.gramWeight}
+            defaultValue={state.values?.gramWeight ?? plan.gramWeight}
             className={modalStyles.select}
           >
             {GRAM_WEIGHT_OPTIONS.map((gram) => (
@@ -155,7 +155,7 @@ export function EditPlanModal({
           <select
             id={beanQuantityId}
             name="beanQuantity"
-            defaultValue={plan.beanQuantity}
+            defaultValue={state.values?.beanQuantity ?? plan.beanQuantity}
             className={modalStyles.select}
           >
             {BEAN_QUANTITY_OPTIONS.map((quantity) => (
@@ -180,7 +180,7 @@ export function EditPlanModal({
             name="price"
             type="number"
             min="0"
-            defaultValue={plan.price}
+            defaultValue={state.values?.price ?? plan.price}
             className={modalStyles.input}
           />
           {state.fieldErrors?.price?.map((msg) => (
@@ -194,7 +194,7 @@ export function EditPlanModal({
           id={isRecommendedId}
           name="isRecommended"
           label="おすすめバッジ"
-          defaultChecked={plan.isRecommended}
+          defaultChecked={state.values?.isRecommended ?? plan.isRecommended}
         />
 
         <div className={modalStyles.actions}>

--- a/admin-frontend/src/app/(admin)/plans/[id]/_components/PlanActions.tsx
+++ b/admin-frontend/src/app/(admin)/plans/[id]/_components/PlanActions.tsx
@@ -7,17 +7,24 @@ import { EditPlanModal } from "./EditPlanModal";
 
 export function PlanActions({ plan }: { plan: PlanDetail }) {
   const [isEditOpen, setIsEditOpen] = useState(false);
+  const [editKey, setEditKey] = useState(0);
+
+  const handleEditOpen = () => {
+    setEditKey((prev) => prev + 1);
+    setIsEditOpen(true);
+  };
 
   return (
     <div className={actionStyles.actions}>
       <button
         type="button"
-        onClick={() => setIsEditOpen(true)}
+        onClick={handleEditOpen}
         className={actionStyles.editButton}
       >
         編集
       </button>
       <EditPlanModal
+        key={`edit-${editKey}`}
         plan={plan}
         isOpen={isEditOpen}
         onClose={() => setIsEditOpen(false)}

--- a/admin-frontend/src/app/(admin)/plans/[id]/_components/PlanActions.tsx
+++ b/admin-frontend/src/app/(admin)/plans/[id]/_components/PlanActions.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useState } from "react";
+import type { PlanDetail } from "@/api/plans";
+import actionStyles from "@/components/actions.module.css";
+import { EditPlanModal } from "./EditPlanModal";
+
+export function PlanActions({ plan }: { plan: PlanDetail }) {
+  const [isEditOpen, setIsEditOpen] = useState(false);
+
+  return (
+    <div className={actionStyles.actions}>
+      <button
+        type="button"
+        onClick={() => setIsEditOpen(true)}
+        className={actionStyles.editButton}
+      >
+        編集
+      </button>
+      <EditPlanModal
+        plan={plan}
+        isOpen={isEditOpen}
+        onClose={() => setIsEditOpen(false)}
+      />
+    </div>
+  );
+}

--- a/admin-frontend/src/app/(admin)/plans/[id]/_components/PlanDetail.module.css
+++ b/admin-frontend/src/app/(admin)/plans/[id]/_components/PlanDetail.module.css
@@ -1,0 +1,74 @@
+.container {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1.5rem;
+}
+
+.backLink {
+  color: var(--color-brand);
+  text-decoration: none;
+  font-size: 0.875rem;
+}
+
+.card {
+  background: #fff;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 2rem;
+}
+
+.titleRow {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin: 0 0 1.5rem;
+}
+
+.title {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--color-text-primary);
+  margin: 0;
+}
+
+.badge {
+  display: inline-block;
+  padding: 0.125rem 0.625rem;
+  background: var(--color-brand);
+  color: #fff;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.fields {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin: 0;
+}
+
+.field {
+  display: grid;
+  grid-template-columns: 200px 1fr;
+  gap: 1rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.label {
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  font-size: 0.875rem;
+}
+
+.value {
+  color: var(--color-text-primary);
+  word-break: break-word;
+}

--- a/admin-frontend/src/app/(admin)/plans/[id]/_components/PlanDetail.tsx
+++ b/admin-frontend/src/app/(admin)/plans/[id]/_components/PlanDetail.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import Link from "next/link";
+import type { PlanDetail as PlanDetailType } from "@/api/plans";
+import { PLAN_TYPE_LABELS } from "../../_lib/planLabels";
+import { PlanActions } from "./PlanActions";
+import detailStyles from "./PlanDetail.module.css";
+
+export function PlanDetail({ plan }: { plan: PlanDetailType }) {
+  return (
+    <div className={detailStyles.container}>
+      <div className={detailStyles.header}>
+        <Link href="/plans" className={detailStyles.backLink}>
+          ← 一覧に戻る
+        </Link>
+        <PlanActions plan={plan} />
+      </div>
+
+      <div className={detailStyles.card}>
+        <div className={detailStyles.titleRow}>
+          <h1 className={detailStyles.title}>{plan.label}</h1>
+          {plan.isRecommended && (
+            <span className={detailStyles.badge}>おすすめ</span>
+          )}
+        </div>
+
+        <dl className={detailStyles.fields}>
+          <div className={detailStyles.field}>
+            <dt className={detailStyles.label}>ShopifyプランID</dt>
+            <dd className={detailStyles.value}>{plan.shopifyPlanId}</dd>
+          </div>
+          <div className={detailStyles.field}>
+            <dt className={detailStyles.label}>プラン表示名</dt>
+            <dd className={detailStyles.value}>{plan.label}</dd>
+          </div>
+          <div className={detailStyles.field}>
+            <dt className={detailStyles.label}>プラン種別</dt>
+            <dd className={detailStyles.value}>
+              {PLAN_TYPE_LABELS[plan.type] ?? plan.type}
+            </dd>
+          </div>
+          <div className={detailStyles.field}>
+            <dt className={detailStyles.label}>1種あたりのグラム数</dt>
+            <dd className={detailStyles.value}>{plan.gramWeight}g</dd>
+          </div>
+          <div className={detailStyles.field}>
+            <dt className={detailStyles.label}>豆の種類数</dt>
+            <dd className={detailStyles.value}>{plan.beanQuantity}種</dd>
+          </div>
+          <div className={detailStyles.field}>
+            <dt className={detailStyles.label}>価格</dt>
+            <dd className={detailStyles.value}>
+              ¥{plan.price.toLocaleString()}
+            </dd>
+          </div>
+          <div className={detailStyles.field}>
+            <dt className={detailStyles.label}>おすすめバッジ</dt>
+            <dd className={detailStyles.value}>
+              {plan.isRecommended ? "あり" : "なし"}
+            </dd>
+          </div>
+        </dl>
+      </div>
+    </div>
+  );
+}

--- a/admin-frontend/src/app/(admin)/plans/[id]/_components/editPlanAction.ts
+++ b/admin-frontend/src/app/(admin)/plans/[id]/_components/editPlanAction.ts
@@ -22,7 +22,7 @@ export async function editPlanAction(
     beanQuantity: formData.get("beanQuantity") as string,
     price: formData.get("price") as string,
     type: formData.get("type") as string,
-    isRecommended: formData.get("isRecommended") === "on",
+    isRecommended: isChecked(formData, "isRecommended"),
   };
 
   const parsed = planFormSchema.safeParse(rawData);

--- a/admin-frontend/src/app/(admin)/plans/[id]/_components/editPlanAction.ts
+++ b/admin-frontend/src/app/(admin)/plans/[id]/_components/editPlanAction.ts
@@ -5,10 +5,21 @@ import { createAuthenticatedApiClient } from "@/api/client";
 import { planFormSchema } from "@/app/(admin)/plans/_lib/planFormSchema";
 import { isChecked } from "@/lib/formData";
 
+export type EditPlanValues = {
+  shopifyPlanId?: string;
+  label?: string;
+  gramWeight?: string;
+  beanQuantity?: string;
+  price?: string;
+  type?: string;
+  isRecommended?: boolean;
+};
+
 export type EditPlanState = {
   success?: boolean;
   error?: string;
   fieldErrors?: Record<string, string[]>;
+  values?: EditPlanValues;
 };
 
 export async function editPlanAction(
@@ -30,6 +41,7 @@ export async function editPlanAction(
   if (!parsed.success) {
     return {
       fieldErrors: parsed.error.flatten().fieldErrors,
+      values: rawData,
     };
   }
 
@@ -43,7 +55,7 @@ export async function editPlanAction(
   });
 
   if (error) {
-    return { error: "プランの更新に失敗しました" };
+    return { error: "プランの更新に失敗しました", values: rawData };
   }
 
   revalidatePath(`/plans/${id}`);

--- a/admin-frontend/src/app/(admin)/plans/[id]/_components/editPlanAction.ts
+++ b/admin-frontend/src/app/(admin)/plans/[id]/_components/editPlanAction.ts
@@ -3,6 +3,7 @@
 import { revalidatePath } from "next/cache";
 import { createAuthenticatedApiClient } from "@/api/client";
 import { planFormSchema } from "@/app/(admin)/plans/_lib/planFormSchema";
+import { isChecked } from "@/lib/formData";
 
 export type EditPlanState = {
   success?: boolean;

--- a/admin-frontend/src/app/(admin)/plans/[id]/_components/editPlanAction.ts
+++ b/admin-frontend/src/app/(admin)/plans/[id]/_components/editPlanAction.ts
@@ -1,0 +1,51 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { createAuthenticatedApiClient } from "@/api/client";
+import { planFormSchema } from "@/app/(admin)/plans/_lib/planFormSchema";
+
+export type EditPlanState = {
+  success?: boolean;
+  error?: string;
+  fieldErrors?: Record<string, string[]>;
+};
+
+export async function editPlanAction(
+  _prevState: EditPlanState,
+  formData: FormData,
+): Promise<EditPlanState> {
+  const id = formData.get("id") as string;
+  const rawData = {
+    shopifyPlanId: formData.get("shopifyPlanId") as string,
+    label: formData.get("label") as string,
+    gramWeight: formData.get("gramWeight") as string,
+    beanQuantity: formData.get("beanQuantity") as string,
+    price: formData.get("price") as string,
+    type: formData.get("type") as string,
+    isRecommended: formData.get("isRecommended") === "on",
+  };
+
+  const parsed = planFormSchema.safeParse(rawData);
+  if (!parsed.success) {
+    return {
+      fieldErrors: parsed.error.flatten().fieldErrors,
+    };
+  }
+
+  const client = await createAuthenticatedApiClient();
+  const { error } = await client.PUT("/api/admin/plans/{id}", {
+    params: { path: { id } },
+    body: {
+      ...parsed.data,
+      type: parsed.data.type as "SUBSCRIPTION" | "SINGLE",
+    },
+  });
+
+  if (error) {
+    return { error: "プランの更新に失敗しました" };
+  }
+
+  revalidatePath(`/plans/${id}`);
+  revalidatePath(`/plans`);
+  return { success: true };
+}

--- a/admin-frontend/src/app/(admin)/plans/[id]/page.tsx
+++ b/admin-frontend/src/app/(admin)/plans/[id]/page.tsx
@@ -1,0 +1,18 @@
+import { notFound } from "next/navigation";
+import { fetchPlan } from "@/api/plans";
+import { PlanDetail } from "./_components/PlanDetail";
+
+export default async function PlanDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const plan = await fetchPlan(id);
+
+  if (!plan) {
+    notFound();
+  }
+
+  return <PlanDetail plan={plan} />;
+}

--- a/admin-frontend/src/app/(admin)/plans/_components/PlanListTable.tsx
+++ b/admin-frontend/src/app/(admin)/plans/_components/PlanListTable.tsx
@@ -49,34 +49,39 @@ export function PlanListTable({
         </button>
       </form>
 
-      <table className={listStyles.table}>
-        <thead>
-          <tr>
-            <th>プラン表示名</th>
-            <th>種別</th>
-            <th>グラム数</th>
-            <th>種類数</th>
-            <th>価格</th>
-            <th>おすすめ</th>
-          </tr>
-        </thead>
-        <tbody>
-          {plans.map((plan) => (
-            <tr key={plan.id} className={listStyles.row}>
-              <td>
-                <Link href={`/plans/${plan.id}`} className={listStyles.link}>
-                  {plan.label}
-                </Link>
-              </td>
-              <td>{PLAN_TYPE_LABELS[plan.type] ?? plan.type}</td>
-              <td>{plan.gramWeight}g</td>
-              <td>{plan.beanQuantity}種</td>
-              <td>¥{plan.price.toLocaleString()}</td>
-              <td>{plan.isRecommended ? "★" : "-"}</td>
+      <div className={listStyles.tableWrapper}>
+        <table className={listStyles.table}>
+          <thead>
+            <tr>
+              <th>プラン表示名</th>
+              <th>種別</th>
+              <th>グラム数</th>
+              <th>種類数</th>
+              <th>価格</th>
+              <th>おすすめ</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {plans.map((plan) => (
+              <tr key={plan.id} className={listStyles.clickableRow}>
+                <td>
+                  <Link
+                    href={`/plans/${plan.id}`}
+                    className={listStyles.rowLink}
+                  >
+                    {plan.label}
+                  </Link>
+                </td>
+                <td>{PLAN_TYPE_LABELS[plan.type] ?? plan.type}</td>
+                <td>{plan.gramWeight}g</td>
+                <td>{plan.beanQuantity}種</td>
+                <td>¥{plan.price.toLocaleString()}</td>
+                <td>{plan.isRecommended ? "★" : "-"}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 }

--- a/admin-frontend/src/app/(admin)/plans/_components/PlanListTable.tsx
+++ b/admin-frontend/src/app/(admin)/plans/_components/PlanListTable.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useState } from "react";
+import type { PlanListItem } from "@/api/plans";
+import listStyles from "@/components/list-page.module.css";
+import { PLAN_TYPE_LABELS } from "../_lib/planLabels";
+
+export function PlanListTable({
+  plans,
+  total,
+}: {
+  plans: PlanListItem[];
+  total: number;
+}) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [keyword, setKeyword] = useState(searchParams.get("keyword") ?? "");
+
+  const handleSearch = (e: React.FormEvent) => {
+    e.preventDefault();
+    const params = new URLSearchParams();
+    if (keyword) {
+      params.set("keyword", keyword);
+    }
+    router.push(`/plans?${params.toString()}`);
+  };
+
+  return (
+    <div className={listStyles.container}>
+      <div className={listStyles.header}>
+        <div className={listStyles.titleGroup}>
+          <h1 className={listStyles.title}>プラン管理</h1>
+          <p className={listStyles.count}>{total}件のプラン</p>
+        </div>
+      </div>
+
+      <form onSubmit={handleSearch} className={listStyles.searchForm}>
+        <input
+          type="text"
+          value={keyword}
+          onChange={(e) => setKeyword(e.target.value)}
+          placeholder="プラン表示名で検索"
+          className={listStyles.searchInput}
+        />
+        <button type="submit" className={listStyles.searchButton}>
+          検索
+        </button>
+      </form>
+
+      <table className={listStyles.table}>
+        <thead>
+          <tr>
+            <th>プラン表示名</th>
+            <th>種別</th>
+            <th>グラム数</th>
+            <th>種類数</th>
+            <th>価格</th>
+            <th>おすすめ</th>
+          </tr>
+        </thead>
+        <tbody>
+          {plans.map((plan) => (
+            <tr key={plan.id} className={listStyles.row}>
+              <td>
+                <Link href={`/plans/${plan.id}`} className={listStyles.link}>
+                  {plan.label}
+                </Link>
+              </td>
+              <td>{PLAN_TYPE_LABELS[plan.type] ?? plan.type}</td>
+              <td>{plan.gramWeight}g</td>
+              <td>{plan.beanQuantity}種</td>
+              <td>¥{plan.price.toLocaleString()}</td>
+              <td>{plan.isRecommended ? "★" : "-"}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/admin-frontend/src/app/(admin)/plans/_lib/planFormSchema.ts
+++ b/admin-frontend/src/app/(admin)/plans/_lib/planFormSchema.ts
@@ -1,0 +1,33 @@
+import { z } from "zod";
+import { BEAN_QUANTITY_OPTIONS, GRAM_WEIGHT_OPTIONS } from "./planLabels";
+
+export const planFormSchema = z.object({
+  shopifyPlanId: z
+    .string()
+    .min(1, "ShopifyプランIDは必須です")
+    .max(255, "ShopifyプランIDは255文字以内で入力してください"),
+  label: z
+    .string()
+    .min(1, "プラン表示名は必須です")
+    .max(50, "プラン表示名は50文字以内で入力してください"),
+  gramWeight: z.coerce
+    .number()
+    .refine(
+      (v) => (GRAM_WEIGHT_OPTIONS as readonly number[]).includes(v),
+      "30 / 60 / 90 のいずれかを選択してください",
+    ),
+  beanQuantity: z.coerce
+    .number()
+    .refine(
+      (v) => (BEAN_QUANTITY_OPTIONS as readonly number[]).includes(v),
+      "3 / 4 / 5 のいずれかを選択してください",
+    ),
+  price: z.coerce
+    .number()
+    .int("価格は整数で入力してください")
+    .min(0, "価格は0以上で入力してください"),
+  type: z.enum(["SUBSCRIPTION", "SINGLE"], {
+    message: "プラン種別を選択してください",
+  }),
+  isRecommended: z.boolean(),
+});

--- a/admin-frontend/src/app/(admin)/plans/_lib/planLabels.ts
+++ b/admin-frontend/src/app/(admin)/plans/_lib/planLabels.ts
@@ -1,0 +1,12 @@
+export const PLAN_TYPE_OPTIONS = [
+  { value: "SUBSCRIPTION", label: "定期便" },
+  { value: "SINGLE", label: "単品" },
+] as const;
+
+export const PLAN_TYPE_LABELS: Record<string, string> = Object.fromEntries(
+  PLAN_TYPE_OPTIONS.map((option) => [option.value, option.label]),
+);
+
+export const GRAM_WEIGHT_OPTIONS = [30, 60, 90] as const;
+
+export const BEAN_QUANTITY_OPTIONS = [3, 4, 5] as const;

--- a/admin-frontend/src/app/(admin)/plans/page.tsx
+++ b/admin-frontend/src/app/(admin)/plans/page.tsx
@@ -43,6 +43,7 @@ async function PlanListContent({
         currentPage={page}
         totalPages={totalPages}
         basePath="/plans"
+        query={{ keyword }}
       />
     </>
   );

--- a/admin-frontend/src/app/(admin)/plans/page.tsx
+++ b/admin-frontend/src/app/(admin)/plans/page.tsx
@@ -1,0 +1,49 @@
+import { Suspense } from "react";
+import { fetchPlans } from "@/api/plans";
+import { Pagination } from "@/components/Pagination";
+import { PlanListTable } from "./_components/PlanListTable";
+
+type SearchParams = {
+  page?: string;
+  keyword?: string;
+};
+
+export default async function PlansPage({
+  searchParams,
+}: {
+  searchParams: Promise<SearchParams>;
+}) {
+  const params = await searchParams;
+  const page = Number.parseInt(params.page ?? "0", 10);
+  const keyword = params.keyword;
+
+  return (
+    <div>
+      <Suspense fallback={<div>読み込み中...</div>}>
+        <PlanListContent page={page} keyword={keyword} />
+      </Suspense>
+    </div>
+  );
+}
+
+async function PlanListContent({
+  page,
+  keyword,
+}: {
+  page: number;
+  keyword?: string;
+}) {
+  const data = await fetchPlans(page, 20, keyword);
+  const totalPages = Math.ceil(data.totalCount / data.size);
+
+  return (
+    <>
+      <PlanListTable plans={data.items} total={data.totalCount} />
+      <Pagination
+        currentPage={page}
+        totalPages={totalPages}
+        basePath="/plans"
+      />
+    </>
+  );
+}

--- a/admin-frontend/src/app/(admin)/shops/[id]/_components/EditShopModal.tsx
+++ b/admin-frontend/src/app/(admin)/shops/[id]/_components/EditShopModal.tsx
@@ -11,6 +11,7 @@ import type { ShopDetail } from "@/api/shops";
 import { PREFECTURE_OPTIONS } from "@/app/(admin)/shops/_lib/prefecture";
 import { ImageUploadField } from "@/components/ImageUploadField";
 import modalStyles from "@/components/modal.module.css";
+import { ToggleField } from "@/components/ToggleField";
 import { type EditShopState, editShopAction } from "./editShopAction";
 
 const initialState: EditShopState = {};
@@ -206,29 +207,16 @@ export function EditShopModal({
           ))}
         </div>
 
-        <div className={modalStyles.toggleField}>
-          <label htmlFor={publishStatusId} className={modalStyles.label}>
-            公開状態
-            <span className={modalStyles.required}>*</span>
-          </label>
-          <label className={modalStyles.toggleSwitch}>
-            <input
-              id={publishStatusId}
-              name="publishStatus"
-              type="checkbox"
-              defaultChecked={
-                (state.values?.publishStatus ?? shop.publishStatus) ===
-                "PUBLISHED"
-              }
-            />
-            <span className={modalStyles.toggleSlider} />
-          </label>
-          {state.fieldErrors?.publishStatus?.map((msg) => (
-            <span key={msg} className={modalStyles.fieldError}>
-              {msg}
-            </span>
-          ))}
-        </div>
+        <ToggleField
+          id={publishStatusId}
+          name="publishStatus"
+          label="公開状態"
+          required
+          defaultChecked={
+            (state.values?.publishStatus ?? shop.publishStatus) === "PUBLISHED"
+          }
+          errors={state.fieldErrors?.publishStatus}
+        />
 
         <ImageUploadField
           imageTypes={[{ value: "MAIN", label: "メイン" }]}

--- a/admin-frontend/src/app/(admin)/shops/[id]/_components/EditShopModal.tsx
+++ b/admin-frontend/src/app/(admin)/shops/[id]/_components/EditShopModal.tsx
@@ -11,7 +11,6 @@ import type { ShopDetail } from "@/api/shops";
 import { PREFECTURE_OPTIONS } from "@/app/(admin)/shops/_lib/prefecture";
 import { ImageUploadField } from "@/components/ImageUploadField";
 import modalStyles from "@/components/modal.module.css";
-import { PUBLISH_STATUS_OPTIONS } from "@/components/publishStatus";
 import { type EditShopState, editShopAction } from "./editShopAction";
 
 const initialState: EditShopState = {};
@@ -207,23 +206,23 @@ export function EditShopModal({
           ))}
         </div>
 
-        <div className={modalStyles.field}>
+        <div className={modalStyles.toggleField}>
           <label htmlFor={publishStatusId} className={modalStyles.label}>
             公開状態
             <span className={modalStyles.required}>*</span>
           </label>
-          <select
-            id={publishStatusId}
-            name="publishStatus"
-            defaultValue={state.values?.publishStatus ?? shop.publishStatus}
-            className={modalStyles.input}
-          >
-            {PUBLISH_STATUS_OPTIONS.map((option) => (
-              <option key={option.value} value={option.value}>
-                {option.label}
-              </option>
-            ))}
-          </select>
+          <label className={modalStyles.toggleSwitch}>
+            <input
+              id={publishStatusId}
+              name="publishStatus"
+              type="checkbox"
+              defaultChecked={
+                (state.values?.publishStatus ?? shop.publishStatus) ===
+                "PUBLISHED"
+              }
+            />
+            <span className={modalStyles.toggleSlider} />
+          </label>
           {state.fieldErrors?.publishStatus?.map((msg) => (
             <span key={msg} className={modalStyles.fieldError}>
               {msg}

--- a/admin-frontend/src/app/(admin)/shops/[id]/_components/editShopAction.ts
+++ b/admin-frontend/src/app/(admin)/shops/[id]/_components/editShopAction.ts
@@ -7,6 +7,7 @@ import {
   type ShopFormState,
   shopFieldsSchema,
 } from "@/app/(admin)/shops/_lib/shopFormSchema";
+import { isChecked } from "@/lib/formData";
 
 const editShopSchema = shopFieldsSchema.extend({
   id: z.string(),

--- a/admin-frontend/src/app/(admin)/shops/[id]/_components/editShopAction.ts
+++ b/admin-frontend/src/app/(admin)/shops/[id]/_components/editShopAction.ts
@@ -25,7 +25,8 @@ export async function editShopAction(
     particular: (formData.get("particular") as string) ?? "",
     shopUrl: (formData.get("shopUrl") as string) ?? "",
     prefecture: (formData.get("prefecture") as string) ?? "",
-    publishStatus: (formData.get("publishStatus") as string) ?? "",
+    publishStatus:
+      formData.get("publishStatus") === "on" ? "PUBLISHED" : "DRAFT",
   };
 
   const result = editShopSchema.safeParse({

--- a/admin-frontend/src/app/(admin)/shops/[id]/_components/editShopAction.ts
+++ b/admin-frontend/src/app/(admin)/shops/[id]/_components/editShopAction.ts
@@ -25,8 +25,7 @@ export async function editShopAction(
     particular: (formData.get("particular") as string) ?? "",
     shopUrl: (formData.get("shopUrl") as string) ?? "",
     prefecture: (formData.get("prefecture") as string) ?? "",
-    publishStatus:
-      formData.get("publishStatus") === "on" ? "PUBLISHED" : "DRAFT",
+    publishStatus: isChecked(formData, "publishStatus") ? "PUBLISHED" : "DRAFT",
   };
 
   const result = editShopSchema.safeParse({

--- a/admin-frontend/src/app/(admin)/shops/_components/CreateShopModal.tsx
+++ b/admin-frontend/src/app/(admin)/shops/_components/CreateShopModal.tsx
@@ -10,6 +10,7 @@ import {
 import { PREFECTURE_OPTIONS } from "@/app/(admin)/shops/_lib/prefecture";
 import { ImageUploadField } from "@/components/ImageUploadField";
 import styles from "@/components/modal.module.css";
+import { ToggleField } from "@/components/ToggleField";
 import { type CreateShopState, createShopAction } from "./createShopAction";
 
 const initialState: CreateShopState = {};
@@ -204,28 +205,16 @@ export function CreateShopModal({
           ))}
         </div>
 
-        <div className={styles.toggleField}>
-          <label htmlFor={publishStatusId} className={styles.label}>
-            公開状態
-            <span className={styles.required}>*</span>
-          </label>
-          <label className={styles.toggleSwitch}>
-            <input
-              id={publishStatusId}
-              name="publishStatus"
-              type="checkbox"
-              defaultChecked={
-                (state.values?.publishStatus ?? "DRAFT") === "PUBLISHED"
-              }
-            />
-            <span className={styles.toggleSlider} />
-          </label>
-          {state.fieldErrors?.publishStatus?.map((msg) => (
-            <span key={msg} className={styles.fieldError}>
-              {msg}
-            </span>
-          ))}
-        </div>
+        <ToggleField
+          id={publishStatusId}
+          name="publishStatus"
+          label="公開状態"
+          required
+          defaultChecked={
+            (state.values?.publishStatus ?? "DRAFT") === "PUBLISHED"
+          }
+          errors={state.fieldErrors?.publishStatus}
+        />
 
         <ImageUploadField imageTypes={[{ value: "MAIN", label: "メイン" }]} />
         <ImageUploadField

--- a/admin-frontend/src/app/(admin)/shops/_components/CreateShopModal.tsx
+++ b/admin-frontend/src/app/(admin)/shops/_components/CreateShopModal.tsx
@@ -10,7 +10,6 @@ import {
 import { PREFECTURE_OPTIONS } from "@/app/(admin)/shops/_lib/prefecture";
 import { ImageUploadField } from "@/components/ImageUploadField";
 import styles from "@/components/modal.module.css";
-import { PUBLISH_STATUS_OPTIONS } from "@/components/publishStatus";
 import { type CreateShopState, createShopAction } from "./createShopAction";
 
 const initialState: CreateShopState = {};
@@ -205,23 +204,22 @@ export function CreateShopModal({
           ))}
         </div>
 
-        <div className={styles.field}>
+        <div className={styles.toggleField}>
           <label htmlFor={publishStatusId} className={styles.label}>
             公開状態
             <span className={styles.required}>*</span>
           </label>
-          <select
-            id={publishStatusId}
-            name="publishStatus"
-            defaultValue={state.values?.publishStatus ?? "DRAFT"}
-            className={styles.input}
-          >
-            {PUBLISH_STATUS_OPTIONS.map((option) => (
-              <option key={option.value} value={option.value}>
-                {option.label}
-              </option>
-            ))}
-          </select>
+          <label className={styles.toggleSwitch}>
+            <input
+              id={publishStatusId}
+              name="publishStatus"
+              type="checkbox"
+              defaultChecked={
+                (state.values?.publishStatus ?? "DRAFT") === "PUBLISHED"
+              }
+            />
+            <span className={styles.toggleSlider} />
+          </label>
           {state.fieldErrors?.publishStatus?.map((msg) => (
             <span key={msg} className={styles.fieldError}>
               {msg}

--- a/admin-frontend/src/app/(admin)/shops/_components/ShopListTable.tsx
+++ b/admin-frontend/src/app/(admin)/shops/_components/ShopListTable.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import type { PagedResponse, ShopListItem } from "@/api/shops";
+import type { ShopListResponse } from "@/api/shops";
 import styles from "@/components/list-page.module.css";
 import { Pagination } from "@/components/Pagination";
 import { PublishStatusBadge } from "@/components/PublishStatusBadge";
@@ -9,7 +9,7 @@ export function ShopListTable({
   shops,
   currentPage,
 }: {
-  shops: PagedResponse<ShopListItem>;
+  shops: ShopListResponse;
   currentPage: number;
 }) {
   const totalPages = Math.ceil(shops.totalCount / shops.size);

--- a/admin-frontend/src/app/(admin)/shops/_components/createShopAction.ts
+++ b/admin-frontend/src/app/(admin)/shops/_components/createShopAction.ts
@@ -20,7 +20,8 @@ export async function createShopAction(
     particular: (formData.get("particular") as string) ?? "",
     shopUrl: (formData.get("shopUrl") as string) ?? "",
     prefecture: (formData.get("prefecture") as string) ?? "",
-    publishStatus: (formData.get("publishStatus") as string) ?? "",
+    publishStatus:
+      formData.get("publishStatus") === "on" ? "PUBLISHED" : "DRAFT",
   };
 
   const result = shopFieldsSchema.safeParse(values);

--- a/admin-frontend/src/app/(admin)/shops/_components/createShopAction.ts
+++ b/admin-frontend/src/app/(admin)/shops/_components/createShopAction.ts
@@ -6,6 +6,7 @@ import {
   type ShopFormState,
   shopFieldsSchema,
 } from "@/app/(admin)/shops/_lib/shopFormSchema";
+import { isChecked } from "@/lib/formData";
 
 export type CreateShopState = ShopFormState;
 

--- a/admin-frontend/src/app/(admin)/shops/_components/createShopAction.ts
+++ b/admin-frontend/src/app/(admin)/shops/_components/createShopAction.ts
@@ -20,8 +20,7 @@ export async function createShopAction(
     particular: (formData.get("particular") as string) ?? "",
     shopUrl: (formData.get("shopUrl") as string) ?? "",
     prefecture: (formData.get("prefecture") as string) ?? "",
-    publishStatus:
-      formData.get("publishStatus") === "on" ? "PUBLISHED" : "DRAFT",
+    publishStatus: isChecked(formData, "publishStatus") ? "PUBLISHED" : "DRAFT",
   };
 
   const result = shopFieldsSchema.safeParse(values);

--- a/admin-frontend/src/components/Pagination.tsx
+++ b/admin-frontend/src/components/Pagination.tsx
@@ -22,14 +22,12 @@ export function Pagination({
   );
   const end = Math.min(totalPages, start + maxVisible);
 
-  const hrefForPage = (page: number) => {
-    const params = new URLSearchParams();
-    params.set("page", String(page));
-    for (const [key, value] of Object.entries(query ?? {})) {
-      if (value) params.set(key, value);
-    }
-    return `${basePath}?${params.toString()}`;
-  };
+  // 全ページリンクで共通のクエリ部分は一度だけ組み立てる。
+  const extraQuery = Object.entries(query ?? {})
+    .filter(([, value]) => value)
+    .map(([key, value]) => `&${key}=${encodeURIComponent(value as string)}`)
+    .join("");
+  const hrefForPage = (page: number) => `${basePath}?page=${page}${extraQuery}`;
 
   return (
     <div className={styles.pagination}>

--- a/admin-frontend/src/components/Pagination.tsx
+++ b/admin-frontend/src/components/Pagination.tsx
@@ -5,10 +5,12 @@ export function Pagination({
   currentPage,
   totalPages,
   basePath,
+  query,
 }: {
   currentPage: number;
   totalPages: number;
   basePath: string;
+  query?: Record<string, string | undefined>;
 }) {
   if (totalPages <= 1) return null;
 
@@ -20,13 +22,19 @@ export function Pagination({
   );
   const end = Math.min(totalPages, start + maxVisible);
 
+  const hrefForPage = (page: number) => {
+    const params = new URLSearchParams();
+    params.set("page", String(page));
+    for (const [key, value] of Object.entries(query ?? {})) {
+      if (value) params.set(key, value);
+    }
+    return `${basePath}?${params.toString()}`;
+  };
+
   return (
     <div className={styles.pagination}>
       {currentPage > 0 && (
-        <Link
-          href={`${basePath}?page=${currentPage - 1}`}
-          className={styles.pageLink}
-        >
+        <Link href={hrefForPage(currentPage - 1)} className={styles.pageLink}>
           &lt; 前へ
         </Link>
       )}
@@ -35,7 +43,7 @@ export function Pagination({
         return (
           <Link
             key={`page-${page}`}
-            href={`${basePath}?page=${page}`}
+            href={hrefForPage(page)}
             className={
               page === currentPage
                 ? `${styles.pageLink} ${styles.pageLinkActive}`
@@ -47,10 +55,7 @@ export function Pagination({
         );
       })}
       {currentPage < totalPages - 1 && (
-        <Link
-          href={`${basePath}?page=${currentPage + 1}`}
-          className={styles.pageLink}
-        >
+        <Link href={hrefForPage(currentPage + 1)} className={styles.pageLink}>
           次へ &gt;
         </Link>
       )}

--- a/admin-frontend/src/components/ToggleField.tsx
+++ b/admin-frontend/src/components/ToggleField.tsx
@@ -1,0 +1,46 @@
+import modalStyles from "@/components/modal.module.css";
+
+/**
+ * トグルスイッチ形式の真偽値入力フィールド。
+ *
+ * 内部はネイティブの checkbox で、送信値は checked 時に "on"。
+ * server action 側で必要なドメイン値へ変換する。
+ */
+export function ToggleField({
+  id,
+  name,
+  label,
+  defaultChecked,
+  required = false,
+  errors,
+}: {
+  id: string;
+  name: string;
+  label: string;
+  defaultChecked: boolean;
+  required?: boolean;
+  errors?: string[];
+}) {
+  return (
+    <div className={modalStyles.toggleField}>
+      <label htmlFor={id} className={modalStyles.label}>
+        {label}
+        {required && <span className={modalStyles.required}>*</span>}
+      </label>
+      <label className={modalStyles.toggleSwitch}>
+        <input
+          id={id}
+          name={name}
+          type="checkbox"
+          defaultChecked={defaultChecked}
+        />
+        <span className={modalStyles.toggleSlider} />
+      </label>
+      {errors?.map((msg) => (
+        <span key={msg} className={modalStyles.fieldError}>
+          {msg}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/admin-frontend/src/components/list-page.module.css
+++ b/admin-frontend/src/components/list-page.module.css
@@ -49,6 +49,47 @@
   background: var(--color-brand-hover);
 }
 
+/* Search */
+.searchForm {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.searchInput {
+  flex: 1;
+  max-width: 320px;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  font-size: 0.875rem;
+  color: var(--color-text-primary);
+  background: #ffffff;
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.searchInput:focus {
+  border-color: var(--color-brand);
+  box-shadow: 0 0 0 3px rgba(139, 105, 20, 0.1);
+}
+
+.searchButton {
+  padding: 0.5rem 1.25rem;
+  background: var(--color-brand);
+  color: #ffffff;
+  border: none;
+  border-radius: 8px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.searchButton:hover {
+  background: var(--color-brand-hover);
+}
+
 /* Table */
 .tableWrapper {
   flex: 1;

--- a/admin-frontend/src/components/modal.module.css
+++ b/admin-frontend/src/components/modal.module.css
@@ -147,6 +147,63 @@
   margin-top: 0.5rem;
 }
 
+/* Toggle switch */
+.toggleField {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.toggleSwitch {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+}
+
+.toggleSwitch input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+}
+
+.toggleSlider {
+  position: relative;
+  display: inline-block;
+  width: 2.75rem;
+  height: 1.5rem;
+  background: var(--color-border);
+  border-radius: 999px;
+  transition: background 0.15s;
+}
+
+.toggleSlider::before {
+  content: "";
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 1.25rem;
+  height: 1.25rem;
+  background: #ffffff;
+  border-radius: 50%;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+  transition: transform 0.15s;
+}
+
+.toggleSwitch input:checked + .toggleSlider {
+  background: var(--color-brand);
+}
+
+.toggleSwitch input:checked + .toggleSlider::before {
+  transform: translateX(1.25rem);
+}
+
+.toggleSwitch input:focus-visible + .toggleSlider {
+  box-shadow: 0 0 0 3px rgba(139, 105, 20, 0.1);
+}
+
 .cancelButton {
   padding: 0.625rem 1.25rem;
   border: 1px solid var(--color-border);

--- a/admin-frontend/src/lib/formData.ts
+++ b/admin-frontend/src/lib/formData.ts
@@ -1,0 +1,9 @@
+/**
+ * チェックボックス（トグル含む）の送信値を boolean に変換する。
+ *
+ * HTMLのチェックボックスは ON のとき "on" を送信し、OFF のときキー自体を
+ * 送信しない。この仕様依存を各 server action に散らさず一箇所に集約する。
+ */
+export function isChecked(formData: FormData, name: string): boolean {
+  return formData.get(name) === "on";
+}

--- a/admin-frontend/src/lib/navigation.ts
+++ b/admin-frontend/src/lib/navigation.ts
@@ -2,6 +2,7 @@ export const NAV_ITEMS = [
   { label: "ダッシュボード", path: "/", icon: "📊" },
   { label: "店舗管理", path: "/shops", icon: "🏪" },
   { label: "コーヒー豆管理", path: "/coffee-beans", icon: "☕" },
+  { label: "プラン管理", path: "/plans", icon: "📦" },
 ] as const;
 
 export const PATH_LABELS: Record<string, string> = Object.fromEntries([

--- a/backend/admin-api/build.gradle.kts
+++ b/backend/admin-api/build.gradle.kts
@@ -38,6 +38,12 @@ openApi {
 	}
 }
 
+afterEvaluate {
+	tasks.named("forkedSpringBootRun") {
+		dependsOn(":common:jar")
+	}
+}
+
 dependencies {
 	implementation(project(":common"))
 

--- a/backend/admin-api/build.gradle.kts
+++ b/backend/admin-api/build.gradle.kts
@@ -38,12 +38,6 @@ openApi {
 	}
 }
 
-afterEvaluate {
-	tasks.named("forkedSpringBootRun") {
-		dependsOn(":common:jar")
-	}
-}
-
 dependencies {
 	implementation(project(":common"))
 

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/application/usecase/FindPlansUsecase.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/application/usecase/FindPlansUsecase.kt
@@ -1,0 +1,18 @@
+package com.mametosho.admin.application.usecase
+
+import com.mametosho.admin.application.result.PagedResult
+import com.mametosho.domain.model.plan.Plan
+import com.mametosho.domain.repository.PlanRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class FindPlansUsecase(
+    private val planRepository: PlanRepository,
+) {
+    @Transactional(readOnly = true)
+    open fun execute(page: Int, size: Int, keyword: String? = null): PagedResult<Plan> {
+        val (plans, totalCount) = planRepository.findAll(page, size, keyword)
+        return PagedResult(plans, totalCount, page, size)
+    }
+}

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/application/usecase/GetPlanUsecase.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/application/usecase/GetPlanUsecase.kt
@@ -1,0 +1,17 @@
+package com.mametosho.admin.application.usecase
+
+import com.mametosho.domain.model.plan.Plan
+import com.mametosho.domain.model.plan.PlanId
+import com.mametosho.domain.repository.PlanRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class GetPlanUsecase(
+    private val planRepository: PlanRepository,
+) {
+    @Transactional(readOnly = true)
+    open fun execute(id: String): Plan? {
+        return planRepository.findById(PlanId(id))
+    }
+}

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/application/usecase/UpdatePlanUsecase.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/application/usecase/UpdatePlanUsecase.kt
@@ -1,0 +1,31 @@
+package com.mametosho.admin.application.usecase
+
+import com.mametosho.admin.presentation.dto.request.UpdatePlanRequest
+import com.mametosho.domain.model.plan.Plan
+import com.mametosho.domain.model.plan.PlanId
+import com.mametosho.domain.model.plan.PlanType
+import com.mametosho.domain.repository.PlanRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class UpdatePlanUsecase(
+    private val planRepository: PlanRepository,
+) {
+    @Transactional
+    open fun execute(id: String, request: UpdatePlanRequest): Plan? {
+        val existingPlan = planRepository.findById(PlanId(id)) ?: return null
+
+        val updatedPlan = existingPlan.update(
+            shopifyPlanId = request.shopifyPlanId,
+            label = request.label,
+            gramWeight = request.gramWeight,
+            beanQuantity = request.beanQuantity,
+            price = request.price,
+            type = PlanType.valueOf(request.type),
+            isRecommended = request.isRecommended,
+        )
+        planRepository.save(updatedPlan)
+        return updatedPlan
+    }
+}

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/controller/CoffeeBeanController.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/controller/CoffeeBeanController.kt
@@ -8,10 +8,10 @@ import com.mametosho.admin.application.usecase.UpdateCoffeeBeanUsecase
 import com.mametosho.admin.presentation.dto.request.CreateCoffeeBeanRequest
 import com.mametosho.admin.presentation.dto.request.UpdateCoffeeBeanRequest
 import com.mametosho.admin.presentation.dto.response.CoffeeBeanDetailResponse
+import com.mametosho.admin.presentation.dto.response.CoffeeBeanListResponse
 import com.mametosho.admin.presentation.dto.response.CoffeeBeanSummaryResponse
 import com.mametosho.admin.presentation.dto.response.CoffeeBeanResponse
 import com.mametosho.admin.presentation.dto.response.ErrorResponse
-import com.mametosho.admin.presentation.dto.response.PagedResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.ExampleObject
@@ -56,6 +56,7 @@ class CoffeeBeanController(
                 description = "取得成功",
                 content = [
                     Content(
+                        schema = Schema(implementation = CoffeeBeanListResponse::class),
                         examples = [
                             ExampleObject(
                                 name = "success",
@@ -94,9 +95,9 @@ class CoffeeBeanController(
         @RequestParam(defaultValue = "0") page: Int,
         @Parameter(description = "1ページあたりの件数", example = "20")
         @RequestParam(defaultValue = "20") size: Int,
-    ): ResponseEntity<PagedResponse<CoffeeBeanSummaryResponse>> {
+    ): ResponseEntity<CoffeeBeanListResponse> {
         val result = findCoffeeBeansUsecase.execute(page, size)
-        return ResponseEntity.ok(PagedResponse.from(result) { CoffeeBeanSummaryResponse.from(it) })
+        return ResponseEntity.ok(CoffeeBeanListResponse.from(result))
     }
 
     @GetMapping("/{id}")

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/controller/PlanController.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/controller/PlanController.kt
@@ -1,0 +1,264 @@
+package com.mametosho.admin.presentation.controller
+
+import com.mametosho.admin.application.usecase.FindPlansUsecase
+import com.mametosho.admin.application.usecase.GetPlanUsecase
+import com.mametosho.admin.application.usecase.UpdatePlanUsecase
+import com.mametosho.admin.presentation.dto.request.UpdatePlanRequest
+import com.mametosho.admin.presentation.dto.response.ErrorResponse
+import com.mametosho.admin.presentation.dto.response.PagedResponse
+import com.mametosho.admin.presentation.dto.response.PlanDetailResponse
+import com.mametosho.admin.presentation.dto.response.PlanResponse
+import com.mametosho.admin.presentation.dto.response.PlanSummaryResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/admin/plans")
+@Tag(name = "Plan", description = "プランAPI")
+class PlanController(
+    private val findPlansUsecase: FindPlansUsecase,
+    private val getPlanUsecase: GetPlanUsecase,
+    private val updatePlanUsecase: UpdatePlanUsecase,
+) {
+    @GetMapping
+    @Operation(
+        summary = "プラン一覧取得",
+        description = "プランの一覧をページネーション付きで取得します。プラン表示名による部分一致検索が可能です。",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "取得成功",
+                content = [
+                    Content(
+                        examples = [
+                            ExampleObject(
+                                name = "success",
+                                summary = "取得成功例",
+                                value = """
+                                    {
+                                      "items": [
+                                        {
+                                          "id": "00000000-0000-4000-8000-000000000024",
+                                          "shopifyPlanId": "test-plan-001",
+                                          "label": "定番",
+                                          "gramWeight": 60,
+                                          "beanQuantity": 4,
+                                          "price": 3800,
+                                          "type": "SUBSCRIPTION",
+                                          "isRecommended": true
+                                        }
+                                      ],
+                                      "totalCount": 1,
+                                      "page": 0,
+                                      "size": 20
+                                    }
+                                """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+    fun listPlans(
+        @Parameter(description = "ページ番号（0始まり）", example = "0")
+        @RequestParam(defaultValue = "0") page: Int,
+        @Parameter(description = "1ページあたりの件数", example = "20")
+        @RequestParam(defaultValue = "20") size: Int,
+        @Parameter(description = "プラン表示名（部分一致検索）", example = "定番", required = false)
+        @RequestParam(required = false) keyword: String?,
+    ): ResponseEntity<PagedResponse<PlanSummaryResponse>> {
+        val result = findPlansUsecase.execute(page, size, keyword)
+        return ResponseEntity.ok(PagedResponse.from(result) { PlanSummaryResponse.from(it) })
+    }
+
+    @GetMapping("/{id}")
+    @Operation(
+        summary = "プラン詳細取得",
+        description = "指定されたIDのプランの詳細情報を取得します。",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "取得成功",
+                content = [
+                    Content(
+                        schema = Schema(implementation = PlanDetailResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "success",
+                                summary = "取得成功例",
+                                value = """
+                                    {
+                                      "id": "00000000-0000-4000-8000-000000000024",
+                                      "shopifyPlanId": "test-plan-001",
+                                      "label": "定番",
+                                      "gramWeight": 60,
+                                      "beanQuantity": 4,
+                                      "price": 3800,
+                                      "type": "SUBSCRIPTION",
+                                      "isRecommended": true
+                                    }
+                                """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "プランが見つかりません",
+                content = [
+                    Content(
+                        examples = [
+                            ExampleObject(
+                                name = "not_found",
+                                summary = "プランが見つからない場合",
+                                value = """
+                                    {
+                                      "timestamp": "2026-02-23T12:00:00.000+00:00",
+                                      "status": 404,
+                                      "error": "Not Found",
+                                      "path": "/api/admin/plans/00000000-0000-4000-8000-000000000999"
+                                    }
+                                """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+    fun getPlan(
+        @Parameter(description = "プランID", required = true, example = "00000000-0000-4000-8000-000000000024")
+        @PathVariable id: String,
+    ): ResponseEntity<PlanDetailResponse> {
+        val plan = getPlanUsecase.execute(id)
+            ?: return ResponseEntity.notFound().build()
+        return ResponseEntity.ok(PlanDetailResponse.from(plan))
+    }
+
+    @PutMapping("/{id}")
+    @Operation(
+        summary = "プラン編集",
+        description = "指定されたIDのプランを編集します。全項目を置換します。",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "編集成功",
+                content = [
+                    Content(
+                        schema = Schema(implementation = PlanResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "success",
+                                summary = "編集成功例",
+                                value = """
+                                    {
+                                      "id": "00000000-0000-4000-8000-000000000024"
+                                    }
+                                """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "バリデーションエラー",
+                content = [
+                    Content(
+                        schema = Schema(implementation = ErrorResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "bad_request",
+                                summary = "バリデーションエラーの場合",
+                                value = """
+                                    {
+                                      "timestamp": "2026-02-23T12:00:00.000+00:00",
+                                      "status": 400,
+                                      "error": "Bad Request",
+                                      "path": "/api/admin/plans/00000000-0000-4000-8000-000000000024"
+                                    }
+                                """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "プランが見つかりません",
+                content = [
+                    Content(
+                        examples = [
+                            ExampleObject(
+                                name = "not_found",
+                                summary = "プランが見つからない場合",
+                                value = """
+                                    {
+                                      "timestamp": "2026-02-23T12:00:00.000+00:00",
+                                      "status": 404,
+                                      "error": "Not Found",
+                                      "path": "/api/admin/plans/00000000-0000-4000-8000-000000000999"
+                                    }
+                                """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "409",
+                description = "ShopifyプランIDが重複しています",
+                content = [
+                    Content(
+                        schema = Schema(implementation = ErrorResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "conflict",
+                                summary = "ShopifyプランIDが重複している場合",
+                                value = """
+                                    {
+                                      "timestamp": "2026-02-23T12:00:00.000+00:00",
+                                      "status": 409,
+                                      "error": "Conflict",
+                                      "path": "/api/admin/plans/00000000-0000-4000-8000-000000000024"
+                                    }
+                                """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+    fun updatePlan(
+        @Parameter(description = "プランID", required = true, example = "00000000-0000-4000-8000-000000000024")
+        @PathVariable id: String,
+        @RequestBody request: UpdatePlanRequest,
+    ): ResponseEntity<PlanResponse> {
+        val plan = updatePlanUsecase.execute(id, request)
+            ?: return ResponseEntity.notFound().build()
+        return ResponseEntity.ok(PlanResponse.from(plan))
+    }
+}

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/controller/PlanController.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/controller/PlanController.kt
@@ -5,10 +5,9 @@ import com.mametosho.admin.application.usecase.GetPlanUsecase
 import com.mametosho.admin.application.usecase.UpdatePlanUsecase
 import com.mametosho.admin.presentation.dto.request.UpdatePlanRequest
 import com.mametosho.admin.presentation.dto.response.ErrorResponse
-import com.mametosho.admin.presentation.dto.response.PagedResponse
 import com.mametosho.admin.presentation.dto.response.PlanDetailResponse
+import com.mametosho.admin.presentation.dto.response.PlanListResponse
 import com.mametosho.admin.presentation.dto.response.PlanResponse
-import com.mametosho.admin.presentation.dto.response.PlanSummaryResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.media.Content
@@ -46,6 +45,7 @@ class PlanController(
                 description = "取得成功",
                 content = [
                     Content(
+                        schema = Schema(implementation = PlanListResponse::class),
                         examples = [
                             ExampleObject(
                                 name = "success",
@@ -83,9 +83,9 @@ class PlanController(
         @RequestParam(defaultValue = "20") size: Int,
         @Parameter(description = "プラン表示名（部分一致検索）", example = "定番", required = false)
         @RequestParam(required = false) keyword: String?,
-    ): ResponseEntity<PagedResponse<PlanSummaryResponse>> {
+    ): ResponseEntity<PlanListResponse> {
         val result = findPlansUsecase.execute(page, size, keyword)
-        return ResponseEntity.ok(PagedResponse.from(result) { PlanSummaryResponse.from(it) })
+        return ResponseEntity.ok(PlanListResponse.from(result))
     }
 
     @GetMapping("/{id}")

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/controller/ShopController.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/controller/ShopController.kt
@@ -8,8 +8,8 @@ import com.mametosho.admin.application.usecase.UpdateShopUsecase
 import com.mametosho.admin.presentation.dto.request.CreateShopRequest
 import com.mametosho.admin.presentation.dto.request.UpdateShopRequest
 import com.mametosho.admin.presentation.dto.response.ErrorResponse
-import com.mametosho.admin.presentation.dto.response.PagedResponse
 import com.mametosho.admin.presentation.dto.response.ShopDetailResponse
+import com.mametosho.admin.presentation.dto.response.ShopListResponse
 import com.mametosho.admin.presentation.dto.response.ShopSummaryResponse
 import com.mametosho.admin.presentation.dto.response.ShopResponse
 import io.swagger.v3.oas.annotations.Operation
@@ -56,6 +56,7 @@ class ShopController(
                 description = "取得成功",
                 content = [
                     Content(
+                        schema = Schema(implementation = ShopListResponse::class),
                         examples = [
                             ExampleObject(
                                 name = "success",
@@ -93,9 +94,9 @@ class ShopController(
         @RequestParam(defaultValue = "20") size: Int,
         @Parameter(description = "店名（部分一致検索）", example = "珈琲", required = false)
         @RequestParam(required = false) name: String?,
-    ): ResponseEntity<PagedResponse<ShopSummaryResponse>> {
+    ): ResponseEntity<ShopListResponse> {
         val result = findShopsUsecase.execute(page, size, name)
-        return ResponseEntity.ok(PagedResponse.from(result) { ShopSummaryResponse.from(it) })
+        return ResponseEntity.ok(ShopListResponse.from(result))
     }
 
     @GetMapping("/{id}")

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/request/CreateCoffeeBeanRequest.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/request/CreateCoffeeBeanRequest.kt
@@ -30,7 +30,7 @@ data class CreateCoffeeBeanRequest(
     val processingMethod: String,
 
     @Schema(description = "スペシャルティコーヒーかどうか", example = "true")
-    @param:JsonProperty("isSpecialty")
+    @JsonProperty("isSpecialty")
     val isSpecialty: Boolean,
 
     @Schema(

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/request/CreateCoffeeBeanRequest.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/request/CreateCoffeeBeanRequest.kt
@@ -5,32 +5,32 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "コーヒー豆登録リクエスト")
 data class CreateCoffeeBeanRequest(
-    @Schema(description = "店舗ID", example = "00000000-0000-4000-8000-000000000031")
+    @Schema(description = "店舗ID", example = "00000000-0000-4000-8000-000000000031", requiredMode = Schema.RequiredMode.REQUIRED)
     val shopId: String,
 
-    @Schema(description = "Shopifyの商品ID", example = "gid://shopify/Product/999999")
+    @Schema(description = "Shopifyの商品ID", example = "gid://shopify/Product/999999", requiredMode = Schema.RequiredMode.REQUIRED)
     val shopifyBeanId: String,
 
-    @Schema(description = "豆の名前", example = "テストコーヒー豆")
+    @Schema(description = "豆の名前", example = "テストコーヒー豆", requiredMode = Schema.RequiredMode.REQUIRED)
     val name: String,
 
-    @Schema(description = "説明", example = "テスト説明文")
+    @Schema(description = "説明", example = "テスト説明文", requiredMode = Schema.RequiredMode.REQUIRED)
     val description: String,
 
-    @Schema(description = "産地", example = "エチオピア")
+    @Schema(description = "産地", example = "エチオピア", requiredMode = Schema.RequiredMode.REQUIRED)
     val origin: String,
 
     @Schema(description = "農園名", example = "テスト農園", nullable = true)
     val farm: String?,
 
-    @Schema(description = "焙煎度", example = "MEDIUM")
+    @Schema(description = "焙煎度", example = "MEDIUM", requiredMode = Schema.RequiredMode.REQUIRED)
     val roastLevel: String,
 
-    @Schema(description = "精製方法", example = "WASHED")
+    @Schema(description = "精製方法", example = "WASHED", requiredMode = Schema.RequiredMode.REQUIRED)
     val processingMethod: String,
 
-    @Schema(description = "スペシャルティコーヒーかどうか", example = "true")
-    @JsonProperty("isSpecialty")
+    @get:Schema(description = "スペシャルティコーヒーかどうか", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
+    @get:JsonProperty("isSpecialty")
     val isSpecialty: Boolean,
 
     @Schema(
@@ -40,15 +40,15 @@ data class CreateCoffeeBeanRequest(
     )
     val publishStatus: String,
 
-    @Schema(description = "テイスト評価一覧")
+    @Schema(description = "テイスト評価一覧", requiredMode = Schema.RequiredMode.REQUIRED)
     val tastes: List<TasteRequest>,
 ) {
     @Schema(description = "テイスト評価リクエスト")
     data class TasteRequest(
-        @Schema(description = "テイストID", example = "00000000-0000-4000-8000-000000000041")
+        @Schema(description = "テイストID", example = "00000000-0000-4000-8000-000000000041", requiredMode = Schema.RequiredMode.REQUIRED)
         val tasteId: String,
 
-        @Schema(description = "評価値（0-5）", example = "3")
+        @Schema(description = "評価値（0-5）", example = "3", requiredMode = Schema.RequiredMode.REQUIRED)
         val evaluationValue: Int,
     )
 }

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/request/CreateCoffeeBeanRequest.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/request/CreateCoffeeBeanRequest.kt
@@ -1,5 +1,6 @@
 package com.mametosho.admin.presentation.dto.request
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "コーヒー豆登録リクエスト")
@@ -29,6 +30,7 @@ data class CreateCoffeeBeanRequest(
     val processingMethod: String,
 
     @Schema(description = "スペシャルティコーヒーかどうか", example = "true")
+    @param:JsonProperty("isSpecialty")
     val isSpecialty: Boolean,
 
     @Schema(

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/request/CreateShopRequest.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/request/CreateShopRequest.kt
@@ -4,10 +4,10 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "店舗登録リクエスト")
 data class CreateShopRequest(
-    @Schema(description = "ShopifyのショップID", example = "test-shop-001")
+    @Schema(description = "ShopifyのショップID", example = "test-shop-001", requiredMode = Schema.RequiredMode.REQUIRED)
     val shopifyShopId: String,
 
-    @Schema(description = "店舗名", example = "テスト店舗")
+    @Schema(description = "店舗名", example = "テスト店舗", requiredMode = Schema.RequiredMode.REQUIRED)
     val name: String,
 
     @Schema(description = "店舗紹介", example = "テスト紹介文", nullable = true)
@@ -16,10 +16,10 @@ data class CreateShopRequest(
     @Schema(description = "こだわり", example = "テストこだわり", nullable = true)
     val particular: String?,
 
-    @Schema(description = "店舗URL", example = "https://example.com")
+    @Schema(description = "店舗URL", example = "https://example.com", requiredMode = Schema.RequiredMode.REQUIRED)
     val shopUrl: String,
 
-    @Schema(description = "都道府県", example = "TOKYO")
+    @Schema(description = "都道府県", example = "TOKYO", requiredMode = Schema.RequiredMode.REQUIRED)
     val prefecture: String,
 
     @Schema(

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/request/UpdateCoffeeBeanRequest.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/request/UpdateCoffeeBeanRequest.kt
@@ -30,7 +30,7 @@ data class UpdateCoffeeBeanRequest(
     val processingMethod: String,
 
     @Schema(description = "スペシャルティコーヒーかどうか", example = "true")
-    @param:JsonProperty("isSpecialty")
+    @JsonProperty("isSpecialty")
     val isSpecialty: Boolean,
 
     @Schema(

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/request/UpdateCoffeeBeanRequest.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/request/UpdateCoffeeBeanRequest.kt
@@ -1,5 +1,6 @@
 package com.mametosho.admin.presentation.dto.request
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "コーヒー豆更新リクエスト")
@@ -29,6 +30,7 @@ data class UpdateCoffeeBeanRequest(
     val processingMethod: String,
 
     @Schema(description = "スペシャルティコーヒーかどうか", example = "true")
+    @param:JsonProperty("isSpecialty")
     val isSpecialty: Boolean,
 
     @Schema(

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/request/UpdateCoffeeBeanRequest.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/request/UpdateCoffeeBeanRequest.kt
@@ -5,32 +5,32 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "コーヒー豆更新リクエスト")
 data class UpdateCoffeeBeanRequest(
-    @Schema(description = "店舗ID", example = "00000000-0000-4000-8000-000000000001")
+    @Schema(description = "店舗ID", example = "00000000-0000-4000-8000-000000000001", requiredMode = Schema.RequiredMode.REQUIRED)
     val shopId: String,
 
-    @Schema(description = "Shopifyの商品ID", example = "test-bean-001")
+    @Schema(description = "Shopifyの商品ID", example = "test-bean-001", requiredMode = Schema.RequiredMode.REQUIRED)
     val shopifyBeanId: String,
 
-    @Schema(description = "豆の名前", example = "テストコーヒー豆")
+    @Schema(description = "豆の名前", example = "テストコーヒー豆", requiredMode = Schema.RequiredMode.REQUIRED)
     val name: String,
 
-    @Schema(description = "説明", example = "テスト説明文")
+    @Schema(description = "説明", example = "テスト説明文", requiredMode = Schema.RequiredMode.REQUIRED)
     val description: String,
 
-    @Schema(description = "産地", example = "エチオピア")
+    @Schema(description = "産地", example = "エチオピア", requiredMode = Schema.RequiredMode.REQUIRED)
     val origin: String,
 
     @Schema(description = "農園名", example = "テスト農園", nullable = true)
     val farm: String?,
 
-    @Schema(description = "焙煎度", example = "MEDIUM")
+    @Schema(description = "焙煎度", example = "MEDIUM", requiredMode = Schema.RequiredMode.REQUIRED)
     val roastLevel: String,
 
-    @Schema(description = "精製方法", example = "WASHED")
+    @Schema(description = "精製方法", example = "WASHED", requiredMode = Schema.RequiredMode.REQUIRED)
     val processingMethod: String,
 
-    @Schema(description = "スペシャルティコーヒーかどうか", example = "true")
-    @JsonProperty("isSpecialty")
+    @get:Schema(description = "スペシャルティコーヒーかどうか", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
+    @get:JsonProperty("isSpecialty")
     val isSpecialty: Boolean,
 
     @Schema(
@@ -40,15 +40,15 @@ data class UpdateCoffeeBeanRequest(
     )
     val publishStatus: String,
 
-    @Schema(description = "テイスト評価一覧")
+    @Schema(description = "テイスト評価一覧", requiredMode = Schema.RequiredMode.REQUIRED)
     val tastes: List<TasteRequest>,
 ) {
     @Schema(description = "テイスト評価リクエスト")
     data class TasteRequest(
-        @Schema(description = "テイストID", example = "00000000-0000-4000-8000-000000000041")
+        @Schema(description = "テイストID", example = "00000000-0000-4000-8000-000000000041", requiredMode = Schema.RequiredMode.REQUIRED)
         val tasteId: String,
 
-        @Schema(description = "評価値（0-5）", example = "3")
+        @Schema(description = "評価値（0-5）", example = "3", requiredMode = Schema.RequiredMode.REQUIRED)
         val evaluationValue: Int,
     )
 }

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/request/UpdatePlanRequest.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/request/UpdatePlanRequest.kt
@@ -25,6 +25,5 @@ data class UpdatePlanRequest(
 
     @Schema(description = "おすすめバッジ", example = "true")
     @param:JsonProperty("isRecommended")
-    @get:JsonProperty("isRecommended")
     val isRecommended: Boolean,
 )

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/request/UpdatePlanRequest.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/request/UpdatePlanRequest.kt
@@ -24,6 +24,6 @@ data class UpdatePlanRequest(
     val type: String,
 
     @Schema(description = "おすすめバッジ", example = "true")
-    @param:JsonProperty("isRecommended")
+    @JsonProperty("isRecommended")
     val isRecommended: Boolean,
 )

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/request/UpdatePlanRequest.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/request/UpdatePlanRequest.kt
@@ -5,25 +5,25 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "プラン編集リクエスト")
 data class UpdatePlanRequest(
-    @Schema(description = "ShopifyのプランID", example = "test-plan-001")
+    @Schema(description = "ShopifyのプランID", example = "test-plan-001", requiredMode = Schema.RequiredMode.REQUIRED)
     val shopifyPlanId: String,
 
-    @Schema(description = "プラン表示名", example = "定番")
+    @Schema(description = "プラン表示名", example = "定番", requiredMode = Schema.RequiredMode.REQUIRED)
     val label: String,
 
-    @Schema(description = "1種あたりのグラム数（30 / 60 / 90）", example = "60")
+    @Schema(description = "1種あたりのグラム数（30 / 60 / 90）", example = "60", requiredMode = Schema.RequiredMode.REQUIRED)
     val gramWeight: Int,
 
-    @Schema(description = "豆の種類数（3 / 4 / 5）", example = "4")
+    @Schema(description = "豆の種類数（3 / 4 / 5）", example = "4", requiredMode = Schema.RequiredMode.REQUIRED)
     val beanQuantity: Int,
 
-    @Schema(description = "価格", example = "3800")
+    @Schema(description = "価格", example = "3800", requiredMode = Schema.RequiredMode.REQUIRED)
     val price: Int,
 
-    @Schema(description = "プラン種別（SUBSCRIPTION / SINGLE）", example = "SUBSCRIPTION")
+    @Schema(description = "プラン種別（SUBSCRIPTION / SINGLE）", example = "SUBSCRIPTION", requiredMode = Schema.RequiredMode.REQUIRED)
     val type: String,
 
-    @Schema(description = "おすすめバッジ", example = "true")
-    @JsonProperty("isRecommended")
+    @get:Schema(description = "おすすめバッジ", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
+    @get:JsonProperty("isRecommended")
     val isRecommended: Boolean,
 )

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/request/UpdatePlanRequest.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/request/UpdatePlanRequest.kt
@@ -24,6 +24,7 @@ data class UpdatePlanRequest(
     val type: String,
 
     @Schema(description = "おすすめバッジ", example = "true")
+    @param:JsonProperty("isRecommended")
     @get:JsonProperty("isRecommended")
     val isRecommended: Boolean,
 )

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/request/UpdatePlanRequest.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/request/UpdatePlanRequest.kt
@@ -1,5 +1,6 @@
 package com.mametosho.admin.presentation.dto.request
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "プラン編集リクエスト")
@@ -23,5 +24,6 @@ data class UpdatePlanRequest(
     val type: String,
 
     @Schema(description = "おすすめバッジ", example = "true")
+    @get:JsonProperty("isRecommended")
     val isRecommended: Boolean,
 )

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/request/UpdatePlanRequest.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/request/UpdatePlanRequest.kt
@@ -1,0 +1,27 @@
+package com.mametosho.admin.presentation.dto.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "プラン編集リクエスト")
+data class UpdatePlanRequest(
+    @Schema(description = "ShopifyのプランID", example = "test-plan-001")
+    val shopifyPlanId: String,
+
+    @Schema(description = "プラン表示名", example = "定番")
+    val label: String,
+
+    @Schema(description = "1種あたりのグラム数（30 / 60 / 90）", example = "60")
+    val gramWeight: Int,
+
+    @Schema(description = "豆の種類数（3 / 4 / 5）", example = "4")
+    val beanQuantity: Int,
+
+    @Schema(description = "価格", example = "3800")
+    val price: Int,
+
+    @Schema(description = "プラン種別（SUBSCRIPTION / SINGLE）", example = "SUBSCRIPTION")
+    val type: String,
+
+    @Schema(description = "おすすめバッジ", example = "true")
+    val isRecommended: Boolean,
+)

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/request/UpdateShopRequest.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/request/UpdateShopRequest.kt
@@ -4,10 +4,10 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "店舗編集リクエスト")
 data class UpdateShopRequest(
-    @Schema(description = "ShopifyのショップID", example = "test-shop-001")
+    @Schema(description = "ShopifyのショップID", example = "test-shop-001", requiredMode = Schema.RequiredMode.REQUIRED)
     val shopifyShopId: String,
 
-    @Schema(description = "店舗名", example = "テスト店舗")
+    @Schema(description = "店舗名", example = "テスト店舗", requiredMode = Schema.RequiredMode.REQUIRED)
     val name: String,
 
     @Schema(description = "店舗紹介", example = "テスト紹介文", nullable = true)
@@ -16,10 +16,10 @@ data class UpdateShopRequest(
     @Schema(description = "こだわり", example = "テストこだわり", nullable = true)
     val particular: String?,
 
-    @Schema(description = "店舗URL", example = "https://example.com")
+    @Schema(description = "店舗URL", example = "https://example.com", requiredMode = Schema.RequiredMode.REQUIRED)
     val shopUrl: String,
 
-    @Schema(description = "都道府県", example = "TOKYO")
+    @Schema(description = "都道府県", example = "TOKYO", requiredMode = Schema.RequiredMode.REQUIRED)
     val prefecture: String,
 
     @Schema(

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/CoffeeBeanDetailResponse.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/CoffeeBeanDetailResponse.kt
@@ -1,5 +1,6 @@
 package com.mametosho.admin.presentation.dto.response
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import com.mametosho.admin.application.query.result.CoffeeBeanDetailResult
 import io.swagger.v3.oas.annotations.media.Schema
 
@@ -24,6 +25,7 @@ data class CoffeeBeanDetailResponse(
     @Schema(description = "精製方法", example = "WASHED")
     val processingMethod: String,
     @Schema(description = "スペシャルティコーヒーかどうか", example = "true")
+    @get:JsonProperty("isSpecialty")
     val isSpecialty: Boolean,
     @Schema(
         description = "公開状態（DRAFT: 下書き / PUBLISHED: 公開）",

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/CoffeeBeanDetailResponse.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/CoffeeBeanDetailResponse.kt
@@ -6,25 +6,25 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "コーヒー豆詳細レスポンス")
 data class CoffeeBeanDetailResponse(
-    @Schema(description = "コーヒー豆ID", example = "00000000-0000-4000-8000-000000000001")
+    @Schema(description = "コーヒー豆ID", example = "00000000-0000-4000-8000-000000000001", requiredMode = Schema.RequiredMode.REQUIRED)
     val id: String,
-    @Schema(description = "ショップID", example = "00000000-0000-4000-8000-000000000002")
+    @Schema(description = "ショップID", example = "00000000-0000-4000-8000-000000000002", requiredMode = Schema.RequiredMode.REQUIRED)
     val shopId: String,
-    @Schema(description = "Shopify商品ID", example = "test-bean-001")
+    @Schema(description = "Shopify商品ID", example = "test-bean-001", requiredMode = Schema.RequiredMode.REQUIRED)
     val shopifyBeanId: String,
-    @Schema(description = "豆の名前", example = "エチオピア イルガチェフェ")
+    @Schema(description = "豆の名前", example = "エチオピア イルガチェフェ", requiredMode = Schema.RequiredMode.REQUIRED)
     val name: String,
-    @Schema(description = "説明", example = "フルーティーな香りが特徴的なコーヒー豆です。")
+    @Schema(description = "説明", example = "フルーティーな香りが特徴的なコーヒー豆です。", requiredMode = Schema.RequiredMode.REQUIRED)
     val description: String,
-    @Schema(description = "産地", example = "エチオピア")
+    @Schema(description = "産地", example = "エチオピア", requiredMode = Schema.RequiredMode.REQUIRED)
     val origin: String,
     @Schema(description = "農園名", nullable = true, example = "イルガチェフェ農園")
     val farm: String?,
-    @Schema(description = "焙煎度", example = "MEDIUM")
+    @Schema(description = "焙煎度", example = "MEDIUM", requiredMode = Schema.RequiredMode.REQUIRED)
     val roastLevel: String,
-    @Schema(description = "精製方法", example = "WASHED")
+    @Schema(description = "精製方法", example = "WASHED", requiredMode = Schema.RequiredMode.REQUIRED)
     val processingMethod: String,
-    @Schema(description = "スペシャルティコーヒーかどうか", example = "true")
+    @get:Schema(description = "スペシャルティコーヒーかどうか", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
     @get:JsonProperty("isSpecialty")
     val isSpecialty: Boolean,
     @Schema(
@@ -33,30 +33,30 @@ data class CoffeeBeanDetailResponse(
         requiredMode = Schema.RequiredMode.REQUIRED,
     )
     val publishStatus: String,
-    @Schema(description = "画像一覧")
+    @Schema(description = "画像一覧", requiredMode = Schema.RequiredMode.REQUIRED)
     val images: List<ImageDetail>,
-    @Schema(description = "テイスト評価一覧")
+    @Schema(description = "テイスト評価一覧", requiredMode = Schema.RequiredMode.REQUIRED)
     val tastes: List<TasteDetail>,
 ) {
     @Schema(description = "画像詳細")
     data class ImageDetail(
-        @Schema(description = "画像ID", example = "00000000-0000-4000-8000-000000000010")
+        @Schema(description = "画像ID", example = "00000000-0000-4000-8000-000000000010", requiredMode = Schema.RequiredMode.REQUIRED)
         val id: String,
-        @Schema(description = "画像種別", example = "MAIN")
+        @Schema(description = "画像種別", example = "MAIN", requiredMode = Schema.RequiredMode.REQUIRED)
         val type: String,
-        @Schema(description = "画像URL", example = "https://example.com/image.jpg")
+        @Schema(description = "画像URL", example = "https://example.com/image.jpg", requiredMode = Schema.RequiredMode.REQUIRED)
         val imageUrl: String,
     )
 
     @Schema(description = "テイスト評価詳細")
     data class TasteDetail(
-        @Schema(description = "テイスト評価ID", example = "00000000-0000-4000-8000-000000000020")
+        @Schema(description = "テイスト評価ID", example = "00000000-0000-4000-8000-000000000020", requiredMode = Schema.RequiredMode.REQUIRED)
         val id: String,
-        @Schema(description = "テイストマスタID", example = "00000000-0000-4000-8000-000000000041")
+        @Schema(description = "テイストマスタID", example = "00000000-0000-4000-8000-000000000041", requiredMode = Schema.RequiredMode.REQUIRED)
         val tasteId: String,
-        @Schema(description = "テイスト名", example = "酸味")
+        @Schema(description = "テイスト名", example = "酸味", requiredMode = Schema.RequiredMode.REQUIRED)
         val tasteName: String,
-        @Schema(description = "評価値（0-5）", example = "4")
+        @Schema(description = "評価値（0-5）", example = "4", requiredMode = Schema.RequiredMode.REQUIRED)
         val evaluationValue: Int,
     )
 

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/CoffeeBeanListResponse.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/CoffeeBeanListResponse.kt
@@ -1,0 +1,26 @@
+package com.mametosho.admin.presentation.dto.response
+
+import com.mametosho.admin.application.query.result.CoffeeBeanSummaryResult
+import com.mametosho.admin.application.result.PagedResult
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "コーヒー豆一覧レスポンス")
+data class CoffeeBeanListResponse(
+    @Schema(description = "アイテム一覧", requiredMode = Schema.RequiredMode.REQUIRED)
+    val items: List<CoffeeBeanSummaryResponse>,
+    @Schema(description = "全件数", example = "42", requiredMode = Schema.RequiredMode.REQUIRED)
+    val totalCount: Long,
+    @Schema(description = "現在のページ番号（0始まり）", example = "0", requiredMode = Schema.RequiredMode.REQUIRED)
+    val page: Int,
+    @Schema(description = "1ページあたりの件数", example = "20", requiredMode = Schema.RequiredMode.REQUIRED)
+    val size: Int,
+) {
+    companion object {
+        fun from(result: PagedResult<CoffeeBeanSummaryResult>): CoffeeBeanListResponse = CoffeeBeanListResponse(
+            items = result.items.map { CoffeeBeanSummaryResponse.from(it) },
+            totalCount = result.totalCount,
+            page = result.page,
+            size = result.size,
+        )
+    }
+}

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/CoffeeBeanResponse.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/CoffeeBeanResponse.kt
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "コーヒー豆登録レスポンス")
 data class CoffeeBeanResponse(
-    @Schema(description = "コーヒー豆ID", example = "00000000-0000-4000-8000-000000000001")
+    @Schema(description = "コーヒー豆ID", example = "00000000-0000-4000-8000-000000000001", requiredMode = Schema.RequiredMode.REQUIRED)
     val id: String,
 ) {
     companion object {

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/CoffeeBeanSummaryResponse.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/CoffeeBeanSummaryResponse.kt
@@ -6,25 +6,25 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "コーヒー豆一覧アイテム")
 data class CoffeeBeanSummaryResponse(
-    @Schema(description = "コーヒー豆ID", example = "00000000-0000-4000-8000-000000000001")
+    @Schema(description = "コーヒー豆ID", example = "00000000-0000-4000-8000-000000000001", requiredMode = Schema.RequiredMode.REQUIRED)
     val id: String,
-    @Schema(description = "ショップID", example = "00000000-0000-4000-8000-000000000002")
+    @Schema(description = "ショップID", example = "00000000-0000-4000-8000-000000000002", requiredMode = Schema.RequiredMode.REQUIRED)
     val shopId: String,
-    @Schema(description = "Shopify商品ID", example = "test-bean-001")
+    @Schema(description = "Shopify商品ID", example = "test-bean-001", requiredMode = Schema.RequiredMode.REQUIRED)
     val shopifyBeanId: String,
-    @Schema(description = "豆の名前", example = "エチオピア イルガチェフェ")
+    @Schema(description = "豆の名前", example = "エチオピア イルガチェフェ", requiredMode = Schema.RequiredMode.REQUIRED)
     val name: String,
-    @Schema(description = "説明", example = "フルーティーな香りが特徴的なコーヒー豆です。")
+    @Schema(description = "説明", example = "フルーティーな香りが特徴的なコーヒー豆です。", requiredMode = Schema.RequiredMode.REQUIRED)
     val description: String,
-    @Schema(description = "産地", example = "エチオピア")
+    @Schema(description = "産地", example = "エチオピア", requiredMode = Schema.RequiredMode.REQUIRED)
     val origin: String,
     @Schema(description = "農園名", nullable = true, example = "イルガチェフェ農園")
     val farm: String?,
-    @Schema(description = "焙煎度", example = "MEDIUM")
+    @Schema(description = "焙煎度", example = "MEDIUM", requiredMode = Schema.RequiredMode.REQUIRED)
     val roastLevel: String,
-    @Schema(description = "精製方法", example = "WASHED")
+    @Schema(description = "精製方法", example = "WASHED", requiredMode = Schema.RequiredMode.REQUIRED)
     val processingMethod: String,
-    @Schema(description = "スペシャルティコーヒーかどうか", example = "true")
+    @get:Schema(description = "スペシャルティコーヒーかどうか", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
     @get:JsonProperty("isSpecialty")
     val isSpecialty: Boolean,
     @Schema(

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/CoffeeBeanSummaryResponse.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/CoffeeBeanSummaryResponse.kt
@@ -1,5 +1,6 @@
 package com.mametosho.admin.presentation.dto.response
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import com.mametosho.admin.application.query.result.CoffeeBeanSummaryResult
 import io.swagger.v3.oas.annotations.media.Schema
 
@@ -24,6 +25,7 @@ data class CoffeeBeanSummaryResponse(
     @Schema(description = "精製方法", example = "WASHED")
     val processingMethod: String,
     @Schema(description = "スペシャルティコーヒーかどうか", example = "true")
+    @get:JsonProperty("isSpecialty")
     val isSpecialty: Boolean,
     @Schema(
         description = "公開状態（DRAFT: 下書き / PUBLISHED: 公開）",

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/ErrorResponse.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/ErrorResponse.kt
@@ -5,18 +5,18 @@ import java.time.OffsetDateTime
 
 @Schema(description = "エラーレスポンス")
 data class ErrorResponse(
-    @Schema(description = "エラー発生日時", example = "2026-02-23T12:00:00.000+00:00")
+    @Schema(description = "エラー発生日時", example = "2026-02-23T12:00:00.000+00:00", requiredMode = Schema.RequiredMode.REQUIRED)
     val timestamp: OffsetDateTime,
 
-    @Schema(description = "HTTPステータスコード", example = "404")
+    @Schema(description = "HTTPステータスコード", example = "404", requiredMode = Schema.RequiredMode.REQUIRED)
     val status: Int,
 
-    @Schema(description = "エラー概要", example = "Not Found")
+    @Schema(description = "エラー概要", example = "Not Found", requiredMode = Schema.RequiredMode.REQUIRED)
     val error: String,
 
     @Schema(description = "エラーメッセージ", example = "tastes must not be empty", nullable = true)
     val message: String?,
 
-    @Schema(description = "リクエストパス", example = "/api/admin/resources/00000000-0000-4000-8000-000000000099")
+    @Schema(description = "リクエストパス", example = "/api/admin/resources/00000000-0000-4000-8000-000000000099", requiredMode = Schema.RequiredMode.REQUIRED)
     val path: String,
 )

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/ErrorResponse.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/ErrorResponse.kt
@@ -17,6 +17,10 @@ data class ErrorResponse(
     @Schema(description = "エラーメッセージ", example = "tastes must not be empty", nullable = true)
     val message: String?,
 
-    @Schema(description = "リクエストパス", example = "/api/admin/resources/00000000-0000-4000-8000-000000000099", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(
+        description = "リクエストパス",
+        example = "/api/admin/resources/00000000-0000-4000-8000-000000000099",
+        requiredMode = Schema.RequiredMode.REQUIRED,
+    )
     val path: String,
 )

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/LoginResponse.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/LoginResponse.kt
@@ -4,12 +4,12 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "ログインレスポンス")
 data class LoginResponse(
-    @Schema(description = "アクセストークン", example = "eyJhbGciOiJIUzI1NiJ9...")
+    @Schema(description = "アクセストークン", example = "eyJhbGciOiJIUzI1NiJ9...", requiredMode = Schema.RequiredMode.REQUIRED)
     val accessToken: String,
 
-    @Schema(description = "トークンタイプ", example = "Bearer")
+    @Schema(description = "トークンタイプ", example = "Bearer", requiredMode = Schema.RequiredMode.REQUIRED)
     val tokenType: String = "Bearer",
 
-    @Schema(description = "有効期限（秒）", example = "3600")
+    @Schema(description = "有効期限（秒）", example = "3600", requiredMode = Schema.RequiredMode.REQUIRED)
     val expiresIn: Long,
 )

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/PlanDetailResponse.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/PlanDetailResponse.kt
@@ -21,7 +21,6 @@ data class PlanDetailResponse(
     @Schema(description = "プラン種別（SUBSCRIPTION / SINGLE）", example = "SUBSCRIPTION")
     val type: String,
     @Schema(description = "おすすめバッジ", example = "true")
-    @param:JsonProperty("isRecommended")
     @get:JsonProperty("isRecommended")
     val isRecommended: Boolean,
 ) {

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/PlanDetailResponse.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/PlanDetailResponse.kt
@@ -1,5 +1,6 @@
 package com.mametosho.admin.presentation.dto.response
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import com.mametosho.domain.model.plan.Plan
 import io.swagger.v3.oas.annotations.media.Schema
 
@@ -20,6 +21,7 @@ data class PlanDetailResponse(
     @Schema(description = "プラン種別（SUBSCRIPTION / SINGLE）", example = "SUBSCRIPTION")
     val type: String,
     @Schema(description = "おすすめバッジ", example = "true")
+    @get:JsonProperty("isRecommended")
     val isRecommended: Boolean,
 ) {
     companion object {

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/PlanDetailResponse.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/PlanDetailResponse.kt
@@ -6,21 +6,21 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "プラン詳細レスポンス")
 data class PlanDetailResponse(
-    @Schema(description = "プランID", example = "00000000-0000-4000-8000-000000000024")
+    @Schema(description = "プランID", example = "00000000-0000-4000-8000-000000000024", requiredMode = Schema.RequiredMode.REQUIRED)
     val id: String,
-    @Schema(description = "ShopifyのプランID", example = "test-plan-001")
+    @Schema(description = "ShopifyのプランID", example = "test-plan-001", requiredMode = Schema.RequiredMode.REQUIRED)
     val shopifyPlanId: String,
-    @Schema(description = "プラン表示名", example = "定番")
+    @Schema(description = "プラン表示名", example = "定番", requiredMode = Schema.RequiredMode.REQUIRED)
     val label: String,
-    @Schema(description = "1種あたりのグラム数", example = "60")
+    @Schema(description = "1種あたりのグラム数", example = "60", requiredMode = Schema.RequiredMode.REQUIRED)
     val gramWeight: Int,
-    @Schema(description = "豆の種類数", example = "4")
+    @Schema(description = "豆の種類数", example = "4", requiredMode = Schema.RequiredMode.REQUIRED)
     val beanQuantity: Int,
-    @Schema(description = "価格", example = "3800")
+    @Schema(description = "価格", example = "3800", requiredMode = Schema.RequiredMode.REQUIRED)
     val price: Int,
-    @Schema(description = "プラン種別（SUBSCRIPTION / SINGLE）", example = "SUBSCRIPTION")
+    @Schema(description = "プラン種別（SUBSCRIPTION / SINGLE）", example = "SUBSCRIPTION", requiredMode = Schema.RequiredMode.REQUIRED)
     val type: String,
-    @Schema(description = "おすすめバッジ", example = "true")
+    @get:Schema(description = "おすすめバッジ", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
     @get:JsonProperty("isRecommended")
     val isRecommended: Boolean,
 ) {

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/PlanDetailResponse.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/PlanDetailResponse.kt
@@ -21,6 +21,7 @@ data class PlanDetailResponse(
     @Schema(description = "プラン種別（SUBSCRIPTION / SINGLE）", example = "SUBSCRIPTION")
     val type: String,
     @Schema(description = "おすすめバッジ", example = "true")
+    @param:JsonProperty("isRecommended")
     @get:JsonProperty("isRecommended")
     val isRecommended: Boolean,
 ) {

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/PlanDetailResponse.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/PlanDetailResponse.kt
@@ -1,0 +1,37 @@
+package com.mametosho.admin.presentation.dto.response
+
+import com.mametosho.domain.model.plan.Plan
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "プラン詳細レスポンス")
+data class PlanDetailResponse(
+    @Schema(description = "プランID", example = "00000000-0000-4000-8000-000000000024")
+    val id: String,
+    @Schema(description = "ShopifyのプランID", example = "test-plan-001")
+    val shopifyPlanId: String,
+    @Schema(description = "プラン表示名", example = "定番")
+    val label: String,
+    @Schema(description = "1種あたりのグラム数", example = "60")
+    val gramWeight: Int,
+    @Schema(description = "豆の種類数", example = "4")
+    val beanQuantity: Int,
+    @Schema(description = "価格", example = "3800")
+    val price: Int,
+    @Schema(description = "プラン種別（SUBSCRIPTION / SINGLE）", example = "SUBSCRIPTION")
+    val type: String,
+    @Schema(description = "おすすめバッジ", example = "true")
+    val isRecommended: Boolean,
+) {
+    companion object {
+        fun from(plan: Plan): PlanDetailResponse = PlanDetailResponse(
+            id = plan.id.value,
+            shopifyPlanId = plan.shopifyPlanId.value,
+            label = plan.label,
+            gramWeight = plan.gramWeight,
+            beanQuantity = plan.beanQuantity,
+            price = plan.price,
+            type = plan.type.name,
+            isRecommended = plan.isRecommended,
+        )
+    }
+}

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/PlanListResponse.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/PlanListResponse.kt
@@ -1,0 +1,26 @@
+package com.mametosho.admin.presentation.dto.response
+
+import com.mametosho.admin.application.result.PagedResult
+import com.mametosho.domain.model.plan.Plan
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "プラン一覧レスポンス")
+data class PlanListResponse(
+    @Schema(description = "アイテム一覧", requiredMode = Schema.RequiredMode.REQUIRED)
+    val items: List<PlanSummaryResponse>,
+    @Schema(description = "全件数", example = "42", requiredMode = Schema.RequiredMode.REQUIRED)
+    val totalCount: Long,
+    @Schema(description = "現在のページ番号（0始まり）", example = "0", requiredMode = Schema.RequiredMode.REQUIRED)
+    val page: Int,
+    @Schema(description = "1ページあたりの件数", example = "20", requiredMode = Schema.RequiredMode.REQUIRED)
+    val size: Int,
+) {
+    companion object {
+        fun from(result: PagedResult<Plan>): PlanListResponse = PlanListResponse(
+            items = result.items.map { PlanSummaryResponse.from(it) },
+            totalCount = result.totalCount,
+            page = result.page,
+            size = result.size,
+        )
+    }
+}

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/PlanResponse.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/PlanResponse.kt
@@ -1,0 +1,16 @@
+package com.mametosho.admin.presentation.dto.response
+
+import com.mametosho.domain.model.plan.Plan
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "プラン編集レスポンス")
+data class PlanResponse(
+    @Schema(description = "プランID", example = "00000000-0000-4000-8000-000000000024")
+    val id: String,
+) {
+    companion object {
+        fun from(plan: Plan): PlanResponse {
+            return PlanResponse(id = plan.id.value)
+        }
+    }
+}

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/PlanResponse.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/PlanResponse.kt
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "プラン編集レスポンス")
 data class PlanResponse(
-    @Schema(description = "プランID", example = "00000000-0000-4000-8000-000000000024")
+    @Schema(description = "プランID", example = "00000000-0000-4000-8000-000000000024", requiredMode = Schema.RequiredMode.REQUIRED)
     val id: String,
 ) {
     companion object {

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/PlanSummaryResponse.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/PlanSummaryResponse.kt
@@ -21,6 +21,7 @@ data class PlanSummaryResponse(
     @Schema(description = "プラン種別（SUBSCRIPTION / SINGLE）", example = "SUBSCRIPTION")
     val type: String,
     @Schema(description = "おすすめバッジ", example = "true")
+    @param:JsonProperty("isRecommended")
     @get:JsonProperty("isRecommended")
     val isRecommended: Boolean,
 ) {

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/PlanSummaryResponse.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/PlanSummaryResponse.kt
@@ -1,5 +1,6 @@
 package com.mametosho.admin.presentation.dto.response
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import com.mametosho.domain.model.plan.Plan
 import io.swagger.v3.oas.annotations.media.Schema
 
@@ -20,6 +21,7 @@ data class PlanSummaryResponse(
     @Schema(description = "プラン種別（SUBSCRIPTION / SINGLE）", example = "SUBSCRIPTION")
     val type: String,
     @Schema(description = "おすすめバッジ", example = "true")
+    @get:JsonProperty("isRecommended")
     val isRecommended: Boolean,
 ) {
     companion object {

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/PlanSummaryResponse.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/PlanSummaryResponse.kt
@@ -21,7 +21,6 @@ data class PlanSummaryResponse(
     @Schema(description = "プラン種別（SUBSCRIPTION / SINGLE）", example = "SUBSCRIPTION")
     val type: String,
     @Schema(description = "おすすめバッジ", example = "true")
-    @param:JsonProperty("isRecommended")
     @get:JsonProperty("isRecommended")
     val isRecommended: Boolean,
 ) {

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/PlanSummaryResponse.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/PlanSummaryResponse.kt
@@ -6,21 +6,21 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "プラン一覧アイテム")
 data class PlanSummaryResponse(
-    @Schema(description = "プランID", example = "00000000-0000-4000-8000-000000000024")
+    @Schema(description = "プランID", example = "00000000-0000-4000-8000-000000000024", requiredMode = Schema.RequiredMode.REQUIRED)
     val id: String,
-    @Schema(description = "ShopifyのプランID", example = "test-plan-001")
+    @Schema(description = "ShopifyのプランID", example = "test-plan-001", requiredMode = Schema.RequiredMode.REQUIRED)
     val shopifyPlanId: String,
-    @Schema(description = "プラン表示名", example = "定番")
+    @Schema(description = "プラン表示名", example = "定番", requiredMode = Schema.RequiredMode.REQUIRED)
     val label: String,
-    @Schema(description = "1種あたりのグラム数", example = "60")
+    @Schema(description = "1種あたりのグラム数", example = "60", requiredMode = Schema.RequiredMode.REQUIRED)
     val gramWeight: Int,
-    @Schema(description = "豆の種類数", example = "4")
+    @Schema(description = "豆の種類数", example = "4", requiredMode = Schema.RequiredMode.REQUIRED)
     val beanQuantity: Int,
-    @Schema(description = "価格", example = "3800")
+    @Schema(description = "価格", example = "3800", requiredMode = Schema.RequiredMode.REQUIRED)
     val price: Int,
-    @Schema(description = "プラン種別（SUBSCRIPTION / SINGLE）", example = "SUBSCRIPTION")
+    @Schema(description = "プラン種別（SUBSCRIPTION / SINGLE）", example = "SUBSCRIPTION", requiredMode = Schema.RequiredMode.REQUIRED)
     val type: String,
-    @Schema(description = "おすすめバッジ", example = "true")
+    @get:Schema(description = "おすすめバッジ", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
     @get:JsonProperty("isRecommended")
     val isRecommended: Boolean,
 ) {

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/PlanSummaryResponse.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/PlanSummaryResponse.kt
@@ -1,0 +1,37 @@
+package com.mametosho.admin.presentation.dto.response
+
+import com.mametosho.domain.model.plan.Plan
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "プラン一覧アイテム")
+data class PlanSummaryResponse(
+    @Schema(description = "プランID", example = "00000000-0000-4000-8000-000000000024")
+    val id: String,
+    @Schema(description = "ShopifyのプランID", example = "test-plan-001")
+    val shopifyPlanId: String,
+    @Schema(description = "プラン表示名", example = "定番")
+    val label: String,
+    @Schema(description = "1種あたりのグラム数", example = "60")
+    val gramWeight: Int,
+    @Schema(description = "豆の種類数", example = "4")
+    val beanQuantity: Int,
+    @Schema(description = "価格", example = "3800")
+    val price: Int,
+    @Schema(description = "プラン種別（SUBSCRIPTION / SINGLE）", example = "SUBSCRIPTION")
+    val type: String,
+    @Schema(description = "おすすめバッジ", example = "true")
+    val isRecommended: Boolean,
+) {
+    companion object {
+        fun from(plan: Plan): PlanSummaryResponse = PlanSummaryResponse(
+            id = plan.id.value,
+            shopifyPlanId = plan.shopifyPlanId.value,
+            label = plan.label,
+            gramWeight = plan.gramWeight,
+            beanQuantity = plan.beanQuantity,
+            price = plan.price,
+            type = plan.type.name,
+            isRecommended = plan.isRecommended,
+        )
+    }
+}

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/ShopDetailResponse.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/ShopDetailResponse.kt
@@ -6,19 +6,19 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "店舗詳細レスポンス")
 data class ShopDetailResponse(
-    @Schema(description = "店舗ID", example = "00000000-0000-4000-8000-000000000001")
+    @Schema(description = "店舗ID", example = "00000000-0000-4000-8000-000000000001", requiredMode = Schema.RequiredMode.REQUIRED)
     val id: String,
-    @Schema(description = "ShopifyショップID", example = "test-shop-001")
+    @Schema(description = "ShopifyショップID", example = "test-shop-001", requiredMode = Schema.RequiredMode.REQUIRED)
     val shopifyShopId: String,
-    @Schema(description = "店舗名", example = "テスト珈琲店")
+    @Schema(description = "店舗名", example = "テスト珈琲店", requiredMode = Schema.RequiredMode.REQUIRED)
     val name: String,
     @Schema(description = "店舗紹介", nullable = true, example = "こだわりの珈琲をお届けします。")
     val introduction: String?,
     @Schema(description = "こだわり", nullable = true, example = "厳選された豆のみを使用しています。")
     val particular: String?,
-    @Schema(description = "店舗URL", example = "https://example.com")
+    @Schema(description = "店舗URL", example = "https://example.com", requiredMode = Schema.RequiredMode.REQUIRED)
     val shopUrl: String,
-    @Schema(description = "都道府県", example = "TOKYO")
+    @Schema(description = "都道府県", example = "TOKYO", requiredMode = Schema.RequiredMode.REQUIRED)
     val prefecture: String,
     @Schema(
         description = "公開状態（DRAFT: 下書き / PUBLISHED: 公開）",
@@ -26,16 +26,16 @@ data class ShopDetailResponse(
         requiredMode = Schema.RequiredMode.REQUIRED,
     )
     val publishStatus: String,
-    @Schema(description = "画像一覧")
+    @Schema(description = "画像一覧", requiredMode = Schema.RequiredMode.REQUIRED)
     val images: List<ImageDetail>,
 ) {
     @Schema(description = "画像詳細")
     data class ImageDetail(
-        @Schema(description = "画像ID", example = "00000000-0000-4000-8000-000000000010")
+        @Schema(description = "画像ID", example = "00000000-0000-4000-8000-000000000010", requiredMode = Schema.RequiredMode.REQUIRED)
         val id: String,
-        @Schema(description = "画像種別", example = "MAIN")
+        @Schema(description = "画像種別", example = "MAIN", requiredMode = Schema.RequiredMode.REQUIRED)
         val type: String,
-        @Schema(description = "画像URL", example = "https://example.com/shop-image.jpg")
+        @Schema(description = "画像URL", example = "https://example.com/shop-image.jpg", requiredMode = Schema.RequiredMode.REQUIRED)
         val imageUrl: String,
     ) {
         companion object {

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/ShopListResponse.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/ShopListResponse.kt
@@ -1,0 +1,26 @@
+package com.mametosho.admin.presentation.dto.response
+
+import com.mametosho.admin.application.result.PagedResult
+import com.mametosho.domain.model.shop.Shop
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "店舗一覧レスポンス")
+data class ShopListResponse(
+    @Schema(description = "アイテム一覧", requiredMode = Schema.RequiredMode.REQUIRED)
+    val items: List<ShopSummaryResponse>,
+    @Schema(description = "全件数", example = "42", requiredMode = Schema.RequiredMode.REQUIRED)
+    val totalCount: Long,
+    @Schema(description = "現在のページ番号（0始まり）", example = "0", requiredMode = Schema.RequiredMode.REQUIRED)
+    val page: Int,
+    @Schema(description = "1ページあたりの件数", example = "20", requiredMode = Schema.RequiredMode.REQUIRED)
+    val size: Int,
+) {
+    companion object {
+        fun from(result: PagedResult<Shop>): ShopListResponse = ShopListResponse(
+            items = result.items.map { ShopSummaryResponse.from(it) },
+            totalCount = result.totalCount,
+            page = result.page,
+            size = result.size,
+        )
+    }
+}

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/ShopResponse.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/ShopResponse.kt
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "店舗登録レスポンス")
 data class ShopResponse(
-    @Schema(description = "店舗ID", example = "00000000-0000-4000-8000-000000000001")
+    @Schema(description = "店舗ID", example = "00000000-0000-4000-8000-000000000001", requiredMode = Schema.RequiredMode.REQUIRED)
     val id: String,
 ) {
     companion object {

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/ShopSummaryResponse.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/ShopSummaryResponse.kt
@@ -5,19 +5,19 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "店舗一覧アイテム")
 data class ShopSummaryResponse(
-    @Schema(description = "店舗ID", example = "00000000-0000-4000-8000-000000000001")
+    @Schema(description = "店舗ID", example = "00000000-0000-4000-8000-000000000001", requiredMode = Schema.RequiredMode.REQUIRED)
     val id: String,
-    @Schema(description = "ShopifyショップID", example = "test-shop-001")
+    @Schema(description = "ShopifyショップID", example = "test-shop-001", requiredMode = Schema.RequiredMode.REQUIRED)
     val shopifyShopId: String,
-    @Schema(description = "店舗名", example = "テスト珈琲店")
+    @Schema(description = "店舗名", example = "テスト珈琲店", requiredMode = Schema.RequiredMode.REQUIRED)
     val name: String,
     @Schema(description = "紹介文", nullable = true, example = "こだわりの珈琲をお届けします。")
     val introduction: String?,
     @Schema(description = "こだわり", nullable = true, example = "厳選された豆のみを使用しています。")
     val particular: String?,
-    @Schema(description = "店舗URL", example = "https://example.com")
+    @Schema(description = "店舗URL", example = "https://example.com", requiredMode = Schema.RequiredMode.REQUIRED)
     val shopUrl: String,
-    @Schema(description = "都道府県", example = "TOKYO")
+    @Schema(description = "都道府県", example = "TOKYO", requiredMode = Schema.RequiredMode.REQUIRED)
     val prefecture: String,
     @Schema(
         description = "公開状態（DRAFT: 下書き / PUBLISHED: 公開）",

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/TasteResponse.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/TasteResponse.kt
@@ -5,9 +5,9 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "テイスト一覧アイテム")
 data class TasteResponse(
-    @Schema(description = "テイストID", example = "00000000-0000-4000-8000-000000000041")
+    @Schema(description = "テイストID", example = "00000000-0000-4000-8000-000000000041", requiredMode = Schema.RequiredMode.REQUIRED)
     val id: String,
-    @Schema(description = "テイスト名", example = "酸味")
+    @Schema(description = "テイスト名", example = "酸味", requiredMode = Schema.RequiredMode.REQUIRED)
     val name: String,
 ) {
     companion object {

--- a/backend/admin-api/src/test/kotlin/com/mametosho/admin/application/usecase/FindPlansUsecaseTest.kt
+++ b/backend/admin-api/src/test/kotlin/com/mametosho/admin/application/usecase/FindPlansUsecaseTest.kt
@@ -1,0 +1,61 @@
+package com.mametosho.admin.application.usecase
+
+import com.mametosho.domain.model.plan.Plan
+import com.mametosho.domain.model.plan.PlanId
+import com.mametosho.domain.model.plan.PlanType
+import com.mametosho.domain.model.plan.ShopifyPlanId
+import com.mametosho.domain.repository.PlanRepository
+import org.junit.jupiter.api.Nested
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class FindPlansUsecaseTest {
+
+    private val plan = Plan(
+        id = PlanId("00000000-0000-4000-8000-000000000024"),
+        shopifyPlanId = ShopifyPlanId("existing-plan-001"),
+        label = "定番",
+        gramWeight = 60,
+        beanQuantity = 4,
+        price = 3800,
+        type = PlanType.SUBSCRIPTION,
+        isRecommended = true,
+    )
+
+    private var lastArgs: Triple<Int, Int, String?>? = null
+
+    private val fakeRepository = object : PlanRepository {
+        override fun findAll(): List<Plan> = listOf(plan)
+
+        override fun findAll(page: Int, size: Int, keyword: String?): Pair<List<Plan>, Long> {
+            lastArgs = Triple(page, size, keyword)
+            return Pair(listOf(plan), 1L)
+        }
+
+        override fun findById(id: PlanId): Plan? = null
+
+        override fun save(plan: Plan) = Unit
+    }
+
+    private val usecase = FindPlansUsecase(fakeRepository)
+
+    @Nested
+    inner class 正常系 {
+        @Test
+        fun `ページネーション付きでPlan一覧が返る`() {
+            val result = usecase.execute(0, 20, null)
+
+            assertEquals(1, result.items.size)
+            assertEquals(1L, result.totalCount)
+            assertEquals(0, result.page)
+            assertEquals(20, result.size)
+        }
+
+        @Test
+        fun `検索キーワードがリポジトリに渡される`() {
+            usecase.execute(1, 10, "定番")
+
+            assertEquals(Triple(1, 10, "定番"), lastArgs)
+        }
+    }
+}

--- a/backend/admin-api/src/test/kotlin/com/mametosho/admin/application/usecase/GetPlanUsecaseTest.kt
+++ b/backend/admin-api/src/test/kotlin/com/mametosho/admin/application/usecase/GetPlanUsecaseTest.kt
@@ -1,0 +1,75 @@
+package com.mametosho.admin.application.usecase
+
+import com.mametosho.domain.model.plan.Plan
+import com.mametosho.domain.model.plan.PlanId
+import com.mametosho.domain.model.plan.PlanType
+import com.mametosho.domain.model.plan.ShopifyPlanId
+import com.mametosho.domain.repository.PlanRepository
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class GetPlanUsecaseTest {
+
+    private val existingPlanId = "00000000-0000-4000-8000-000000000024"
+
+    private val existingPlan = Plan(
+        id = PlanId(existingPlanId),
+        shopifyPlanId = ShopifyPlanId("existing-plan-001"),
+        label = "定番",
+        gramWeight = 60,
+        beanQuantity = 4,
+        price = 3800,
+        type = PlanType.SUBSCRIPTION,
+        isRecommended = true,
+    )
+
+    private val fakeRepository = object : PlanRepository {
+        override fun findAll(): List<Plan> = listOf(existingPlan)
+
+        override fun findAll(page: Int, size: Int, keyword: String?): Pair<List<Plan>, Long> =
+            Pair(listOf(existingPlan), 1L)
+
+        override fun findById(id: PlanId): Plan? =
+            if (id.value == existingPlanId) existingPlan else null
+
+        override fun save(plan: Plan) = Unit
+    }
+
+    private val usecase = GetPlanUsecase(fakeRepository)
+
+    @Nested
+    inner class 正常系 {
+        @Test
+        fun `存在するIDの場合はPlanが返る`() {
+            val plan = usecase.execute(existingPlanId)
+
+            assertNotNull(plan)
+            assertEquals(existingPlanId, plan.id.value)
+            assertEquals("定番", plan.label)
+        }
+    }
+
+    @Nested
+    inner class 存在しないID {
+        @Test
+        fun `存在しないIDの場合はnullが返る`() {
+            val plan = usecase.execute("00000000-0000-4000-8000-999999999999")
+
+            assertNull(plan)
+        }
+    }
+
+    @Nested
+    inner class バリデーション {
+        @Test
+        fun `不正なUUID形式のIDの場合は例外が発生する`() {
+            assertThrows<IllegalArgumentException> {
+                usecase.execute("invalid-id")
+            }
+        }
+    }
+}

--- a/backend/admin-api/src/test/kotlin/com/mametosho/admin/application/usecase/UpdatePlanUsecaseTest.kt
+++ b/backend/admin-api/src/test/kotlin/com/mametosho/admin/application/usecase/UpdatePlanUsecaseTest.kt
@@ -1,0 +1,145 @@
+package com.mametosho.admin.application.usecase
+
+import com.mametosho.admin.presentation.dto.request.UpdatePlanRequest
+import com.mametosho.domain.model.plan.Plan
+import com.mametosho.domain.model.plan.PlanId
+import com.mametosho.domain.model.plan.PlanType
+import com.mametosho.domain.model.plan.ShopifyPlanId
+import com.mametosho.domain.repository.PlanRepository
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class UpdatePlanUsecaseTest {
+
+    private val existingPlanId = "00000000-0000-4000-8000-000000000024"
+
+    private val existingPlan = Plan(
+        id = PlanId(existingPlanId),
+        shopifyPlanId = ShopifyPlanId("existing-plan-001"),
+        label = "定番",
+        gramWeight = 60,
+        beanQuantity = 4,
+        price = 3800,
+        type = PlanType.SUBSCRIPTION,
+        isRecommended = true,
+    )
+
+    private val savedPlans = mutableListOf<Plan>()
+
+    private val fakeRepository = object : PlanRepository {
+        override fun findAll(): List<Plan> = listOf(existingPlan)
+
+        override fun findAll(page: Int, size: Int, keyword: String?): Pair<List<Plan>, Long> =
+            Pair(listOf(existingPlan), 1L)
+
+        override fun findById(id: PlanId): Plan? =
+            if (id.value == existingPlanId) existingPlan else null
+
+        override fun save(plan: Plan) {
+            savedPlans.add(plan)
+        }
+    }
+
+    private val usecase = UpdatePlanUsecase(fakeRepository)
+
+    private fun createRequest(
+        shopifyPlanId: String = "updated-plan-001",
+        label: String = "プレミアム",
+        gramWeight: Int = 90,
+        beanQuantity: Int = 5,
+        price: Int = 5800,
+        type: String = "SINGLE",
+        isRecommended: Boolean = false,
+    ): UpdatePlanRequest = UpdatePlanRequest(
+        shopifyPlanId = shopifyPlanId,
+        label = label,
+        gramWeight = gramWeight,
+        beanQuantity = beanQuantity,
+        price = price,
+        type = type,
+        isRecommended = isRecommended,
+    )
+
+    @Nested
+    inner class 正常系 {
+        @Test
+        fun `正常にPlanを編集できる`() {
+            val plan = usecase.execute(existingPlanId, createRequest())
+
+            assertNotNull(plan)
+            assertEquals("updated-plan-001", plan.shopifyPlanId.value)
+            assertEquals("プレミアム", plan.label)
+            assertEquals(90, plan.gramWeight)
+            assertEquals(5, plan.beanQuantity)
+            assertEquals(5800, plan.price)
+            assertEquals(PlanType.SINGLE, plan.type)
+            assertEquals(false, plan.isRecommended)
+        }
+
+        @Test
+        fun `編集後もPlanIdが変わらない`() {
+            val plan = usecase.execute(existingPlanId, createRequest())
+
+            assertNotNull(plan)
+            assertEquals(existingPlanId, plan.id.value)
+        }
+    }
+
+    @Nested
+    inner class 存在しないID {
+        @Test
+        fun `存在しないIDの場合はnullが返る`() {
+            val plan = usecase.execute("00000000-0000-4000-8000-999999999999", createRequest())
+
+            assertNull(plan)
+        }
+    }
+
+    @Nested
+    inner class リポジトリ保存 {
+        @Test
+        fun `編集したPlanがリポジトリに保存される`() {
+            savedPlans.clear()
+            usecase.execute(existingPlanId, createRequest())
+
+            assertEquals(1, savedPlans.size)
+            assertEquals("プレミアム", savedPlans[0].label)
+        }
+
+        @Test
+        fun `存在しないIDの場合はリポジトリに保存されない`() {
+            savedPlans.clear()
+            usecase.execute("00000000-0000-4000-8000-999999999999", createRequest())
+
+            assertEquals(0, savedPlans.size)
+        }
+    }
+
+    @Nested
+    inner class バリデーション {
+        @Test
+        fun `gramWeightが不正な場合は例外が発生する`() {
+            assertThrows<IllegalArgumentException> {
+                usecase.execute(existingPlanId, createRequest(gramWeight = 100))
+            }
+        }
+
+        @Test
+        fun `typeが不正な場合は例外が発生する`() {
+            assertThrows<IllegalArgumentException> {
+                usecase.execute(existingPlanId, createRequest(type = "INVALID"))
+            }
+        }
+
+        @Test
+        fun `不正なUUID形式のIDの場合は例外が発生する`() {
+            assertThrows<IllegalArgumentException> {
+                usecase.execute("invalid-id", createRequest())
+            }
+        }
+    }
+}

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -43,6 +43,16 @@ subprojects {
 	tasks.withType<Test> {
 		useJUnitPlatform()
 	}
+
+	// generateOpenApiDocs が使う forkedSpringBootRun は :common:jar の出力に依存するため、
+	// Spring Boot プラグイン適用モジュールに対して依存を一括宣言する。
+	// forkedSpringBootRun は springdoc プラグインが（モジュールの afterEvaluate 内で）
+	// 遅延登録するため、tasks.matching の configureEach で登場時に設定する。
+	plugins.withId("org.springframework.boot") {
+		tasks.matching { it.name == "forkedSpringBootRun" }.configureEach {
+			dependsOn(":common:jar")
+		}
+	}
 }
 
 tasks.register<JavaExec>("detekt") {

--- a/backend/common/src/main/kotlin/com/mametosho/domain/model/plan/Plan.kt
+++ b/backend/common/src/main/kotlin/com/mametosho/domain/model/plan/Plan.kt
@@ -30,6 +30,39 @@ data class Plan(
         require(price >= 0) { "price must be non-negative" }
     }
 
+    /**
+     * プラン情報を更新する。
+     *
+     * PlanIdは変更せず、それ以外の項目を置換する。
+     *
+     * @param shopifyPlanId ShopifyのプランID
+     * @param label プラン表示名
+     * @param gramWeight 1種あたりのグラム数
+     * @param beanQuantity 豆の種類数
+     * @param price 価格
+     * @param type プラン種別
+     * @param isRecommended おすすめバッジ
+     * @return 更新された[Plan]
+     */
+    fun update(
+        shopifyPlanId: String,
+        label: String,
+        gramWeight: Int,
+        beanQuantity: Int,
+        price: Int,
+        type: PlanType,
+        isRecommended: Boolean,
+    ): Plan = Plan(
+        id = this.id,
+        shopifyPlanId = ShopifyPlanId(shopifyPlanId),
+        label = label,
+        gramWeight = gramWeight,
+        beanQuantity = beanQuantity,
+        price = price,
+        type = type,
+        isRecommended = isRecommended,
+    )
+
     companion object {
         @Suppress("MagicNumber")
         val VALID_GRAM_WEIGHTS = setOf(30, 60, 90)

--- a/backend/common/src/main/kotlin/com/mametosho/domain/repository/PlanRepository.kt
+++ b/backend/common/src/main/kotlin/com/mametosho/domain/repository/PlanRepository.kt
@@ -1,7 +1,11 @@
 package com.mametosho.domain.repository
 
 import com.mametosho.domain.model.plan.Plan
+import com.mametosho.domain.model.plan.PlanId
 
 interface PlanRepository {
     fun findAll(): List<Plan>
+    fun findAll(page: Int, size: Int, keyword: String? = null): Pair<List<Plan>, Long>
+    fun findById(id: PlanId): Plan?
+    fun save(plan: Plan)
 }

--- a/backend/common/src/main/kotlin/com/mametosho/infrastructure/persistence/mybatis/mapper/PlanMapper.kt
+++ b/backend/common/src/main/kotlin/com/mametosho/infrastructure/persistence/mybatis/mapper/PlanMapper.kt
@@ -1,7 +1,9 @@
 package com.mametosho.infrastructure.persistence.mybatis.mapper
 
 import com.mametosho.infrastructure.persistence.mybatis.entity.PlanEntity
+import org.apache.ibatis.annotations.Insert
 import org.apache.ibatis.annotations.Mapper
+import org.apache.ibatis.annotations.Param
 import org.apache.ibatis.annotations.Select
 
 @Mapper
@@ -15,4 +17,64 @@ interface PlanMapper {
         """,
     )
     fun findAll(): List<PlanEntity>
+
+    @Select(
+        """
+        <script>
+        SELECT id, shopify_plan_id, label, gram_weight, bean_quantity, price, type, is_recommended
+        FROM plans
+        <where>
+            <if test="keyword != null">
+                label LIKE CONCAT('%', #{keyword}, '%')
+            </if>
+        </where>
+        ORDER BY bean_quantity ASC, gram_weight ASC
+        LIMIT #{size} OFFSET #{offset}
+        </script>
+        """,
+    )
+    fun findListRows(
+        @Param("size") size: Int,
+        @Param("offset") offset: Int,
+        @Param("keyword") keyword: String?,
+    ): List<PlanEntity>
+
+    @Select(
+        """
+        <script>
+        SELECT COUNT(*) FROM plans
+        <where>
+            <if test="keyword != null">
+                label LIKE CONCAT('%', #{keyword}, '%')
+            </if>
+        </where>
+        </script>
+        """,
+    )
+    fun countByCondition(@Param("keyword") keyword: String?): Long
+
+    @Select(
+        """
+        SELECT id, shopify_plan_id, label, gram_weight, bean_quantity, price, type, is_recommended
+        FROM plans
+        WHERE id = #{id}
+        """,
+    )
+    fun findById(id: String): PlanEntity?
+
+    @Insert(
+        """
+        INSERT INTO plans (id, shopify_plan_id, label, gram_weight, bean_quantity, price, type, is_recommended)
+        VALUES (#{id}, #{shopifyPlanId}, #{label}, #{gramWeight}, #{beanQuantity}, #{price}, #{type}, #{isRecommended})
+        ON DUPLICATE KEY UPDATE
+            shopify_plan_id = VALUES(shopify_plan_id),
+            label = VALUES(label),
+            gram_weight = VALUES(gram_weight),
+            bean_quantity = VALUES(bean_quantity),
+            price = VALUES(price),
+            type = VALUES(type),
+            is_recommended = VALUES(is_recommended)
+        """,
+    )
+    fun upsertPlan(entity: PlanEntity)
 }

--- a/backend/common/src/main/kotlin/com/mametosho/infrastructure/persistence/repository/PlanRepositoryImpl.kt
+++ b/backend/common/src/main/kotlin/com/mametosho/infrastructure/persistence/repository/PlanRepositoryImpl.kt
@@ -5,6 +5,7 @@ import com.mametosho.domain.model.plan.PlanId
 import com.mametosho.domain.model.plan.PlanType
 import com.mametosho.domain.model.plan.ShopifyPlanId
 import com.mametosho.domain.repository.PlanRepository
+import com.mametosho.infrastructure.persistence.mybatis.entity.PlanEntity
 import com.mametosho.infrastructure.persistence.mybatis.mapper.PlanMapper
 import org.springframework.stereotype.Repository
 
@@ -14,17 +15,43 @@ class PlanRepositoryImpl(
 ) : PlanRepository {
 
     override fun findAll(): List<Plan> {
-        return planMapper.findAll().map { entity ->
-            Plan(
-                id = PlanId(entity.id),
-                shopifyPlanId = ShopifyPlanId(entity.shopifyPlanId),
-                label = entity.label,
-                gramWeight = entity.gramWeight,
-                beanQuantity = entity.beanQuantity,
-                price = entity.price,
-                type = PlanType.valueOf(entity.type),
-                isRecommended = entity.isRecommended,
-            )
-        }
+        return planMapper.findAll().map { it.toDomain() }
     }
+
+    override fun findAll(page: Int, size: Int, keyword: String?): Pair<List<Plan>, Long> {
+        val offset = page * size
+        val rows = planMapper.findListRows(size, offset, keyword)
+        val totalCount = planMapper.countByCondition(keyword)
+        return Pair(rows.map { it.toDomain() }, totalCount)
+    }
+
+    override fun findById(id: PlanId): Plan? {
+        return planMapper.findById(id.value)?.toDomain()
+    }
+
+    override fun save(plan: Plan) {
+        planMapper.upsertPlan(
+            PlanEntity(
+                id = plan.id.value,
+                shopifyPlanId = plan.shopifyPlanId.value,
+                label = plan.label,
+                gramWeight = plan.gramWeight,
+                beanQuantity = plan.beanQuantity,
+                price = plan.price,
+                type = plan.type.name,
+                isRecommended = plan.isRecommended,
+            ),
+        )
+    }
+
+    private fun PlanEntity.toDomain(): Plan = Plan(
+        id = PlanId(id),
+        shopifyPlanId = ShopifyPlanId(shopifyPlanId),
+        label = label,
+        gramWeight = gramWeight,
+        beanQuantity = beanQuantity,
+        price = price,
+        type = PlanType.valueOf(type),
+        isRecommended = isRecommended,
+    )
 }

--- a/backend/cs-api/build.gradle.kts
+++ b/backend/cs-api/build.gradle.kts
@@ -38,12 +38,6 @@ openApi {
 	}
 }
 
-afterEvaluate {
-	tasks.named("forkedSpringBootRun") {
-		dependsOn(":common:jar")
-	}
-}
-
 dependencies {
 	implementation(project(":common"))
 

--- a/backend/docs/architecture/implementation/controller-conventions.md
+++ b/backend/docs/architecture/implementation/controller-conventions.md
@@ -121,6 +121,8 @@ class SampleController(
 - [ ] `@Parameter` に `example` があるか
 - [ ] ExampleObjectのJSONは複数行でインデントが揃っているか
 - [ ] 末尾カンマのスタイルが統一されているか
+- [ ] DTO の non-null フィールドに `requiredMode = Schema.RequiredMode.REQUIRED` があるか（ないと TypeScript 型が `?` になる）
+- [ ] `is` プレフィックス Boolean を `@get:JsonProperty` で公開している場合、`@Schema` も `@get:Schema` にしているか
 
 ## エラーハンドリング
 
@@ -155,8 +157,20 @@ class SampleController(
 ### Schemaアノテーション
 
 - クラスレベル: `@Schema(description = "...")`
-- 各プロパティ: `@Schema(description = "...", example = "...")`
+- 各プロパティ（non-null）: `@Schema(description = "...", example = "...", requiredMode = Schema.RequiredMode.REQUIRED)`
 - nullableなフィールド: `@Schema(description = "...", example = "...", nullable = true)`
+- `is` プレフィックス付きの Boolean プロパティ（`@get:JsonProperty` を併用する場合）: `@get:Schema(...)` で getter に直接アノテーションすること
+
+```kotlin
+// 通常の non-null フィールド
+@Schema(description = "店舗ID", example = "...", requiredMode = Schema.RequiredMode.REQUIRED)
+val id: String,
+
+// is-Boolean フィールド（@get:JsonProperty と併用する場合は @get:Schema で揃える）
+@get:Schema(description = "おすすめバッジ", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
+@get:JsonProperty("isRecommended")
+val isRecommended: Boolean,
+```
 
 ### ネスト構造
 

--- a/backend/docs/domains/plan.md
+++ b/backend/docs/domains/plan.md
@@ -35,3 +35,12 @@
 ## PlanType
 
 | 値 | 説明 |
+|----|------|
+| SUBSCRIPTION | 定期便プラン（毎月お届け） |
+| SINGLE | 単品購入プラン（1回のみ） |
+
+## 関連する集約
+
+| 集約 | 関連 | 説明 |
+|------|------|------|
+| [Customer](./customer.md) | 被参照 | CustomerSubscription がこのプランを参照する |

--- a/backend/docs/domains/plan.md
+++ b/backend/docs/domains/plan.md
@@ -35,12 +35,3 @@
 ## PlanType
 
 | 値 | 説明 |
-|----|------|
-| SUBSCRIPTION | 定期便プラン（毎月お届け） |
-| SINGLE | 単品購入プラン（1回のみ） |
-
-## 関連する集約
-
-| 集約 | 関連 | 説明 |
-|------|------|------|
-| [Customer](./customer.md) | 被参照 | CustomerSubscription がこのプランを参照する |

--- a/docs/swagger/admin-api.yml
+++ b/docs/swagger/admin-api.yml
@@ -1025,6 +1025,11 @@ components:
       type: object
       description: コーヒー豆更新リクエスト
       properties:
+        isSpecialty:
+          type: boolean
+          description: スペシャルティコーヒーかどうか
+          example: true
+          writeOnly: true
         shopId:
           type: string
           description: 店舗ID
@@ -1116,6 +1121,11 @@ components:
       type: object
       description: コーヒー豆登録リクエスト
       properties:
+        isSpecialty:
+          type: boolean
+          description: スペシャルティコーヒーかどうか
+          example: true
+          writeOnly: true
         shopId:
           type: string
           description: 店舗ID

--- a/docs/swagger/admin-api.yml
+++ b/docs/swagger/admin-api.yml
@@ -966,6 +966,10 @@ components:
       type: object
       description: プラン編集リクエスト
       properties:
+        isRecommended:
+          type: boolean
+          description: おすすめバッジ
+          example: true
         shopifyPlanId:
           type: string
           description: ShopifyのプランID
@@ -993,8 +997,6 @@ components:
           type: string
           description: プラン種別（SUBSCRIPTION / SINGLE）
           example: SUBSCRIPTION
-        recommended:
-          type: boolean
     PlanResponse:
       type: object
       description: プラン編集レスポンス
@@ -1248,6 +1250,10 @@ components:
       type: object
       description: プラン詳細レスポンス
       properties:
+        isRecommended:
+          type: boolean
+          description: おすすめバッジ
+          example: true
         id:
           type: string
           description: プランID
@@ -1279,8 +1285,6 @@ components:
           type: string
           description: プラン種別（SUBSCRIPTION / SINGLE）
           example: SUBSCRIPTION
-        recommended:
-          type: boolean
     CoffeeBeanDetailResponse:
       type: object
       description: コーヒー豆詳細レスポンス

--- a/docs/swagger/admin-api.yml
+++ b/docs/swagger/admin-api.yml
@@ -11,6 +11,10 @@ servers:
 security:
 - Bearer: []
 tags:
+- name: Plan
+  description: プランAPI
+- name: Taste
+  description: テイストAPI
 - name: Shop
   description: 店舗API
 - name: Auth
@@ -208,6 +212,130 @@ paths:
                     status: 409
                     error: Conflict
                     path: /api/admin/shops/00000000-0000-4000-8000-000000000001
+  /api/admin/plans/{id}:
+    get:
+      tags:
+      - Plan
+      summary: プラン詳細取得
+      description: 指定されたIDのプランの詳細情報を取得します。
+      operationId: getPlan
+      parameters:
+      - name: id
+        in: path
+        description: プランID
+        required: true
+        schema:
+          type: string
+        example: 00000000-0000-4000-8000-000000000024
+      responses:
+        "200":
+          description: 取得成功
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/PlanDetailResponse"
+              examples:
+                success:
+                  summary: 取得成功例
+                  description: success
+                  value:
+                    id: 00000000-0000-4000-8000-000000000024
+                    shopifyPlanId: test-plan-001
+                    label: 定番
+                    gramWeight: 60
+                    beanQuantity: 4
+                    price: 3800
+                    type: SUBSCRIPTION
+                    isRecommended: true
+        "404":
+          description: プランが見つかりません
+          content:
+            '*/*':
+              examples:
+                not_found:
+                  summary: プランが見つからない場合
+                  description: not_found
+                  value:
+                    timestamp: 2026-02-23T12:00:00.000+00:00
+                    status: 404
+                    error: Not Found
+                    path: /api/admin/plans/00000000-0000-4000-8000-000000000999
+    put:
+      tags:
+      - Plan
+      summary: プラン編集
+      description: 指定されたIDのプランを編集します。全項目を置換します。
+      operationId: updatePlan
+      parameters:
+      - name: id
+        in: path
+        description: プランID
+        required: true
+        schema:
+          type: string
+        example: 00000000-0000-4000-8000-000000000024
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdatePlanRequest"
+        required: true
+      responses:
+        "200":
+          description: 編集成功
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/PlanResponse"
+              examples:
+                success:
+                  summary: 編集成功例
+                  description: success
+                  value:
+                    id: 00000000-0000-4000-8000-000000000024
+        "400":
+          description: バリデーションエラー
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              examples:
+                bad_request:
+                  summary: バリデーションエラーの場合
+                  description: bad_request
+                  value:
+                    timestamp: 2026-02-23T12:00:00.000+00:00
+                    status: 400
+                    error: Bad Request
+                    path: /api/admin/plans/00000000-0000-4000-8000-000000000024
+        "404":
+          description: プランが見つかりません
+          content:
+            '*/*':
+              examples:
+                not_found:
+                  summary: プランが見つからない場合
+                  description: not_found
+                  value:
+                    timestamp: 2026-02-23T12:00:00.000+00:00
+                    status: 404
+                    error: Not Found
+                    path: /api/admin/plans/00000000-0000-4000-8000-000000000999
+        "409":
+          description: ShopifyプランIDが重複しています
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              examples:
+                conflict:
+                  summary: ShopifyプランIDが重複している場合
+                  description: conflict
+                  value:
+                    timestamp: 2026-02-23T12:00:00.000+00:00
+                    status: 409
+                    error: Conflict
+                    path: /api/admin/plans/00000000-0000-4000-8000-000000000024
   /api/admin/coffee-beans/{id}:
     get:
       tags:
@@ -676,6 +804,88 @@ paths:
                     status: 401
                     error: Unauthorized
                     path: /api/admin/auth/login
+  /api/admin/tastes:
+    get:
+      tags:
+      - Taste
+      summary: テイスト一覧取得
+      description: テイスト（酸味・苦味・甘味・コク・香りなど）の一覧を取得します。
+      operationId: listTastes
+      responses:
+        "200":
+          description: 取得成功
+          content:
+            '*/*':
+              examples:
+                success:
+                  summary: 取得成功例
+                  description: success
+                  value:
+                  - id: 00000000-0000-4000-8000-000000000041
+                    name: 酸味
+                  - id: 00000000-0000-4000-8000-000000000042
+                    name: 苦味
+                  - id: 00000000-0000-4000-8000-000000000043
+                    name: 甘味
+                  - id: 00000000-0000-4000-8000-000000000044
+                    name: コク
+                  - id: 00000000-0000-4000-8000-000000000045
+                    name: 香り
+  /api/admin/plans:
+    get:
+      tags:
+      - Plan
+      summary: プラン一覧取得
+      description: プランの一覧をページネーション付きで取得します。プラン表示名による部分一致検索が可能です。
+      operationId: listPlans
+      parameters:
+      - name: page
+        in: query
+        description: ページ番号（0始まり）
+        required: false
+        schema:
+          type: integer
+          format: int32
+          default: 0
+        example: 0
+      - name: size
+        in: query
+        description: 1ページあたりの件数
+        required: false
+        schema:
+          type: integer
+          format: int32
+          default: 20
+        example: 20
+      - name: keyword
+        in: query
+        description: プラン表示名（部分一致検索）
+        required: false
+        schema:
+          type: string
+        example: 定番
+      responses:
+        "200":
+          description: 取得成功
+          content:
+            '*/*':
+              examples:
+                success:
+                  summary: 取得成功例
+                  description: success
+                  value:
+                    items:
+                    - id: 00000000-0000-4000-8000-000000000024
+                      shopifyPlanId: test-plan-001
+                      label: 定番
+                      gramWeight: 60
+                      beanQuantity: 4
+                      price: 3800
+                      type: SUBSCRIPTION
+                      isRecommended: true
+                    totalCount: 1
+                    page: 0
+                    size: 20
 components:
   schemas:
     UpdateShopRequest:
@@ -732,10 +942,55 @@ components:
           type: string
           description: エラー概要
           example: Not Found
+        message:
+          type: string
+          description: エラーメッセージ
+          example: tastes must not be empty
         path:
           type: string
           description: リクエストパス
           example: /api/admin/resources/00000000-0000-4000-8000-000000000099
+    UpdatePlanRequest:
+      type: object
+      description: プラン編集リクエスト
+      properties:
+        shopifyPlanId:
+          type: string
+          description: ShopifyのプランID
+          example: test-plan-001
+        label:
+          type: string
+          description: プラン表示名
+          example: 定番
+        gramWeight:
+          type: integer
+          format: int32
+          description: 1種あたりのグラム数（30 / 60 / 90）
+          example: 60
+        beanQuantity:
+          type: integer
+          format: int32
+          description: 豆の種類数（3 / 4 / 5）
+          example: 4
+        price:
+          type: integer
+          format: int32
+          description: 価格
+          example: 3800
+        type:
+          type: string
+          description: プラン種別（SUBSCRIPTION / SINGLE）
+          example: SUBSCRIPTION
+        recommended:
+          type: boolean
+    PlanResponse:
+      type: object
+      description: プラン編集レスポンス
+      properties:
+        id:
+          type: string
+          description: プランID
+          example: 00000000-0000-4000-8000-000000000024
     TasteRequest:
       type: object
       description: テイスト評価リクエスト
@@ -953,6 +1208,43 @@ components:
           description: 画像一覧
           items:
             $ref: "#/components/schemas/ImageDetail"
+    PlanDetailResponse:
+      type: object
+      description: プラン詳細レスポンス
+      properties:
+        id:
+          type: string
+          description: プランID
+          example: 00000000-0000-4000-8000-000000000024
+        shopifyPlanId:
+          type: string
+          description: ShopifyのプランID
+          example: test-plan-001
+        label:
+          type: string
+          description: プラン表示名
+          example: 定番
+        gramWeight:
+          type: integer
+          format: int32
+          description: 1種あたりのグラム数
+          example: 60
+        beanQuantity:
+          type: integer
+          format: int32
+          description: 豆の種類数
+          example: 4
+        price:
+          type: integer
+          format: int32
+          description: 価格
+          example: 3800
+        type:
+          type: string
+          description: プラン種別（SUBSCRIPTION / SINGLE）
+          example: SUBSCRIPTION
+        recommended:
+          type: boolean
     CoffeeBeanDetailResponse:
       type: object
       description: コーヒー豆詳細レスポンス
@@ -1013,6 +1305,10 @@ components:
           type: string
           description: テイスト評価ID
           example: 00000000-0000-4000-8000-000000000020
+        tasteId:
+          type: string
+          description: テイストマスタID
+          example: 00000000-0000-4000-8000-000000000041
         tasteName:
           type: string
           description: テイスト名

--- a/docs/swagger/admin-api.yml
+++ b/docs/swagger/admin-api.yml
@@ -1340,7 +1340,7 @@ components:
           description: テイスト評価一覧
           items:
             $ref: "#/components/schemas/TasteDetail"
-        specialty:
+        isSpecialty:
           type: boolean
       required:
       - publishStatus

--- a/docs/swagger/admin-api.yml
+++ b/docs/swagger/admin-api.yml
@@ -557,6 +557,8 @@ paths:
           description: 取得成功
           content:
             '*/*':
+              schema:
+                $ref: "#/components/schemas/ShopListResponse"
               examples:
                 success:
                   summary: 取得成功例
@@ -677,6 +679,8 @@ paths:
           description: 取得成功
           content:
             '*/*':
+              schema:
+                $ref: "#/components/schemas/CoffeeBeanListResponse"
               examples:
                 success:
                   summary: 取得成功例
@@ -875,6 +879,8 @@ paths:
           description: 取得成功
           content:
             '*/*':
+              schema:
+                $ref: "#/components/schemas/PlanListResponse"
               examples:
                 success:
                   summary: 取得成功例
@@ -927,7 +933,11 @@ components:
           description: "公開状態（DRAFT: 下書き / PUBLISHED: 公開）"
           example: PUBLISHED
       required:
+      - name
+      - prefecture
       - publishStatus
+      - shopUrl
+      - shopifyShopId
     ShopResponse:
       type: object
       description: 店舗登録レスポンス
@@ -936,6 +946,8 @@ components:
           type: string
           description: 店舗ID
           example: 00000000-0000-4000-8000-000000000001
+      required:
+      - id
     ErrorResponse:
       type: object
       description: エラーレスポンス
@@ -962,15 +974,15 @@ components:
           type: string
           description: リクエストパス
           example: /api/admin/resources/00000000-0000-4000-8000-000000000099
+      required:
+      - error
+      - path
+      - status
+      - timestamp
     UpdatePlanRequest:
       type: object
       description: プラン編集リクエスト
       properties:
-        isRecommended:
-          type: boolean
-          description: おすすめバッジ
-          example: true
-          writeOnly: true
         shopifyPlanId:
           type: string
           description: ShopifyのプランID
@@ -998,8 +1010,18 @@ components:
           type: string
           description: プラン種別（SUBSCRIPTION / SINGLE）
           example: SUBSCRIPTION
-        recommended:
+        isRecommended:
           type: boolean
+          description: おすすめバッジ
+          example: true
+      required:
+      - beanQuantity
+      - gramWeight
+      - isRecommended
+      - label
+      - price
+      - shopifyPlanId
+      - type
     PlanResponse:
       type: object
       description: プラン編集レスポンス
@@ -1008,6 +1030,8 @@ components:
           type: string
           description: プランID
           example: 00000000-0000-4000-8000-000000000024
+      required:
+      - id
     TasteRequest:
       type: object
       description: テイスト評価リクエスト
@@ -1021,15 +1045,13 @@ components:
           format: int32
           description: 評価値（0-5）
           example: 3
+      required:
+      - evaluationValue
+      - tasteId
     UpdateCoffeeBeanRequest:
       type: object
       description: コーヒー豆更新リクエスト
       properties:
-        isSpecialty:
-          type: boolean
-          description: スペシャルティコーヒーかどうか
-          example: true
-          writeOnly: true
         shopId:
           type: string
           description: 店舗ID
@@ -1071,10 +1093,21 @@ components:
           description: テイスト評価一覧
           items:
             $ref: "#/components/schemas/TasteRequest"
-        specialty:
+        isSpecialty:
           type: boolean
+          description: スペシャルティコーヒーかどうか
+          example: true
       required:
+      - description
+      - isSpecialty
+      - name
+      - origin
+      - processingMethod
       - publishStatus
+      - roastLevel
+      - shopId
+      - shopifyBeanId
+      - tastes
     CoffeeBeanResponse:
       type: object
       description: コーヒー豆登録レスポンス
@@ -1083,6 +1116,8 @@ components:
           type: string
           description: コーヒー豆ID
           example: 00000000-0000-4000-8000-000000000001
+      required:
+      - id
     CreateShopRequest:
       type: object
       description: 店舗登録リクエスト
@@ -1116,16 +1151,15 @@ components:
           description: "公開状態（DRAFT: 下書き / PUBLISHED: 公開）"
           example: DRAFT
       required:
+      - name
+      - prefecture
       - publishStatus
+      - shopUrl
+      - shopifyShopId
     CreateCoffeeBeanRequest:
       type: object
       description: コーヒー豆登録リクエスト
       properties:
-        isSpecialty:
-          type: boolean
-          description: スペシャルティコーヒーかどうか
-          example: true
-          writeOnly: true
         shopId:
           type: string
           description: 店舗ID
@@ -1167,10 +1201,21 @@ components:
           description: テイスト評価一覧
           items:
             $ref: "#/components/schemas/TasteRequest"
-        specialty:
+        isSpecialty:
           type: boolean
+          description: スペシャルティコーヒーかどうか
+          example: true
       required:
+      - description
+      - isSpecialty
+      - name
+      - origin
+      - processingMethod
       - publishStatus
+      - roastLevel
+      - shopId
+      - shopifyBeanId
+      - tastes
     LoginRequest:
       type: object
       description: ログインリクエスト
@@ -1200,6 +1245,82 @@ components:
           format: int64
           description: 有効期限（秒）
           example: 3600
+      required:
+      - accessToken
+      - expiresIn
+      - tokenType
+    ShopListResponse:
+      type: object
+      description: 店舗一覧レスポンス
+      properties:
+        items:
+          type: array
+          description: アイテム一覧
+          items:
+            $ref: "#/components/schemas/ShopSummaryResponse"
+        totalCount:
+          type: integer
+          format: int64
+          description: 全件数
+          example: 42
+        page:
+          type: integer
+          format: int32
+          description: 現在のページ番号（0始まり）
+          example: 0
+        size:
+          type: integer
+          format: int32
+          description: 1ページあたりの件数
+          example: 20
+      required:
+      - items
+      - page
+      - size
+      - totalCount
+    ShopSummaryResponse:
+      type: object
+      description: 店舗一覧アイテム
+      properties:
+        id:
+          type: string
+          description: 店舗ID
+          example: 00000000-0000-4000-8000-000000000001
+        shopifyShopId:
+          type: string
+          description: ShopifyショップID
+          example: test-shop-001
+        name:
+          type: string
+          description: 店舗名
+          example: テスト珈琲店
+        introduction:
+          type: string
+          description: 紹介文
+          example: こだわりの珈琲をお届けします。
+        particular:
+          type: string
+          description: こだわり
+          example: 厳選された豆のみを使用しています。
+        shopUrl:
+          type: string
+          description: 店舗URL
+          example: https://example.com
+        prefecture:
+          type: string
+          description: 都道府県
+          example: TOKYO
+        publishStatus:
+          type: string
+          description: "公開状態（DRAFT: 下書き / PUBLISHED: 公開）"
+          example: PUBLISHED
+      required:
+      - id
+      - name
+      - prefecture
+      - publishStatus
+      - shopUrl
+      - shopifyShopId
     ImageDetail:
       type: object
       description: 画像詳細
@@ -1216,6 +1337,10 @@ components:
           type: string
           description: 画像URL
           example: https://example.com/image.jpg
+      required:
+      - id
+      - imageUrl
+      - type
     ShopDetailResponse:
       type: object
       description: 店舗詳細レスポンス
@@ -1258,7 +1383,90 @@ components:
           items:
             $ref: "#/components/schemas/ImageDetail"
       required:
+      - id
+      - images
+      - name
+      - prefecture
       - publishStatus
+      - shopUrl
+      - shopifyShopId
+    PlanListResponse:
+      type: object
+      description: プラン一覧レスポンス
+      properties:
+        items:
+          type: array
+          description: アイテム一覧
+          items:
+            $ref: "#/components/schemas/PlanSummaryResponse"
+        totalCount:
+          type: integer
+          format: int64
+          description: 全件数
+          example: 42
+        page:
+          type: integer
+          format: int32
+          description: 現在のページ番号（0始まり）
+          example: 0
+        size:
+          type: integer
+          format: int32
+          description: 1ページあたりの件数
+          example: 20
+      required:
+      - items
+      - page
+      - size
+      - totalCount
+    PlanSummaryResponse:
+      type: object
+      description: プラン一覧アイテム
+      properties:
+        id:
+          type: string
+          description: プランID
+          example: 00000000-0000-4000-8000-000000000024
+        shopifyPlanId:
+          type: string
+          description: ShopifyのプランID
+          example: test-plan-001
+        label:
+          type: string
+          description: プラン表示名
+          example: 定番
+        gramWeight:
+          type: integer
+          format: int32
+          description: 1種あたりのグラム数
+          example: 60
+        beanQuantity:
+          type: integer
+          format: int32
+          description: 豆の種類数
+          example: 4
+        price:
+          type: integer
+          format: int32
+          description: 価格
+          example: 3800
+        type:
+          type: string
+          description: プラン種別（SUBSCRIPTION / SINGLE）
+          example: SUBSCRIPTION
+        isRecommended:
+          type: boolean
+          description: おすすめバッジ
+          example: true
+      required:
+      - beanQuantity
+      - gramWeight
+      - id
+      - isRecommended
+      - label
+      - price
+      - shopifyPlanId
+      - type
     PlanDetailResponse:
       type: object
       description: プラン詳細レスポンス
@@ -1296,6 +1504,105 @@ components:
           example: SUBSCRIPTION
         isRecommended:
           type: boolean
+          description: おすすめバッジ
+          example: true
+      required:
+      - beanQuantity
+      - gramWeight
+      - id
+      - isRecommended
+      - label
+      - price
+      - shopifyPlanId
+      - type
+    CoffeeBeanListResponse:
+      type: object
+      description: コーヒー豆一覧レスポンス
+      properties:
+        items:
+          type: array
+          description: アイテム一覧
+          items:
+            $ref: "#/components/schemas/CoffeeBeanSummaryResponse"
+        totalCount:
+          type: integer
+          format: int64
+          description: 全件数
+          example: 42
+        page:
+          type: integer
+          format: int32
+          description: 現在のページ番号（0始まり）
+          example: 0
+        size:
+          type: integer
+          format: int32
+          description: 1ページあたりの件数
+          example: 20
+      required:
+      - items
+      - page
+      - size
+      - totalCount
+    CoffeeBeanSummaryResponse:
+      type: object
+      description: コーヒー豆一覧アイテム
+      properties:
+        id:
+          type: string
+          description: コーヒー豆ID
+          example: 00000000-0000-4000-8000-000000000001
+        shopId:
+          type: string
+          description: ショップID
+          example: 00000000-0000-4000-8000-000000000002
+        shopifyBeanId:
+          type: string
+          description: Shopify商品ID
+          example: test-bean-001
+        name:
+          type: string
+          description: 豆の名前
+          example: エチオピア イルガチェフェ
+        description:
+          type: string
+          description: 説明
+          example: フルーティーな香りが特徴的なコーヒー豆です。
+        origin:
+          type: string
+          description: 産地
+          example: エチオピア
+        farm:
+          type: string
+          description: 農園名
+          example: イルガチェフェ農園
+        roastLevel:
+          type: string
+          description: 焙煎度
+          example: MEDIUM
+        processingMethod:
+          type: string
+          description: 精製方法
+          example: WASHED
+        publishStatus:
+          type: string
+          description: "公開状態（DRAFT: 下書き / PUBLISHED: 公開）"
+          example: PUBLISHED
+        isSpecialty:
+          type: boolean
+          description: スペシャルティコーヒーかどうか
+          example: true
+      required:
+      - description
+      - id
+      - isSpecialty
+      - name
+      - origin
+      - processingMethod
+      - publishStatus
+      - roastLevel
+      - shopId
+      - shopifyBeanId
     CoffeeBeanDetailResponse:
       type: object
       description: コーヒー豆詳細レスポンス
@@ -1352,8 +1659,21 @@ components:
             $ref: "#/components/schemas/TasteDetail"
         isSpecialty:
           type: boolean
+          description: スペシャルティコーヒーかどうか
+          example: true
       required:
+      - description
+      - id
+      - images
+      - isSpecialty
+      - name
+      - origin
+      - processingMethod
       - publishStatus
+      - roastLevel
+      - shopId
+      - shopifyBeanId
+      - tastes
     TasteDetail:
       type: object
       description: テイスト評価詳細
@@ -1375,6 +1695,11 @@ components:
           format: int32
           description: 評価値（0-5）
           example: 4
+      required:
+      - evaluationValue
+      - id
+      - tasteId
+      - tasteName
   securitySchemes:
     Bearer:
       type: http

--- a/docs/swagger/admin-api.yml
+++ b/docs/swagger/admin-api.yml
@@ -970,6 +970,7 @@ components:
           type: boolean
           description: おすすめバッジ
           example: true
+          writeOnly: true
         shopifyPlanId:
           type: string
           description: ShopifyのプランID
@@ -997,6 +998,8 @@ components:
           type: string
           description: プラン種別（SUBSCRIPTION / SINGLE）
           example: SUBSCRIPTION
+        recommended:
+          type: boolean
     PlanResponse:
       type: object
       description: プラン編集レスポンス
@@ -1250,10 +1253,6 @@ components:
       type: object
       description: プラン詳細レスポンス
       properties:
-        isRecommended:
-          type: boolean
-          description: おすすめバッジ
-          example: true
         id:
           type: string
           description: プランID
@@ -1285,6 +1284,8 @@ components:
           type: string
           description: プラン種別（SUBSCRIPTION / SINGLE）
           example: SUBSCRIPTION
+        isRecommended:
+          type: boolean
     CoffeeBeanDetailResponse:
       type: object
       description: コーヒー豆詳細レスポンス

--- a/docs/swagger/cs-api.yml
+++ b/docs/swagger/cs-api.yml
@@ -44,9 +44,9 @@ paths:
         "200":
           description: 取得成功
           content:
-            '*/*':
+            application/json:
               schema:
-                $ref: "#/components/schemas/ShopListResponse"
+                $ref: "#/components/schemas/PagedResponseShopResponse"
               examples:
                 success:
                   summary: 取得成功例
@@ -83,7 +83,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/PlanListResponse"
+                  $ref: "#/components/schemas/PlanResponse"
               examples:
                 success:
                   summary: 取得成功例
@@ -206,7 +206,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/PagedResponseCoffeeBeanListResponse"
+                $ref: "#/components/schemas/PagedResponseCoffeeBeanResponse"
               examples:
                 success:
                   summary: 取得成功例
@@ -222,6 +222,8 @@ paths:
                       description: 花のような華やかなフレーバーと、柑橘系の明るい酸味が特徴。
                       imageUrl: https://example.com/images/ethiopia.jpg
                       shopName: 珈琲工房 まめとしょ
+                      shopPrefecture: TOKYO
+                      shopUrl: https://mametosho.example.com
                       tasteProfiles:
                       - name: 酸味
                         value: 5
@@ -238,42 +240,10 @@ paths:
                     size: 20
 components:
   schemas:
-    ShopListResponse:
-      type: object
-      description: 店舗一覧アイテム
-      properties:
-        id:
-          type: string
-          description: 店舗ID
-          example: 00000000-0000-4000-8000-000000000031
-        name:
-          type: string
-          description: 店舗名
-          example: 珈琲工房 まめとしょ
-        introduction:
-          type: string
-          description: 店舗紹介文
-          example: 東京都渋谷区にある自家焙煎珈琲店。厳選されたスペシャルティコーヒーをお届けします。
-        shopUrl:
-          type: string
-          description: 店舗URL
-          example: https://mametosho.example.com
-        prefecture:
-          type: string
-          description: 都道府県
-          example: TOKYO
-        logoImageUrl:
-          type: string
-          description: ロゴ画像URL
-          example: https://placehold.jp/100x100.png
-    PlanListResponse:
+    PlanResponse:
       type: object
       description: プラン一覧アイテム
       properties:
-        isRecommended:
-          type: boolean
-          description: おすすめバッジ
-          example: true
         id:
           type: string
           description: プランID
@@ -301,3 +271,5 @@ components:
           type: string
           description: プラン種別（SUBSCRIPTION / SINGLE）
           example: SUBSCRIPTION
+        recommended:
+          type: boolean


### PR DESCRIPTION
## 概要

管理画面（admin-frontend / admin-api）に**プランの閲覧・更新機能**を追加しました。既存の店舗(shop)・コーヒー豆(coffee-bean)管理画面の実装パターンを踏襲しています。

`plans` はShopify連携のマスタデータのため、本PRでは **閲覧＋編集のみ**（作成・削除は対象外）とし、一覧は **検索＋ページネーション** 付きで実装しています。

## 変更内容

### バックエンド (admin-api / common)
- `common`: `Plan` 集約に `update()` を追加。`PlanRepository` に `findAll(page,size,keyword)` / `findById` / `save` を追加し、`PlanRepositoryImpl`・`PlanMapper`（一覧/検索/単体取得/upsert）を実装
- `admin-api`: `PlanController` を追加
  - `GET /api/admin/plans`（一覧・表示名部分一致検索・ページネーション）
  - `GET /api/admin/plans/{id}`（詳細）
  - `PUT /api/admin/plans/{id}`（更新）
  - `FindPlansUsecase` / `GetPlanUsecase` / `UpdatePlanUsecase`、リクエスト/レスポンスDTO
- Usecaseテストを追加（`FindPlansUsecaseTest` / `GetPlanUsecaseTest` / `UpdatePlanUsecaseTest`）

### フロントエンド (admin-frontend)
- `app/(admin)/plans/`: 一覧ページ（検索＋ページネーション）、詳細＋編集モーダル（Server Actions）
- `api/plans.ts`（データフェッチ層）、`planFormSchema`（zodバリデーション）、`planLabels`
- ナビゲーションに「プラン管理」を追加
- OpenAPIクライアント型を再生成

### その他
- `origin/develop`（店・豆の公開/非公開機能 publishStatus 等）をマージ済み。生成ファイルの衝突はOpenAPI/クライアント型の再生成で解決
- なお `plans` テーブルには `publish_status` が無く、`Plan` 集約は公開/非公開機能の対象外のため、プラン側の追加対応は不要と判断

## 動作確認
- backend: `detekt` ✓ / `:admin-api:test`・`:common:test` ✓ / `generateAllOpenApiDocs` ✓
- frontend: `pnpm lint` ✓ / `pnpm build` ✓（`/plans`・`/plans/[id]` ルート生成を確認）

## レビュー観点
- 編集のみ（作成・削除なし）の方針で問題ないか
- 一覧の検索キー（プラン表示名 `label` の部分一致）の妥当性
- プランを公開/非公開機能の対象外とする判断の是非

🤖 Generated with [Claude Code](https://claude.com/claude-code)