### PR TITLE
fix: CS API Swaggerのスキーマ解決エラーとis Boolean名前不一致を修正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,11 @@
 @import frontend/CLAUDE.md
 @import admin-frontend/CLAUDE.md
 
+## Swagger YMLの編集について
+`docs/swagger/*.yml` などのSwaggerファイルは**直接編集しないこと**。
+バックエンドのコード（アノテーションや設定）から自動生成されるため、手動で変更してもビルド時に上書きされる。
+Swagger定義を変更したい場合は、バックエンドのソースコードを修正すること。
+
 ## セットアップ
 コード開発を始める前に、以下のコマンドを実行してください。
 ```shell

--- a/backend/cs-api/src/main/kotlin/com/mametosho/cs/presentation/controller/CoffeeBeanController.kt
+++ b/backend/cs-api/src/main/kotlin/com/mametosho/cs/presentation/controller/CoffeeBeanController.kt
@@ -1,8 +1,7 @@
 package com.mametosho.cs.presentation.controller
 
 import com.mametosho.cs.application.usecase.FindCoffeeBeansUsecase
-import com.mametosho.cs.presentation.dto.response.CoffeeBeanResponse
-import com.mametosho.cs.presentation.dto.response.PagedResponse
+import com.mametosho.cs.presentation.dto.response.CoffeeBeanListResponse
 import com.mametosho.domain.model.coffeebean.RoastLevel
 import com.mametosho.domain.model.shop.Prefecture
 import io.swagger.v3.oas.annotations.Operation
@@ -38,7 +37,7 @@ class CoffeeBeanController(
                 content = [
                     Content(
                         mediaType = "application/json",
-                        schema = Schema(ref = "#/components/schemas/PagedResponseCoffeeBeanResponse"),
+                        schema = Schema(implementation = CoffeeBeanListResponse::class),
                         examples = [
                             ExampleObject(
                                 name = "success",
@@ -90,8 +89,8 @@ class CoffeeBeanController(
         @RequestParam(required = false) roastLevel: RoastLevel?,
         @Parameter(description = "ロースターの都道府県", example = "TOKYO")
         @RequestParam(required = false) prefecture: Prefecture?,
-    ): ResponseEntity<PagedResponse<CoffeeBeanResponse>> {
+    ): ResponseEntity<CoffeeBeanListResponse> {
         val result = findCoffeeBeansUsecase.execute(page, size, origin, roastLevel, prefecture)
-        return ResponseEntity.ok(PagedResponse.from(result) { CoffeeBeanResponse.from(it) })
+        return ResponseEntity.ok(CoffeeBeanListResponse.from(result))
     }
 }

--- a/backend/cs-api/src/main/kotlin/com/mametosho/cs/presentation/controller/ShopController.kt
+++ b/backend/cs-api/src/main/kotlin/com/mametosho/cs/presentation/controller/ShopController.kt
@@ -1,8 +1,7 @@
 package com.mametosho.cs.presentation.controller
 
 import com.mametosho.cs.application.usecase.FindShopsUsecase
-import com.mametosho.cs.presentation.dto.response.PagedResponse
-import com.mametosho.cs.presentation.dto.response.ShopResponse
+import com.mametosho.cs.presentation.dto.response.ShopListResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.media.Content
@@ -36,7 +35,7 @@ class ShopController(
                 content = [
                     Content(
                         mediaType = "application/json",
-                        schema = Schema(ref = "#/components/schemas/PagedResponseShopResponse"),
+                        schema = Schema(implementation = ShopListResponse::class),
                         examples = [
                             ExampleObject(
                                 name = "success",
@@ -78,8 +77,8 @@ class ShopController(
         @RequestParam page: Int,
         @Parameter(description = "1ページあたりの件数", required = true, example = "20")
         @RequestParam size: Int,
-    ): ResponseEntity<PagedResponse<ShopResponse>> {
+    ): ResponseEntity<ShopListResponse> {
         val result = findShopsUsecase.execute(page, size)
-        return ResponseEntity.ok(PagedResponse.from(result) { ShopResponse.from(it) })
+        return ResponseEntity.ok(ShopListResponse.from(result))
     }
 }

--- a/backend/cs-api/src/main/kotlin/com/mametosho/cs/presentation/dto/response/CoffeeBeanListResponse.kt
+++ b/backend/cs-api/src/main/kotlin/com/mametosho/cs/presentation/dto/response/CoffeeBeanListResponse.kt
@@ -1,0 +1,26 @@
+package com.mametosho.cs.presentation.dto.response
+
+import com.mametosho.cs.application.query.result.CoffeeBeanSummaryResult
+import com.mametosho.cs.application.result.PagedResult
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "珈琲豆一覧レスポンス")
+data class CoffeeBeanListResponse(
+    @Schema(description = "アイテム一覧", requiredMode = Schema.RequiredMode.REQUIRED)
+    val items: List<CoffeeBeanResponse>,
+    @Schema(description = "全件数", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+    val totalCount: Long,
+    @Schema(description = "現在のページ番号（0始まり）", example = "0", requiredMode = Schema.RequiredMode.REQUIRED)
+    val page: Int,
+    @Schema(description = "1ページあたりの件数", example = "20", requiredMode = Schema.RequiredMode.REQUIRED)
+    val size: Int,
+) {
+    companion object {
+        fun from(pagedResult: PagedResult<CoffeeBeanSummaryResult>): CoffeeBeanListResponse = CoffeeBeanListResponse(
+            items = pagedResult.items.map { CoffeeBeanResponse.from(it) },
+            totalCount = pagedResult.totalCount,
+            page = pagedResult.page,
+            size = pagedResult.size,
+        )
+    }
+}

--- a/backend/cs-api/src/main/kotlin/com/mametosho/cs/presentation/dto/response/CoffeeBeanResponse.kt
+++ b/backend/cs-api/src/main/kotlin/com/mametosho/cs/presentation/dto/response/CoffeeBeanResponse.kt
@@ -1,5 +1,6 @@
 package com.mametosho.cs.presentation.dto.response
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import com.mametosho.cs.application.query.result.CoffeeBeanSummaryResult
 import io.swagger.v3.oas.annotations.media.Schema
 
@@ -15,7 +16,8 @@ data class CoffeeBeanResponse(
     val roastLevel: String,
     @Schema(description = "精製方法", example = "WASHED")
     val processingMethod: String,
-    @Schema(description = "スペシャルティ珈琲かどうか", example = "true")
+    @get:Schema(description = "スペシャルティ珈琲かどうか", example = "true")
+    @get:JsonProperty("isSpecialty")
     val isSpecialty: Boolean,
     @Schema(description = "説明文", example = "フルーティーな香りと明るい酸味が特徴の豆です。")
     val description: String,

--- a/backend/cs-api/src/main/kotlin/com/mametosho/cs/presentation/dto/response/PlanResponse.kt
+++ b/backend/cs-api/src/main/kotlin/com/mametosho/cs/presentation/dto/response/PlanResponse.kt
@@ -1,5 +1,6 @@
 package com.mametosho.cs.presentation.dto.response
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import com.mametosho.domain.model.plan.Plan
 import io.swagger.v3.oas.annotations.media.Schema
 
@@ -17,7 +18,8 @@ data class PlanResponse(
     val price: Int,
     @Schema(description = "プラン種別（SUBSCRIPTION / SINGLE）", example = "SUBSCRIPTION")
     val type: String,
-    @Schema(description = "おすすめバッジ", example = "true")
+    @get:Schema(description = "おすすめバッジ", example = "true")
+    @get:JsonProperty("isRecommended")
     val isRecommended: Boolean,
 ) {
     companion object {

--- a/backend/cs-api/src/main/kotlin/com/mametosho/cs/presentation/dto/response/ShopListResponse.kt
+++ b/backend/cs-api/src/main/kotlin/com/mametosho/cs/presentation/dto/response/ShopListResponse.kt
@@ -1,0 +1,26 @@
+package com.mametosho.cs.presentation.dto.response
+
+import com.mametosho.cs.application.result.PagedResult
+import com.mametosho.domain.model.shop.Shop
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "店舗一覧レスポンス")
+data class ShopListResponse(
+    @Schema(description = "アイテム一覧", requiredMode = Schema.RequiredMode.REQUIRED)
+    val items: List<ShopResponse>,
+    @Schema(description = "全件数", example = "3", requiredMode = Schema.RequiredMode.REQUIRED)
+    val totalCount: Long,
+    @Schema(description = "現在のページ番号（0始まり）", example = "0", requiredMode = Schema.RequiredMode.REQUIRED)
+    val page: Int,
+    @Schema(description = "1ページあたりの件数", example = "20", requiredMode = Schema.RequiredMode.REQUIRED)
+    val size: Int,
+) {
+    companion object {
+        fun from(pagedResult: PagedResult<Shop>): ShopListResponse = ShopListResponse(
+            items = pagedResult.items.map { ShopResponse.from(it) },
+            totalCount = pagedResult.totalCount,
+            page = pagedResult.page,
+            size = pagedResult.size,
+        )
+    }
+}

--- a/docs/swagger/cs-api.yml
+++ b/docs/swagger/cs-api.yml
@@ -46,7 +46,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/PagedResponseShopResponse"
+                $ref: "#/components/schemas/ShopListResponse"
               examples:
                 success:
                   summary: 取得成功例
@@ -206,7 +206,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/PagedResponseCoffeeBeanResponse"
+                $ref: "#/components/schemas/CoffeeBeanListResponse"
               examples:
                 success:
                   summary: 取得成功例
@@ -240,6 +240,63 @@ paths:
                     size: 20
 components:
   schemas:
+    ShopListResponse:
+      type: object
+      description: 店舗一覧レスポンス
+      properties:
+        items:
+          type: array
+          description: アイテム一覧
+          items:
+            $ref: "#/components/schemas/ShopResponse"
+        totalCount:
+          type: integer
+          format: int64
+          description: 全件数
+          example: 3
+        page:
+          type: integer
+          format: int32
+          description: 現在のページ番号（0始まり）
+          example: 0
+        size:
+          type: integer
+          format: int32
+          description: 1ページあたりの件数
+          example: 20
+      required:
+      - items
+      - page
+      - size
+      - totalCount
+    ShopResponse:
+      type: object
+      description: 店舗一覧アイテム
+      properties:
+        id:
+          type: string
+          description: 店舗ID
+          example: 00000000-0000-4000-8000-000000000031
+        name:
+          type: string
+          description: 店舗名
+          example: 珈琲工房 まめとしょ
+        introduction:
+          type: string
+          description: 店舗紹介文
+          example: 東京都渋谷区にある自家焙煎珈琲店。厳選されたスペシャルティコーヒーをお届けします。
+        shopUrl:
+          type: string
+          description: 店舗URL
+          example: https://mametosho.example.com
+        prefecture:
+          type: string
+          description: 都道府県
+          example: TOKYO
+        logoImageUrl:
+          type: string
+          description: ロゴ画像URL
+          example: https://placehold.jp/100x100.png
     PlanResponse:
       type: object
       description: プラン一覧アイテム
@@ -271,5 +328,102 @@ components:
           type: string
           description: プラン種別（SUBSCRIPTION / SINGLE）
           example: SUBSCRIPTION
-        recommended:
+        isRecommended:
           type: boolean
+          description: おすすめバッジ
+          example: true
+    CoffeeBeanListResponse:
+      type: object
+      description: 珈琲豆一覧レスポンス
+      properties:
+        items:
+          type: array
+          description: アイテム一覧
+          items:
+            $ref: "#/components/schemas/CoffeeBeanResponse"
+        totalCount:
+          type: integer
+          format: int64
+          description: 全件数
+          example: 1
+        page:
+          type: integer
+          format: int32
+          description: 現在のページ番号（0始まり）
+          example: 0
+        size:
+          type: integer
+          format: int32
+          description: 1ページあたりの件数
+          example: 20
+      required:
+      - items
+      - page
+      - size
+      - totalCount
+    CoffeeBeanResponse:
+      type: object
+      description: 珈琲豆一覧アイテム
+      properties:
+        id:
+          type: string
+          description: 珈琲豆ID
+          example: 00000000-0000-4000-8000-000000000071
+        name:
+          type: string
+          description: 珈琲豆名
+          example: エチオピア イルガチェフェ G1
+        origin:
+          type: string
+          description: 産地
+          example: エチオピア
+        roastLevel:
+          type: string
+          description: 焙煎度
+          example: LIGHT
+        processingMethod:
+          type: string
+          description: 精製方法
+          example: WASHED
+        description:
+          type: string
+          description: 説明文
+          example: フルーティーな香りと明るい酸味が特徴の豆です。
+        imageUrl:
+          type: string
+          description: メイン画像URL
+          example: https://example.com/images/coffee.jpg
+        shopName:
+          type: string
+          description: ロースター名
+          example: 山田珈琲焙煎所
+        shopPrefecture:
+          type: string
+          description: ロースターの都道府県
+          example: TOKYO
+        shopUrl:
+          type: string
+          description: ロースターのURL
+          example: https://mametosho.example.com
+        tasteProfiles:
+          type: array
+          description: テイストプロファイル一覧
+          items:
+            $ref: "#/components/schemas/TasteProfileResponse"
+        isSpecialty:
+          type: boolean
+          description: スペシャルティ珈琲かどうか
+          example: true
+    TasteProfileResponse:
+      type: object
+      description: テイストプロファイル
+      properties:
+        name:
+          type: string
+          description: テイスト名
+          example: 酸味
+        value:
+          type: integer
+          format: int32
+          description: 評価値
+          example: 60


### PR DESCRIPTION
## Summary

- `ShopListResponse` / `CoffeeBeanListResponse` クラスを新規追加し、ジェネリック `PagedResponse<T>` への手動 `$ref` 参照を廃止。`Schema(implementation = ...)` による自動生成に統一することで、Swagger UI の Resolver error を解消
- `PlanResponse.isRecommended` / `CoffeeBeanResponse.isSpecialty` に `@get:JsonProperty` + `@get:Schema` を付与し、Kotlin の `is` プレフィックス Boolean が `recommended` / `specialty` として出力されていた問題を修正
- `CLAUDE.md` に `docs/swagger/*.yml` は直接編集せずソースコードを修正して自動生成する旨を追記

## Test plan

- [ ] `./gradlew generateAllOpenApiDocs` を実行し、`docs/swagger/cs-api.yml` が正常に生成されること
- [ ] 生成された YML に `ShopListResponse` / `CoffeeBeanListResponse` / `isRecommended` / `isSpecialty` が正しく含まれること
- [ ] Swagger UI（index-cs.html）で `/api/shops`・`/api/plans`・`/api/coffeeBeans` のレスポンス example とスキーマが正常に表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)