### PR TITLE
feat: 店舗のparticipationStatusを実装（参画ライフサイクル管理）

### DIFF
--- a/admin-frontend/src/api/generated/admin-api.ts
+++ b/admin-frontend/src/api/generated/admin-api.ts
@@ -229,10 +229,10 @@ export interface components {
        */
       prefecture: string;
       /**
-       * @description 公開状態（DRAFT: 下書き / PUBLISHED: 公開）
-       * @example PUBLISHED
+       * @description 参画ステータス（BEFORE_PARTICIPATION: 参画前 / PARTICIPATING: 参画中 / DROPPED: 参画落ち）
+       * @example PARTICIPATING
        */
-      publishStatus: string;
+      participationStatus: string;
     };
     /** @description 店舗登録レスポンス */
     ShopResponse: {
@@ -431,10 +431,10 @@ export interface components {
        */
       prefecture: string;
       /**
-       * @description 公開状態（DRAFT: 下書き / PUBLISHED: 公開）
-       * @example DRAFT
+       * @description 参画ステータス（BEFORE_PARTICIPATION: 参画前 / PARTICIPATING: 参画中）
+       * @example BEFORE_PARTICIPATION
        */
-      publishStatus: string;
+      participationStatus: string;
     };
     /** @description コーヒー豆登録リクエスト */
     CreateCoffeeBeanRequest: {
@@ -584,10 +584,10 @@ export interface components {
        */
       prefecture: string;
       /**
-       * @description 公開状態（DRAFT: 下書き / PUBLISHED: 公開）
-       * @example PUBLISHED
+       * @description 参画ステータス（BEFORE_PARTICIPATION: 参画前 / PARTICIPATING: 参画中 / DROPPED: 参画落ち）
+       * @example PARTICIPATING
        */
-      publishStatus: string;
+      participationStatus: string;
     };
     /** @description 画像詳細 */
     ImageDetail: {
@@ -645,10 +645,10 @@ export interface components {
        */
       prefecture: string;
       /**
-       * @description 公開状態（DRAFT: 下書き / PUBLISHED: 公開）
-       * @example PUBLISHED
+       * @description 参画ステータス（BEFORE_PARTICIPATION: 参画前 / PARTICIPATING: 参画中 / DROPPED: 参画落ち）
+       * @example PARTICIPATING
        */
-      publishStatus: string;
+      participationStatus: string;
       /** @description 画像一覧 */
       images: components["schemas"]["ImageDetail"][];
     };

--- a/admin-frontend/src/app/(admin)/coffee-beans/[id]/_components/editCoffeeBeanAction.ts
+++ b/admin-frontend/src/app/(admin)/coffee-beans/[id]/_components/editCoffeeBeanAction.ts
@@ -63,6 +63,12 @@ export async function editCoffeeBeanAction(
         values,
       };
     }
+    if (response.status === 422) {
+      return {
+        error: "無効化されたコーヒー豆は更新できません。",
+        values,
+      };
+    }
     const body = await response.json().catch(() => null);
     const message = body?.message ?? "コーヒー豆の更新に失敗しました。";
     return { error: message, values };

--- a/admin-frontend/src/app/(admin)/shops/[id]/_components/EditShopModal.tsx
+++ b/admin-frontend/src/app/(admin)/shops/[id]/_components/EditShopModal.tsx
@@ -11,7 +11,10 @@ import type { ShopDetail } from "@/api/shops";
 import { PREFECTURE_OPTIONS } from "@/app/(admin)/shops/_lib/prefecture";
 import { ImageUploadField } from "@/components/ImageUploadField";
 import modalStyles from "@/components/modal.module.css";
-import { ToggleField } from "@/components/ToggleField";
+import {
+  PARTICIPATION_STATUS_LABELS,
+  PARTICIPATION_STATUS_OPTIONS,
+} from "@/components/participationStatus";
 import { type EditShopState, editShopAction } from "./editShopAction";
 
 const initialState: EditShopState = {};
@@ -37,7 +40,7 @@ export function EditShopModal({
   const particularId = useId();
   const shopUrlId = useId();
   const prefectureId = useId();
-  const publishStatusId = useId();
+  const participationStatusId = useId();
 
   useEffect(() => {
     const dialog = dialogRef.current;
@@ -57,7 +60,15 @@ export function EditShopModal({
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    startTransition(() => formAction(new FormData(e.currentTarget)));
+    const formData = new FormData(e.currentTarget);
+    const nextStatus = formData.get("participationStatus");
+    if (nextStatus === "DROPPED") {
+      const confirmed = window.confirm(
+        "店舗を「参画落ち」にすると、この店舗の全コーヒー豆が無効化され、元に戻すことができません。\n\n本当に参画落ちにしますか？",
+      );
+      if (!confirmed) return;
+    }
+    startTransition(() => formAction(formData));
   };
 
   return (
@@ -207,16 +218,54 @@ export function EditShopModal({
           ))}
         </div>
 
-        <ToggleField
-          id={publishStatusId}
-          name="publishStatus"
-          label="公開状態"
-          required
-          defaultChecked={
-            (state.values?.publishStatus ?? shop.publishStatus) === "PUBLISHED"
-          }
-          errors={state.fieldErrors?.publishStatus}
-        />
+        <div className={modalStyles.field}>
+          <label htmlFor={participationStatusId} className={modalStyles.label}>
+            参画ステータス
+            <span className={modalStyles.required}>*</span>
+          </label>
+          {shop.participationStatus === "DROPPED" ? (
+            <>
+              <input type="hidden" name="participationStatus" value="DROPPED" />
+              <input
+                id={participationStatusId}
+                type="text"
+                value={PARTICIPATION_STATUS_LABELS.DROPPED}
+                className={modalStyles.input}
+                disabled
+                readOnly
+              />
+            </>
+          ) : (
+            <select
+              id={participationStatusId}
+              name="participationStatus"
+              defaultValue={
+                state.values?.participationStatus ?? shop.participationStatus
+              }
+              className={modalStyles.input}
+            >
+              {(shop.participationStatus === "PARTICIPATING"
+                ? [
+                    ...PARTICIPATION_STATUS_OPTIONS,
+                    {
+                      value: "DROPPED" as const,
+                      label: PARTICIPATION_STATUS_LABELS.DROPPED,
+                    },
+                  ]
+                : PARTICIPATION_STATUS_OPTIONS
+              ).map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          )}
+          {state.fieldErrors?.participationStatus?.map((msg) => (
+            <span key={msg} className={modalStyles.fieldError}>
+              {msg}
+            </span>
+          ))}
+        </div>
 
         <ImageUploadField
           imageTypes={[{ value: "MAIN", label: "メイン" }]}

--- a/admin-frontend/src/app/(admin)/shops/[id]/_components/EditShopModal.tsx
+++ b/admin-frontend/src/app/(admin)/shops/[id]/_components/EditShopModal.tsx
@@ -14,6 +14,7 @@ import modalStyles from "@/components/modal.module.css";
 import {
   PARTICIPATION_STATUS_LABELS,
   PARTICIPATION_STATUS_OPTIONS,
+  PARTICIPATION_STATUS_OPTIONS_WITH_DROPPED,
 } from "@/components/participationStatus";
 import { type EditShopState, editShopAction } from "./editShopAction";
 
@@ -245,13 +246,7 @@ export function EditShopModal({
               className={modalStyles.input}
             >
               {(shop.participationStatus === "PARTICIPATING"
-                ? [
-                    ...PARTICIPATION_STATUS_OPTIONS,
-                    {
-                      value: "DROPPED" as const,
-                      label: PARTICIPATION_STATUS_LABELS.DROPPED,
-                    },
-                  ]
+                ? PARTICIPATION_STATUS_OPTIONS_WITH_DROPPED
                 : PARTICIPATION_STATUS_OPTIONS
               ).map((opt) => (
                 <option key={opt.value} value={opt.value}>

--- a/admin-frontend/src/app/(admin)/shops/[id]/_components/ShopDetail.tsx
+++ b/admin-frontend/src/app/(admin)/shops/[id]/_components/ShopDetail.tsx
@@ -2,7 +2,7 @@ import Image from "next/image";
 import Link from "next/link";
 import type { ShopDetail as ShopDetailType } from "@/api/shops";
 import { getPrefectureLabel } from "@/app/(admin)/shops/_lib/prefecture";
-import { PublishStatusBadge } from "@/components/PublishStatusBadge";
+import { ParticipationStatusBadge } from "@/components/ParticipationStatusBadge";
 import { ShopActions } from "./ShopActions";
 import styles from "./ShopDetail.module.css";
 
@@ -22,9 +22,9 @@ export function ShopDetail({ shop }: { shop: ShopDetailType }) {
       <div className={styles.content}>
         <dl className={styles.fieldList}>
           <div className={styles.field}>
-            <dt className={styles.fieldLabel}>公開状態</dt>
+            <dt className={styles.fieldLabel}>参画ステータス</dt>
             <dd className={styles.fieldValue}>
-              <PublishStatusBadge status={shop.publishStatus} />
+              <ParticipationStatusBadge status={shop.participationStatus} />
             </dd>
           </div>
 

--- a/admin-frontend/src/app/(admin)/shops/[id]/_components/editShopAction.ts
+++ b/admin-frontend/src/app/(admin)/shops/[id]/_components/editShopAction.ts
@@ -7,7 +7,6 @@ import {
   type ShopFormState,
   shopFieldsSchema,
 } from "@/app/(admin)/shops/_lib/shopFormSchema";
-import { isChecked } from "@/lib/formData";
 
 const editShopSchema = shopFieldsSchema.extend({
   id: z.string(),
@@ -26,7 +25,7 @@ export async function editShopAction(
     particular: (formData.get("particular") as string) ?? "",
     shopUrl: (formData.get("shopUrl") as string) ?? "",
     prefecture: (formData.get("prefecture") as string) ?? "",
-    publishStatus: isChecked(formData, "publishStatus") ? "PUBLISHED" : "DRAFT",
+    participationStatus: (formData.get("participationStatus") as string) ?? "",
   };
 
   const result = editShopSchema.safeParse({
@@ -58,7 +57,7 @@ export async function editShopAction(
     particular,
     shopUrl,
     prefecture,
-    publishStatus,
+    participationStatus,
   } = result.data;
 
   const response = await multipartRequest(
@@ -71,7 +70,7 @@ export async function editShopAction(
       particular,
       shopUrl,
       prefecture,
-      publishStatus,
+      participationStatus,
     },
     formData,
   );
@@ -80,6 +79,12 @@ export async function editShopAction(
     if (response.status === 409) {
       return {
         error: "このShopify Shop IDは既に登録されています。",
+        values,
+      };
+    }
+    if (response.status === 422) {
+      return {
+        error: "この店舗のステータスを変更することはできません。",
         values,
       };
     }

--- a/admin-frontend/src/app/(admin)/shops/_components/CreateShopModal.tsx
+++ b/admin-frontend/src/app/(admin)/shops/_components/CreateShopModal.tsx
@@ -10,7 +10,7 @@ import {
 import { PREFECTURE_OPTIONS } from "@/app/(admin)/shops/_lib/prefecture";
 import { ImageUploadField } from "@/components/ImageUploadField";
 import styles from "@/components/modal.module.css";
-import { ToggleField } from "@/components/ToggleField";
+import { PARTICIPATION_STATUS_OPTIONS } from "@/components/participationStatus";
 import { type CreateShopState, createShopAction } from "./createShopAction";
 
 const initialState: CreateShopState = {};
@@ -34,7 +34,7 @@ export function CreateShopModal({
   const particularId = useId();
   const shopUrlId = useId();
   const prefectureId = useId();
-  const publishStatusId = useId();
+  const participationStatusId = useId();
 
   useEffect(() => {
     const dialog = dialogRef.current;
@@ -205,16 +205,31 @@ export function CreateShopModal({
           ))}
         </div>
 
-        <ToggleField
-          id={publishStatusId}
-          name="publishStatus"
-          label="公開状態"
-          required
-          defaultChecked={
-            (state.values?.publishStatus ?? "DRAFT") === "PUBLISHED"
-          }
-          errors={state.fieldErrors?.publishStatus}
-        />
+        <div className={styles.field}>
+          <label htmlFor={participationStatusId} className={styles.label}>
+            参画ステータス
+            <span className={styles.required}>*</span>
+          </label>
+          <select
+            id={participationStatusId}
+            name="participationStatus"
+            defaultValue={
+              state.values?.participationStatus ?? "BEFORE_PARTICIPATION"
+            }
+            className={styles.input}
+          >
+            {PARTICIPATION_STATUS_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+          {state.fieldErrors?.participationStatus?.map((msg) => (
+            <span key={msg} className={styles.fieldError}>
+              {msg}
+            </span>
+          ))}
+        </div>
 
         <ImageUploadField imageTypes={[{ value: "MAIN", label: "メイン" }]} />
         <ImageUploadField

--- a/admin-frontend/src/app/(admin)/shops/_components/ShopListTable.tsx
+++ b/admin-frontend/src/app/(admin)/shops/_components/ShopListTable.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import type { ShopListResponse } from "@/api/shops";
 import styles from "@/components/list-page.module.css";
 import { Pagination } from "@/components/Pagination";
-import { PublishStatusBadge } from "@/components/PublishStatusBadge";
+import { ParticipationStatusBadge } from "@/components/ParticipationStatusBadge";
 import { CreateShopButton } from "./CreateShopButton";
 
 export function ShopListTable({
@@ -32,7 +32,7 @@ export function ShopListTable({
               <th>紹介文</th>
               <th>こだわり</th>
               <th>店舗URL</th>
-              <th>公開状態</th>
+              <th>参画ステータス</th>
             </tr>
           </thead>
           <tbody>
@@ -74,7 +74,9 @@ export function ShopListTable({
                 </td>
                 <td>
                   <Link href={`/shops/${shop.id}`} className={styles.rowLink}>
-                    <PublishStatusBadge status={shop.publishStatus} />
+                    <ParticipationStatusBadge
+                      status={shop.participationStatus}
+                    />
                   </Link>
                 </td>
               </tr>

--- a/admin-frontend/src/app/(admin)/shops/_components/createShopAction.ts
+++ b/admin-frontend/src/app/(admin)/shops/_components/createShopAction.ts
@@ -6,7 +6,6 @@ import {
   type ShopFormState,
   shopFieldsSchema,
 } from "@/app/(admin)/shops/_lib/shopFormSchema";
-import { isChecked } from "@/lib/formData";
 
 export type CreateShopState = ShopFormState;
 
@@ -21,7 +20,7 @@ export async function createShopAction(
     particular: (formData.get("particular") as string) ?? "",
     shopUrl: (formData.get("shopUrl") as string) ?? "",
     prefecture: (formData.get("prefecture") as string) ?? "",
-    publishStatus: isChecked(formData, "publishStatus") ? "PUBLISHED" : "DRAFT",
+    participationStatus: (formData.get("participationStatus") as string) ?? "",
   };
 
   const result = shopFieldsSchema.safeParse(values);
@@ -46,7 +45,7 @@ export async function createShopAction(
     particular,
     shopUrl,
     prefecture,
-    publishStatus,
+    participationStatus,
   } = result.data;
 
   const response = await multipartRequest(
@@ -59,7 +58,7 @@ export async function createShopAction(
       particular,
       shopUrl,
       prefecture,
-      publishStatus,
+      participationStatus,
     },
     formData,
   );

--- a/admin-frontend/src/app/(admin)/shops/_lib/shopFormSchema.ts
+++ b/admin-frontend/src/app/(admin)/shops/_lib/shopFormSchema.ts
@@ -33,9 +33,12 @@ export const shopFieldsSchema = z.object({
   prefecture: z.enum(prefectureValues, {
     error: "都道府県を選択してください。",
   }),
-  publishStatus: z.enum(["DRAFT", "PUBLISHED"], {
-    error: "公開状態を選択してください。",
-  }),
+  participationStatus: z.enum(
+    ["BEFORE_PARTICIPATION", "PARTICIPATING", "DROPPED"],
+    {
+      error: "参画ステータスを選択してください。",
+    },
+  ),
 });
 
 export type ShopFormValues = {
@@ -45,7 +48,7 @@ export type ShopFormValues = {
   particular?: string;
   shopUrl?: string;
   prefecture?: string;
-  publishStatus?: string;
+  participationStatus?: string;
 };
 
 export type ShopFormState = {
@@ -58,7 +61,7 @@ export type ShopFormState = {
     particular?: string[];
     shopUrl?: string[];
     prefecture?: string[];
-    publishStatus?: string[];
+    participationStatus?: string[];
   };
   values?: ShopFormValues;
 };

--- a/admin-frontend/src/components/ParticipationStatusBadge.module.css
+++ b/admin-frontend/src/components/ParticipationStatusBadge.module.css
@@ -1,0 +1,26 @@
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.5;
+  white-space: nowrap;
+}
+
+.participating {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.beforeParticipation {
+  background: var(--color-bg-page);
+  color: var(--color-text-secondary);
+  border: 1px solid var(--color-border);
+}
+
+.dropped {
+  background: #fee2e2;
+  color: #991b1b;
+}

--- a/admin-frontend/src/components/ParticipationStatusBadge.tsx
+++ b/admin-frontend/src/components/ParticipationStatusBadge.tsx
@@ -1,0 +1,16 @@
+import styles from "./ParticipationStatusBadge.module.css";
+import { getParticipationStatusLabel } from "./participationStatus";
+
+export function ParticipationStatusBadge({ status }: { status: string }) {
+  const badgeClass =
+    status === "PARTICIPATING"
+      ? styles.participating
+      : status === "DROPPED"
+        ? styles.dropped
+        : styles.beforeParticipation;
+  return (
+    <span className={`${styles.badge} ${badgeClass}`}>
+      {getParticipationStatusLabel(status)}
+    </span>
+  );
+}

--- a/admin-frontend/src/components/participationStatus.ts
+++ b/admin-frontend/src/components/participationStatus.ts
@@ -26,6 +26,14 @@ export const PARTICIPATION_STATUS_OPTIONS: {
   },
 ];
 
+export const PARTICIPATION_STATUS_OPTIONS_WITH_DROPPED: {
+  value: ParticipationStatus;
+  label: string;
+}[] = [
+  ...PARTICIPATION_STATUS_OPTIONS,
+  { value: "DROPPED", label: PARTICIPATION_STATUS_LABELS.DROPPED },
+];
+
 export function getParticipationStatusLabel(value: string): string {
   return PARTICIPATION_STATUS_LABELS[value as ParticipationStatus] ?? value;
 }

--- a/admin-frontend/src/components/participationStatus.ts
+++ b/admin-frontend/src/components/participationStatus.ts
@@ -1,0 +1,31 @@
+export const PARTICIPATION_STATUSES = [
+  "BEFORE_PARTICIPATION",
+  "PARTICIPATING",
+  "DROPPED",
+] as const;
+export type ParticipationStatus = (typeof PARTICIPATION_STATUSES)[number];
+
+export const PARTICIPATION_STATUS_LABELS: Record<ParticipationStatus, string> =
+  {
+    BEFORE_PARTICIPATION: "参画前",
+    PARTICIPATING: "参画中",
+    DROPPED: "参画落ち",
+  };
+
+export const PARTICIPATION_STATUS_OPTIONS: {
+  value: ParticipationStatus;
+  label: string;
+}[] = [
+  {
+    value: "BEFORE_PARTICIPATION",
+    label: PARTICIPATION_STATUS_LABELS.BEFORE_PARTICIPATION,
+  },
+  {
+    value: "PARTICIPATING",
+    label: PARTICIPATION_STATUS_LABELS.PARTICIPATING,
+  },
+];
+
+export function getParticipationStatusLabel(value: string): string {
+  return PARTICIPATION_STATUS_LABELS[value as ParticipationStatus] ?? value;
+}

--- a/backend/admin-api/build.gradle.kts
+++ b/backend/admin-api/build.gradle.kts
@@ -54,6 +54,7 @@ dependencies {
 	testImplementation(libs.kotlin.test.junit5)
 	testImplementation(libs.testcontainers.mysql)
 	testImplementation(libs.testcontainers.junit.jupiter)
+	testImplementation(libs.archunit.junit5)
 	testRuntimeOnly(libs.junit.platform.launcher)
 }
 

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/application/usecase/CreateShopUsecase.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/application/usecase/CreateShopUsecase.kt
@@ -38,7 +38,7 @@ class CreateShopUsecase(
             particular = request.particular,
             shopUrl = request.shopUrl,
             prefecture = Prefecture.valueOf(request.prefecture),
-            publishStatus = request.publishStatus,
+            participationStatus = request.participationStatus,
             images = images,
             id = shopId,
         )

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/application/usecase/UpdateShopUsecase.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/application/usecase/UpdateShopUsecase.kt
@@ -3,11 +3,13 @@ package com.mametosho.admin.application.usecase
 import com.mametosho.admin.application.service.deleteImages
 import com.mametosho.admin.application.service.uploadImages
 import com.mametosho.admin.presentation.dto.request.UpdateShopRequest
+import com.mametosho.domain.model.shared.ParticipationStatus
 import com.mametosho.domain.model.shop.Prefecture
 import com.mametosho.domain.model.shop.Shop
 import com.mametosho.domain.model.shop.ShopId
 import com.mametosho.domain.repository.ShopRepository
 import com.mametosho.domain.service.ImageStorageService
+import com.mametosho.domain.service.ShopDropDomainService
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.multipart.MultipartFile
@@ -15,6 +17,7 @@ import org.springframework.web.multipart.MultipartFile
 @Service
 class UpdateShopUsecase(
     private val shopRepository: ShopRepository,
+    private val shopDropDomainService: ShopDropDomainService,
     private val imageStorageService: ImageStorageService,
 ) {
     @Transactional
@@ -46,10 +49,14 @@ class UpdateShopUsecase(
             particular = request.particular,
             shopUrl = request.shopUrl,
             prefecture = Prefecture.valueOf(request.prefecture),
-            publishStatus = request.publishStatus,
+            participationStatus = request.participationStatus,
             images = images,
         )
         shopRepository.save(updatedShop)
+
+        if (updatedShop.participationStatus == ParticipationStatus.DROPPED) {
+            shopDropDomainService.invalidateCoffeeBeans(shopId)
+        }
 
         if (imageFiles.isNotEmpty()) {
             imageStorageService.deleteImages(oldImageUrls)

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/config/GlobalExceptionHandler.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/config/GlobalExceptionHandler.kt
@@ -54,6 +54,24 @@ class GlobalExceptionHandler {
         )
     }
 
+    @ExceptionHandler(IllegalStateException::class)
+    fun handleIllegalState(
+        ex: IllegalStateException,
+        request: HttpServletRequest,
+    ): ResponseEntity<ErrorResponse> {
+        log.warn("{} {}: {}", request.method, request.requestURI, ex.message)
+        val status = HttpStatus.UNPROCESSABLE_ENTITY
+        return ResponseEntity.status(status).body(
+            ErrorResponse(
+                timestamp = OffsetDateTime.now(),
+                status = status.value(),
+                error = status.reasonPhrase,
+                message = ex.message,
+                path = request.requestURI,
+            ),
+        )
+    }
+
     @ExceptionHandler(DuplicateKeyException::class)
     fun handleDuplicateKey(
         ex: DuplicateKeyException,

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/controller/ShopController.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/controller/ShopController.kt
@@ -72,7 +72,7 @@ class ShopController(
                                           "particular": "厳選された豆のみを使用しています。",
                                           "shopUrl": "https://example.com",
                                           "prefecture": "TOKYO",
-                                          "publishStatus": "PUBLISHED"
+                                          "participationStatus": "PARTICIPATING"
                                         }
                                       ],
                                       "totalCount": 1,

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/request/CreateShopRequest.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/request/CreateShopRequest.kt
@@ -23,9 +23,9 @@ data class CreateShopRequest(
     val prefecture: String,
 
     @Schema(
-        description = "公開状態（DRAFT: 下書き / PUBLISHED: 公開）",
-        example = "DRAFT",
+        description = "参画ステータス（BEFORE_PARTICIPATION: 参画前 / PARTICIPATING: 参画中）",
+        example = "BEFORE_PARTICIPATION",
         requiredMode = Schema.RequiredMode.REQUIRED,
     )
-    val publishStatus: String,
+    val participationStatus: String,
 )

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/request/UpdateShopRequest.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/request/UpdateShopRequest.kt
@@ -23,9 +23,9 @@ data class UpdateShopRequest(
     val prefecture: String,
 
     @Schema(
-        description = "公開状態（DRAFT: 下書き / PUBLISHED: 公開）",
-        example = "PUBLISHED",
+        description = "参画ステータス（BEFORE_PARTICIPATION: 参画前 / PARTICIPATING: 参画中 / DROPPED: 参画落ち）",
+        example = "PARTICIPATING",
         requiredMode = Schema.RequiredMode.REQUIRED,
     )
-    val publishStatus: String,
+    val participationStatus: String,
 )

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/ShopDetailResponse.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/ShopDetailResponse.kt
@@ -21,11 +21,11 @@ data class ShopDetailResponse(
     @Schema(description = "都道府県", example = "TOKYO", requiredMode = Schema.RequiredMode.REQUIRED)
     val prefecture: String,
     @Schema(
-        description = "公開状態（DRAFT: 下書き / PUBLISHED: 公開）",
-        example = "PUBLISHED",
+        description = "参画ステータス（BEFORE_PARTICIPATION: 参画前 / PARTICIPATING: 参画中 / DROPPED: 参画落ち）",
+        example = "PARTICIPATING",
         requiredMode = Schema.RequiredMode.REQUIRED,
     )
-    val publishStatus: String,
+    val participationStatus: String,
     @Schema(description = "画像一覧", requiredMode = Schema.RequiredMode.REQUIRED)
     val images: List<ImageDetail>,
 ) {
@@ -56,7 +56,7 @@ data class ShopDetailResponse(
             particular = shop.particular,
             shopUrl = shop.shopUrl,
             prefecture = shop.prefecture.name,
-            publishStatus = shop.publishStatus.name,
+            participationStatus = shop.participationStatus.name,
             images = shop.images.map { ImageDetail.from(it) },
         )
     }

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/ShopSummaryResponse.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/ShopSummaryResponse.kt
@@ -20,11 +20,11 @@ data class ShopSummaryResponse(
     @Schema(description = "都道府県", example = "TOKYO", requiredMode = Schema.RequiredMode.REQUIRED)
     val prefecture: String,
     @Schema(
-        description = "公開状態（DRAFT: 下書き / PUBLISHED: 公開）",
-        example = "PUBLISHED",
+        description = "参画ステータス（BEFORE_PARTICIPATION: 参画前 / PARTICIPATING: 参画中 / DROPPED: 参画落ち）",
+        example = "PARTICIPATING",
         requiredMode = Schema.RequiredMode.REQUIRED,
     )
-    val publishStatus: String,
+    val participationStatus: String,
 ) {
     companion object {
         fun from(shop: Shop): ShopSummaryResponse = ShopSummaryResponse(
@@ -35,7 +35,7 @@ data class ShopSummaryResponse(
             particular = shop.particular,
             shopUrl = shop.shopUrl,
             prefecture = shop.prefecture.name,
-            publishStatus = shop.publishStatus.name,
+            participationStatus = shop.participationStatus.name,
         )
     }
 }

--- a/backend/admin-api/src/test/kotlin/com/mametosho/admin/application/usecase/CreateCoffeeBeanUsecaseTest.kt
+++ b/backend/admin-api/src/test/kotlin/com/mametosho/admin/application/usecase/CreateCoffeeBeanUsecaseTest.kt
@@ -3,8 +3,10 @@ package com.mametosho.admin.application.usecase
 import com.mametosho.admin.presentation.dto.request.CreateCoffeeBeanRequest
 import com.mametosho.admin.test.FakeImageStorageService
 import com.mametosho.domain.model.coffeebean.CoffeeBean
+import com.mametosho.domain.model.coffeebean.CoffeeBeanId
 import com.mametosho.domain.model.coffeebean.ProcessingMethod
 import com.mametosho.domain.model.coffeebean.RoastLevel
+import com.mametosho.domain.model.shop.ShopId
 import com.mametosho.domain.repository.CoffeeBeanRepository
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.assertThrows
@@ -23,8 +25,9 @@ class CreateCoffeeBeanUsecaseTest {
             savedBeans.add(coffeeBean)
         }
 
-        override fun findById(id: com.mametosho.domain.model.coffeebean.CoffeeBeanId): CoffeeBean? = null
-        override fun deleteById(id: com.mametosho.domain.model.coffeebean.CoffeeBeanId) = Unit
+        override fun findById(id: CoffeeBeanId): CoffeeBean? = null
+        override fun deleteById(id: CoffeeBeanId) = Unit
+        override fun invalidateByShopId(shopId: ShopId) = Unit
     }
 
     private val usecase = CreateCoffeeBeanUsecase(fakeRepository, FakeImageStorageService)

--- a/backend/admin-api/src/test/kotlin/com/mametosho/admin/application/usecase/CreateShopUsecaseTest.kt
+++ b/backend/admin-api/src/test/kotlin/com/mametosho/admin/application/usecase/CreateShopUsecaseTest.kt
@@ -1,7 +1,7 @@
 package com.mametosho.admin.application.usecase
 
 import com.mametosho.admin.presentation.dto.request.CreateShopRequest
-import com.mametosho.domain.model.shared.PublishStatus
+import com.mametosho.domain.model.shared.ParticipationStatus
 import com.mametosho.domain.model.shop.Shop
 import com.mametosho.domain.model.shop.ShopId
 import com.mametosho.domain.repository.ShopRepository
@@ -28,7 +28,7 @@ class CreateShopUsecaseTest {
             page: Int,
             size: Int,
             name: String?,
-            publishStatus: PublishStatus?,
+            participationStatus: ParticipationStatus?,
         ): Pair<List<Shop>, Long> = Pair(emptyList(), 0L)
         override fun deleteById(id: ShopId) = Unit
     }
@@ -44,7 +44,7 @@ class CreateShopUsecaseTest {
         particular: String? = "テストこだわり",
         shopUrl: String = "https://example.com",
         prefecture: String = "TOKYO",
-        publishStatus: String = "PUBLISHED",
+        participationStatus: String = "BEFORE_PARTICIPATION",
     ): CreateShopRequest = CreateShopRequest(
         shopifyShopId = shopifyShopId,
         name = name,
@@ -52,7 +52,7 @@ class CreateShopUsecaseTest {
         particular = particular,
         shopUrl = shopUrl,
         prefecture = prefecture,
-        publishStatus = publishStatus,
+        participationStatus = participationStatus,
     )
 
     @Nested
@@ -118,6 +118,13 @@ class CreateShopUsecaseTest {
         fun `LOGO画像なしの場合は例外が発生する`() {
             assertThrows<IllegalArgumentException> {
                 usecase.execute(createRequest(), emptyList(), emptyList())
+            }
+        }
+
+        @Test
+        fun `初期ステータスにDROPPEDを指定すると例外が発生する`() {
+            assertThrows<IllegalArgumentException> {
+                usecase.execute(createRequest(participationStatus = "DROPPED"), listOf(logoFile), listOf("LOGO"))
             }
         }
     }

--- a/backend/admin-api/src/test/kotlin/com/mametosho/admin/application/usecase/DeleteCoffeeBeanUsecaseTest.kt
+++ b/backend/admin-api/src/test/kotlin/com/mametosho/admin/application/usecase/DeleteCoffeeBeanUsecaseTest.kt
@@ -2,6 +2,7 @@ package com.mametosho.admin.application.usecase
 
 import com.mametosho.domain.model.coffeebean.CoffeeBean
 import com.mametosho.domain.model.coffeebean.CoffeeBeanId
+import com.mametosho.domain.model.shop.ShopId
 import com.mametosho.domain.repository.CoffeeBeanRepository
 import com.mametosho.admin.test.FakeImageStorageService
 import org.junit.jupiter.api.Nested
@@ -39,6 +40,7 @@ class DeleteCoffeeBeanUsecaseTest {
         override fun deleteById(id: CoffeeBeanId) {
             deletedIds.add(id)
         }
+        override fun invalidateByShopId(shopId: ShopId) = Unit
     }
 
     private val usecase = DeleteCoffeeBeanUsecase(fakeRepository, FakeImageStorageService)

--- a/backend/admin-api/src/test/kotlin/com/mametosho/admin/application/usecase/DeleteShopUsecaseTest.kt
+++ b/backend/admin-api/src/test/kotlin/com/mametosho/admin/application/usecase/DeleteShopUsecaseTest.kt
@@ -1,7 +1,7 @@
 package com.mametosho.admin.application.usecase
 
 import com.mametosho.domain.model.shared.ImageUrl
-import com.mametosho.domain.model.shared.PublishStatus
+import com.mametosho.domain.model.shared.ParticipationStatus
 import com.mametosho.domain.model.shop.Shop
 import com.mametosho.domain.model.shop.ShopId
 import com.mametosho.domain.model.shop.ShopImage
@@ -30,7 +30,7 @@ class DeleteShopUsecaseTest {
         particular = "テストこだわり",
         shopUrl = "https://example.com",
         prefecture = Prefecture.TOKYO,
-        publishStatus = PublishStatus.PUBLISHED,
+        participationStatus = ParticipationStatus.PARTICIPATING,
         images = listOf(
             ShopImage(
                 id = ShopImageId("00000000-0000-4000-8000-000000000011"),
@@ -58,7 +58,7 @@ class DeleteShopUsecaseTest {
             page: Int,
             size: Int,
             name: String?,
-            publishStatus: PublishStatus?,
+            participationStatus: ParticipationStatus?,
         ): Pair<List<Shop>, Long> = Pair(emptyList(), 0L)
         override fun deleteById(id: ShopId) {
             deletedIds.add(id)

--- a/backend/admin-api/src/test/kotlin/com/mametosho/admin/application/usecase/UpdateCoffeeBeanUsecaseTest.kt
+++ b/backend/admin-api/src/test/kotlin/com/mametosho/admin/application/usecase/UpdateCoffeeBeanUsecaseTest.kt
@@ -6,6 +6,7 @@ import com.mametosho.domain.model.coffeebean.CoffeeBean
 import com.mametosho.domain.model.coffeebean.CoffeeBeanId
 import com.mametosho.domain.model.coffeebean.ProcessingMethod
 import com.mametosho.domain.model.coffeebean.RoastLevel
+import com.mametosho.domain.model.shop.ShopId
 import com.mametosho.domain.repository.CoffeeBeanRepository
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.assertThrows
@@ -44,6 +45,7 @@ class UpdateCoffeeBeanUsecaseTest {
         }
 
         override fun deleteById(id: CoffeeBeanId) = Unit
+        override fun invalidateByShopId(shopId: ShopId) = Unit
     }
 
     private val usecase = UpdateCoffeeBeanUsecase(fakeRepository, FakeImageStorageService)

--- a/backend/admin-api/src/test/kotlin/com/mametosho/admin/application/usecase/UpdateShopUsecaseTest.kt
+++ b/backend/admin-api/src/test/kotlin/com/mametosho/admin/application/usecase/UpdateShopUsecaseTest.kt
@@ -2,7 +2,7 @@ package com.mametosho.admin.application.usecase
 
 import com.mametosho.admin.presentation.dto.request.UpdateShopRequest
 import com.mametosho.domain.model.shared.ImageUrl
-import com.mametosho.domain.model.shared.PublishStatus
+import com.mametosho.domain.model.shared.ParticipationStatus
 import com.mametosho.domain.model.shop.Shop
 import com.mametosho.domain.model.shop.ShopId
 import com.mametosho.domain.model.shop.ShopImage
@@ -10,7 +10,12 @@ import com.mametosho.domain.model.shop.ShopImageId
 import com.mametosho.domain.model.shop.ShopImageType
 import com.mametosho.domain.model.shop.Prefecture
 import com.mametosho.domain.model.shop.ShopifyShopId
+import com.mametosho.domain.model.shop.ShopId as ShopIdModel
+import com.mametosho.domain.repository.CoffeeBeanRepository
+import com.mametosho.domain.model.coffeebean.CoffeeBean
+import com.mametosho.domain.model.coffeebean.CoffeeBeanId
 import com.mametosho.domain.repository.ShopRepository
+import com.mametosho.domain.service.ShopDropDomainService
 import com.mametosho.admin.test.FakeImageStorageService
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.assertThrows
@@ -32,7 +37,7 @@ class UpdateShopUsecaseTest {
         particular = "既存こだわり",
         shopUrl = "https://existing.example.com",
         prefecture = Prefecture.TOKYO,
-        publishStatus = PublishStatus.PUBLISHED,
+        participationStatus = ParticipationStatus.PARTICIPATING,
         images = listOf(
             ShopImage(
                 id = ShopImageId("00000000-0000-4000-8000-000000000011"),
@@ -47,27 +52,43 @@ class UpdateShopUsecaseTest {
         ),
     )
 
+    private val droppedShop = existingShop.copy(participationStatus = ParticipationStatus.DROPPED)
+
     private val savedShops = mutableListOf<Shop>()
 
     private val fakeRepository = object : ShopRepository {
+        var shopToReturn: Shop? = existingShop
+
         override fun save(shop: Shop) {
             savedShops.add(shop)
         }
 
         override fun findById(id: ShopId): Shop? {
-            return if (id.value == existingShopId) existingShop else null
+            return when (id.value) {
+                existingShopId -> shopToReturn
+                else -> null
+            }
         }
 
         override fun findAll(
             page: Int,
             size: Int,
             name: String?,
-            publishStatus: PublishStatus?,
+            participationStatus: ParticipationStatus?,
         ): Pair<List<Shop>, Long> = Pair(emptyList(), 0L)
         override fun deleteById(id: ShopId) = Unit
     }
 
-    private val usecase = UpdateShopUsecase(fakeRepository, FakeImageStorageService)
+    private val fakeCoffeeBeanRepository = object : CoffeeBeanRepository {
+        override fun save(coffeeBean: CoffeeBean) = Unit
+        override fun findById(id: CoffeeBeanId): CoffeeBean? = null
+        override fun deleteById(id: CoffeeBeanId) = Unit
+        override fun invalidateByShopId(shopId: ShopIdModel) = Unit
+    }
+
+    private val fakeShopDropDomainService = ShopDropDomainService(fakeCoffeeBeanRepository)
+
+    private val usecase = UpdateShopUsecase(fakeRepository, fakeShopDropDomainService, FakeImageStorageService)
 
     private fun createRequest(
         shopifyShopId: String = "updated-shop-001",
@@ -76,7 +97,7 @@ class UpdateShopUsecaseTest {
         particular: String? = "更新こだわり",
         shopUrl: String = "https://updated.example.com",
         prefecture: String = "OSAKA",
-        publishStatus: String = "PUBLISHED",
+        participationStatus: String = "PARTICIPATING",
     ): UpdateShopRequest = UpdateShopRequest(
         shopifyShopId = shopifyShopId,
         name = name,
@@ -84,7 +105,7 @@ class UpdateShopUsecaseTest {
         particular = particular,
         shopUrl = shopUrl,
         prefecture = prefecture,
-        publishStatus = publishStatus,
+        participationStatus = participationStatus,
     )
 
     @Nested
@@ -183,6 +204,22 @@ class UpdateShopUsecaseTest {
         fun `不正なUUID形式のIDの場合は例外が発生する`() {
             assertThrows<IllegalArgumentException> {
                 usecase.execute("invalid-id", createRequest(), emptyList(), emptyList())
+            }
+        }
+
+        @Test
+        fun `DROPPED状態の店舗を更新しようとすると例外が発生する`() {
+            fakeRepository.shopToReturn = droppedShop
+            assertThrows<IllegalArgumentException> {
+                usecase.execute(existingShopId, createRequest(participationStatus = "DROPPED"), emptyList(), emptyList())
+            }
+        }
+
+        @Test
+        fun `BEFORE_PARTICIPATIONからDROPPEDへの直接遷移は例外が発生する`() {
+            fakeRepository.shopToReturn = existingShop.copy(participationStatus = ParticipationStatus.BEFORE_PARTICIPATION)
+            assertThrows<IllegalArgumentException> {
+                usecase.execute(existingShopId, createRequest(participationStatus = "DROPPED"), emptyList(), emptyList())
             }
         }
     }

--- a/backend/admin-api/src/test/kotlin/com/mametosho/admin/architecture/FqcnUsageTest.kt
+++ b/backend/admin-api/src/test/kotlin/com/mametosho/admin/architecture/FqcnUsageTest.kt
@@ -32,12 +32,9 @@ class FqcnUsageTest {
 
                 sourceFile.readLines().forEachIndexed { lineIndex, line ->
                     val trimmed = line.trim()
-                    if (trimmed.startsWith("package ") ||
-                        trimmed.startsWith("import ") ||
-                        trimmed.startsWith("//") ||
-                        trimmed.startsWith("/*") ||
-                        trimmed.startsWith("*")
-                    ) return@forEachIndexed
+                    val isSkippable = listOf("package ", "import ", "//", "/*", "*")
+                        .any { trimmed.startsWith(it) }
+                    if (isSkippable) return@forEachIndexed
 
                     fqcnPattern.findAll(trimmed).forEach { match ->
                         events.add(

--- a/backend/admin-api/src/test/kotlin/com/mametosho/admin/architecture/FqcnUsageTest.kt
+++ b/backend/admin-api/src/test/kotlin/com/mametosho/admin/architecture/FqcnUsageTest.kt
@@ -1,0 +1,67 @@
+package com.mametosho.admin.architecture
+
+import com.tngtech.archunit.core.domain.JavaClass
+import com.tngtech.archunit.core.importer.ClassFileImporter
+import com.tngtech.archunit.core.importer.ImportOption
+import com.tngtech.archunit.lang.ArchCondition
+import com.tngtech.archunit.lang.ConditionEvents
+import com.tngtech.archunit.lang.SimpleConditionEvent
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes
+import java.io.File
+import kotlin.test.Test
+
+/**
+ * com.mametosho.admin パッケージ内で FQCN（完全修飾クラス名）を使わないことを保証するテスト。
+ *
+ * 対象: コードボディ内の FQCN 参照。
+ * 除外: package 宣言、import 文、コメント行（//、/＊、＊）。
+ */
+class FqcnUsageTest {
+
+    private val importedClasses = ClassFileImporter()
+        .withImportOption(ImportOption.DoNotIncludeTests())
+        .importPackages("com.mametosho.admin")
+
+    @Test
+    fun `コードボディにFQCNを使用しない`() {
+        val fqcnPattern = Regex("""(?<![.\w])com\.mametosho(?:\.[a-z][a-zA-Z0-9_]*)+\.[A-Z]\w*""")
+
+        val noFqcnCondition = object : ArchCondition<JavaClass>("コードボディにFQCNを使用しない") {
+            override fun check(item: JavaClass, events: ConditionEvents) {
+                val sourceFile = resolveSourceFile(item) ?: return
+
+                sourceFile.readLines().forEachIndexed { lineIndex, line ->
+                    val trimmed = line.trim()
+                    if (trimmed.startsWith("package ") ||
+                        trimmed.startsWith("import ") ||
+                        trimmed.startsWith("//") ||
+                        trimmed.startsWith("/*") ||
+                        trimmed.startsWith("*")
+                    ) return@forEachIndexed
+
+                    fqcnPattern.findAll(trimmed).forEach { match ->
+                        events.add(
+                            SimpleConditionEvent.violated(
+                                item,
+                                "${sourceFile.name}:${lineIndex + 1}: FQCNが使用されています → '${match.value}'" +
+                                    "（import文と短縮名を使用すること）",
+                            ),
+                        )
+                    }
+                }
+            }
+
+            private fun resolveSourceFile(item: JavaClass): File? {
+                val simpleName = item.simpleName.removeSuffix("Kt")
+                val packagePath = item.packageName.replace('.', File.separatorChar)
+                return File("src/main/kotlin/$packagePath/$simpleName.kt").takeIf { it.exists() }
+            }
+        }
+
+        classes()
+            .that().resideInAPackage("com.mametosho.admin..")
+            .should(noFqcnCondition)
+            .because("コードボディでは import 文と短縮名を使用し、FQCNは使用しないこと")
+            .check(importedClasses)
+    }
+}

--- a/backend/admin-api/src/test/kotlin/com/mametosho/admin/presentation/controller/ShopControllerTest.kt
+++ b/backend/admin-api/src/test/kotlin/com/mametosho/admin/presentation/controller/ShopControllerTest.kt
@@ -138,7 +138,7 @@ class ShopControllerTest {
                 particular = "テストこだわり",
                 shopUrl = "https://example.com",
                 prefecture = "TOKYO",
-                publishStatus = "PUBLISHED",
+                participationStatus = "PARTICIPATING",
             )
 
             val response = shopController.createShop(request, listOf(logoFile), listOf("LOGO"))
@@ -162,7 +162,7 @@ class ShopControllerTest {
                 particular = "更新こだわり",
                 shopUrl = "https://updated.example.com",
                 prefecture = "OSAKA",
-                publishStatus = "PUBLISHED",
+                participationStatus = "PARTICIPATING",
             )
 
             val response = shopController.updateShop("00000000-0000-4000-8000-000000000001", request, listOf(logoFile), listOf("LOGO"))
@@ -180,7 +180,7 @@ class ShopControllerTest {
                 particular = null,
                 shopUrl = "https://example.com",
                 prefecture = "TOKYO",
-                publishStatus = "PUBLISHED",
+                participationStatus = "PARTICIPATING",
             )
 
             val response = shopController.updateShop("00000000-0000-4000-8000-999999999999", request, listOf(logoFile), listOf("LOGO"))

--- a/backend/admin-api/src/test/kotlin/com/mametosho/admin/presentation/dto/response/ShopResponseTest.kt
+++ b/backend/admin-api/src/test/kotlin/com/mametosho/admin/presentation/dto/response/ShopResponseTest.kt
@@ -1,7 +1,7 @@
 package com.mametosho.admin.presentation.dto.response
 
 import com.mametosho.domain.model.shared.ImageUrl
-import com.mametosho.domain.model.shared.PublishStatus
+import com.mametosho.domain.model.shared.ParticipationStatus
 import com.mametosho.domain.model.shop.Shop
 import com.mametosho.domain.model.shop.ShopId
 import com.mametosho.domain.model.shop.ShopImage
@@ -23,7 +23,7 @@ class ShopResponseTest {
         particular = "テストこだわり",
         shopUrl = "https://example.com",
         prefecture = Prefecture.TOKYO,
-        publishStatus = PublishStatus.PUBLISHED,
+        participationStatus = ParticipationStatus.PARTICIPATING,
         images = listOf(
             ShopImage(
                 id = ShopImageId("00000000-0000-4000-8000-000000000011"),
@@ -41,9 +41,18 @@ class ShopResponseTest {
     @Nested
     inner class 正常系変換 {
         @Test
-        fun `正常にShopからShopResponseに変換できる`() {
-            val response = ShopResponse.from(createShop())
+        fun `正常にShopからShopSummaryResponseに変換できる`() {
+            val response = ShopSummaryResponse.from(createShop())
             assertEquals("00000000-0000-4000-8000-000000000001", response.id)
+            assertEquals("PARTICIPATING", response.participationStatus)
+        }
+
+        @Test
+        fun `正常にShopからShopDetailResponseに変換できる`() {
+            val response = ShopDetailResponse.from(createShop())
+            assertEquals("00000000-0000-4000-8000-000000000001", response.id)
+            assertEquals("PARTICIPATING", response.participationStatus)
+            assertEquals(2, response.images.size)
         }
     }
 }

--- a/backend/common/build.gradle.kts
+++ b/backend/common/build.gradle.kts
@@ -41,5 +41,6 @@ dependencies {
 	testImplementation(libs.kotlin.test.junit5)
 	testImplementation(libs.testcontainers.mysql)
 	testImplementation(libs.testcontainers.junit.jupiter)
+	testImplementation(libs.archunit.junit5)
 	testRuntimeOnly(libs.junit.platform.launcher)
 }

--- a/backend/common/src/main/kotlin/com/mametosho/domain/model/coffeebean/CoffeeBean.kt
+++ b/backend/common/src/main/kotlin/com/mametosho/domain/model/coffeebean/CoffeeBean.kt
@@ -93,33 +93,38 @@ data class CoffeeBean(
         publishStatus: String,
         images: List<Pair<String, String>>,
         tastes: List<Pair<String, Int>>,
-    ): CoffeeBean = CoffeeBean(
-        id = this.id,
-        shopId = ShopId(shopId),
-        shopifyBeanId = ShopifyBeanId(shopifyBeanId),
-        name = name,
-        description = description,
-        origin = origin,
-        farm = farm,
-        roastLevel = RoastLevel.valueOf(roastLevel),
-        processingMethod = ProcessingMethod.valueOf(processingMethod),
-        isSpecialty = isSpecialty,
-        publishStatus = PublishStatus.valueOf(publishStatus),
-        images = images.map { (type, imageUrl) ->
-            CoffeeBeanImage(
-                id = CoffeeBeanImageId(UUID.randomUUID().toString()),
-                type = CoffeeBeanImageType.valueOf(type),
-                imageUrl = ImageUrl(imageUrl),
-            )
-        },
-        tastes = tastes.map { (tasteId, evaluationValue) ->
-            CoffeeBeanTaste(
-                id = CoffeeBeanTasteId(UUID.randomUUID().toString()),
-                tasteId = TasteId(tasteId),
-                evaluationValue = evaluationValue,
-            )
-        },
-    )
+    ): CoffeeBean {
+        require(this.publishStatus != PublishStatus.INVALIDATED) {
+            "無効化されたコーヒー豆は更新できません"
+        }
+        return CoffeeBean(
+            id = this.id,
+            shopId = ShopId(shopId),
+            shopifyBeanId = ShopifyBeanId(shopifyBeanId),
+            name = name,
+            description = description,
+            origin = origin,
+            farm = farm,
+            roastLevel = RoastLevel.valueOf(roastLevel),
+            processingMethod = ProcessingMethod.valueOf(processingMethod),
+            isSpecialty = isSpecialty,
+            publishStatus = PublishStatus.valueOf(publishStatus),
+            images = images.map { (type, imageUrl) ->
+                CoffeeBeanImage(
+                    id = CoffeeBeanImageId(UUID.randomUUID().toString()),
+                    type = CoffeeBeanImageType.valueOf(type),
+                    imageUrl = ImageUrl(imageUrl),
+                )
+            },
+            tastes = tastes.map { (tasteId, evaluationValue) ->
+                CoffeeBeanTaste(
+                    id = CoffeeBeanTasteId(UUID.randomUUID().toString()),
+                    tasteId = TasteId(tasteId),
+                    evaluationValue = evaluationValue,
+                )
+            },
+        )
+    }
 
     companion object {
         /**

--- a/backend/common/src/main/kotlin/com/mametosho/domain/model/shared/ParticipationStatus.kt
+++ b/backend/common/src/main/kotlin/com/mametosho/domain/model/shared/ParticipationStatus.kt
@@ -1,0 +1,14 @@
+package com.mametosho.domain.model.shared
+
+/**
+ * 参画ステータス。
+ *
+ * BEFORE_PARTICIPATION（参画前）→ PARTICIPATING（参画中）→ DROPPED（参画落ち）の直線遷移のみ許可。
+ * DROPPED になると以降のステータス変更は不可。
+ * PARTICIPATING の店舗のみ CS（一般ユーザー向け）に公開される。
+ */
+enum class ParticipationStatus {
+    BEFORE_PARTICIPATION,
+    PARTICIPATING,
+    DROPPED,
+}

--- a/backend/common/src/main/kotlin/com/mametosho/domain/model/shared/PublishStatus.kt
+++ b/backend/common/src/main/kotlin/com/mametosho/domain/model/shared/PublishStatus.kt
@@ -3,10 +3,13 @@ package com.mametosho.domain.model.shared
 /**
  * 公開状態。
  *
- * draft（下書き・非公開）と published（公開）の双方向の遷移が可能。
- * 下書きのデータはCS（一般ユーザー向け）には公開されない。
+ * DRAFT（下書き・非公開）と PUBLISHED（公開）の双方向の遷移が可能。
+ * INVALIDATED は店舗が参画落ちになった際にシステムが自動設定する終端状態。
+ * INVALIDATED になったデータはそれ以降の変更は不可。
+ * PUBLISHED 以外のデータは CS（一般ユーザー向け）には公開されない。
  */
 enum class PublishStatus {
     DRAFT,
     PUBLISHED,
+    INVALIDATED,
 }

--- a/backend/common/src/main/kotlin/com/mametosho/domain/model/shop/Shop.kt
+++ b/backend/common/src/main/kotlin/com/mametosho/domain/model/shop/Shop.kt
@@ -1,7 +1,7 @@
 package com.mametosho.domain.model.shop
 
 import com.mametosho.domain.model.shared.ImageUrl
-import com.mametosho.domain.model.shared.PublishStatus
+import com.mametosho.domain.model.shared.ParticipationStatus
 import java.util.UUID
 
 /**
@@ -16,7 +16,7 @@ import java.util.UUID
  * @property particular こだわり
  * @property shopUrl 店舗URL
  * @property prefecture 都道府県
- * @property publishStatus 公開状態（draft/published）
+ * @property participationStatus 参画ステータス（参画前/参画中/参画落ち）
  * @property images 店舗画像一覧
  */
 @Suppress("MagicNumber")
@@ -28,7 +28,7 @@ data class Shop(
     val particular: String?,
     val shopUrl: String,
     val prefecture: Prefecture,
-    val publishStatus: PublishStatus,
+    val participationStatus: ParticipationStatus,
     val images: List<ShopImage>,
 ) {
     init {
@@ -54,13 +54,15 @@ data class Shop(
      * 店舗情報を更新する。
      *
      * ShopIdは変更せず、それ以外の項目を置換する。ShopImageIdはUUIDv4を自動再生成する。
+     * 参画ステータスの遷移は BEFORE_PARTICIPATION → PARTICIPATING → DROPPED の直線遷移のみ許可。
+     * DROPPED 状態からはいかなる変更も不可。
      *
      * @param shopifyShopId ShopifyのショップID
      * @param name 店舗名
      * @param introduction 店舗紹介
      * @param particular こだわり
      * @param shopUrl 店舗URL
-     * @param publishStatus 公開状態（draft/published）
+     * @param participationStatus 参画ステータス
      * @param images 画像情報（種別とURL）のリスト
      * @return 更新された[Shop]
      */
@@ -71,38 +73,54 @@ data class Shop(
         particular: String?,
         shopUrl: String,
         prefecture: Prefecture,
-        publishStatus: String,
+        participationStatus: String,
         images: List<Pair<String, String>>,
-    ): Shop = Shop(
-        id = this.id,
-        shopifyShopId = ShopifyShopId(shopifyShopId),
-        name = name,
-        introduction = introduction,
-        particular = particular,
-        shopUrl = shopUrl,
-        prefecture = prefecture,
-        publishStatus = PublishStatus.valueOf(publishStatus),
-        images = images.map { (type, imageUrl) ->
-            ShopImage(
-                id = ShopImageId(UUID.randomUUID().toString()),
-                type = ShopImageType.valueOf(type),
-                imageUrl = ImageUrl(imageUrl),
+    ): Shop {
+        require(this.participationStatus != ParticipationStatus.DROPPED) {
+            "参画落ちの店舗は更新できません"
+        }
+        val newStatus = ParticipationStatus.valueOf(participationStatus)
+        if (newStatus != this.participationStatus) {
+            val validNext = mapOf(
+                ParticipationStatus.BEFORE_PARTICIPATION to ParticipationStatus.PARTICIPATING,
+                ParticipationStatus.PARTICIPATING to ParticipationStatus.DROPPED,
             )
-        },
-    )
+            require(validNext[this.participationStatus] == newStatus) {
+                "${this.participationStatus} から $newStatus への遷移は無効です"
+            }
+        }
+        return Shop(
+            id = this.id,
+            shopifyShopId = ShopifyShopId(shopifyShopId),
+            name = name,
+            introduction = introduction,
+            particular = particular,
+            shopUrl = shopUrl,
+            prefecture = prefecture,
+            participationStatus = newStatus,
+            images = images.map { (type, imageUrl) ->
+                ShopImage(
+                    id = ShopImageId(UUID.randomUUID().toString()),
+                    type = ShopImageType.valueOf(type),
+                    imageUrl = ImageUrl(imageUrl),
+                )
+            },
+        )
+    }
 
     companion object {
         /**
          * 新しい店舗を生成する。
          *
          * IDはサーバー側でUUIDv4を自動生成する。
+         * 初期ステータスに DROPPED は指定不可。
          *
          * @param shopifyShopId ShopifyのショップID
          * @param name 店舗名
          * @param introduction 店舗紹介
          * @param particular こだわり
          * @param shopUrl 店舗URL
-         * @param publishStatus 公開状態（draft/published）
+         * @param participationStatus 参画ステータス
          * @param images 画像情報（種別とURL）のリスト
          * @return 生成された[Shop]
          */
@@ -113,25 +131,31 @@ data class Shop(
             particular: String?,
             shopUrl: String,
             prefecture: Prefecture,
-            publishStatus: String,
+            participationStatus: String,
             images: List<Pair<String, String>>,
             id: String = UUID.randomUUID().toString(),
-        ): Shop = Shop(
-            id = ShopId(id),
-            shopifyShopId = ShopifyShopId(shopifyShopId),
-            name = name,
-            introduction = introduction,
-            particular = particular,
-            shopUrl = shopUrl,
-            prefecture = prefecture,
-            publishStatus = PublishStatus.valueOf(publishStatus),
-            images = images.map { (type, imageUrl) ->
-                ShopImage(
-                    id = ShopImageId(UUID.randomUUID().toString()),
-                    type = ShopImageType.valueOf(type),
-                    imageUrl = ImageUrl(imageUrl),
-                )
-            },
-        )
+        ): Shop {
+            val status = ParticipationStatus.valueOf(participationStatus)
+            require(status != ParticipationStatus.DROPPED) {
+                "初期ステータスに DROPPED は指定できません"
+            }
+            return Shop(
+                id = ShopId(id),
+                shopifyShopId = ShopifyShopId(shopifyShopId),
+                name = name,
+                introduction = introduction,
+                particular = particular,
+                shopUrl = shopUrl,
+                prefecture = prefecture,
+                participationStatus = status,
+                images = images.map { (type, imageUrl) ->
+                    ShopImage(
+                        id = ShopImageId(UUID.randomUUID().toString()),
+                        type = ShopImageType.valueOf(type),
+                        imageUrl = ImageUrl(imageUrl),
+                    )
+                },
+            )
+        }
     }
 }

--- a/backend/common/src/main/kotlin/com/mametosho/domain/repository/CoffeeBeanRepository.kt
+++ b/backend/common/src/main/kotlin/com/mametosho/domain/repository/CoffeeBeanRepository.kt
@@ -2,9 +2,16 @@ package com.mametosho.domain.repository
 
 import com.mametosho.domain.model.coffeebean.CoffeeBean
 import com.mametosho.domain.model.coffeebean.CoffeeBeanId
+import com.mametosho.domain.model.shop.ShopId
 
 interface CoffeeBeanRepository {
     fun save(coffeeBean: CoffeeBean)
     fun findById(id: CoffeeBeanId): CoffeeBean?
     fun deleteById(id: CoffeeBeanId)
+
+    /**
+     * 指定した店舗に属する全コーヒー豆の公開ステータスを INVALIDATED に更新する。
+     * 店舗が参画落ちになった際にシステムが自動的に呼び出す。
+     */
+    fun invalidateByShopId(shopId: ShopId)
 }

--- a/backend/common/src/main/kotlin/com/mametosho/domain/repository/ShopRepository.kt
+++ b/backend/common/src/main/kotlin/com/mametosho/domain/repository/ShopRepository.kt
@@ -1,6 +1,6 @@
 package com.mametosho.domain.repository
 
-import com.mametosho.domain.model.shared.PublishStatus
+import com.mametosho.domain.model.shared.ParticipationStatus
 import com.mametosho.domain.model.shop.Shop
 import com.mametosho.domain.model.shop.ShopId
 
@@ -11,14 +11,14 @@ interface ShopRepository {
     /**
      * 店舗を一覧取得する。
      *
-     * @param publishStatus 公開状態フィルタ。nullの場合は全状態を取得する（管理画面用）。
-     *   [PublishStatus.PUBLISHED] を指定すると公開済みのみ取得する（CS用）。
+     * @param participationStatus 参画ステータスフィルタ。nullの場合は全状態を取得する（管理画面用）。
+     *   [ParticipationStatus.PARTICIPATING] を指定すると参画中のみ取得する（CS用）。
      */
     fun findAll(
         page: Int,
         size: Int,
         name: String? = null,
-        publishStatus: PublishStatus? = null,
+        participationStatus: ParticipationStatus? = null,
     ): Pair<List<Shop>, Long>
 
     fun deleteById(id: ShopId)

--- a/backend/common/src/main/kotlin/com/mametosho/domain/service/ShopDropDomainService.kt
+++ b/backend/common/src/main/kotlin/com/mametosho/domain/service/ShopDropDomainService.kt
@@ -1,0 +1,21 @@
+package com.mametosho.domain.service
+
+import com.mametosho.domain.model.shop.ShopId
+import com.mametosho.domain.repository.CoffeeBeanRepository
+import org.springframework.stereotype.Service
+
+/**
+ * 店舗の参画落ちに伴うドメインルールを担うサービス。
+ *
+ * 店舗が参画落ち（DROPPED）になると、その店舗に属する全コーヒー豆を
+ * INVALIDATED（無効化）状態に移行する。
+ * この操作は不可逆であり、無効化された豆はそれ以降の更新が禁止される。
+ */
+@Service
+class ShopDropDomainService(
+    private val coffeeBeanRepository: CoffeeBeanRepository,
+) {
+    fun invalidateCoffeeBeans(shopId: ShopId) {
+        coffeeBeanRepository.invalidateByShopId(shopId)
+    }
+}

--- a/backend/common/src/main/kotlin/com/mametosho/infrastructure/persistence/mybatis/entity/ShopEntity.kt
+++ b/backend/common/src/main/kotlin/com/mametosho/infrastructure/persistence/mybatis/entity/ShopEntity.kt
@@ -8,5 +8,5 @@ data class ShopEntity(
     val particular: String?,
     val shopUrl: String,
     val prefecture: String,
-    val publishStatus: String,
+    val participationStatus: String,
 )

--- a/backend/common/src/main/kotlin/com/mametosho/infrastructure/persistence/mybatis/entity/ShopListRow.kt
+++ b/backend/common/src/main/kotlin/com/mametosho/infrastructure/persistence/mybatis/entity/ShopListRow.kt
@@ -8,7 +8,7 @@ data class ShopListRow(
     val particular: String?,
     val shopUrl: String,
     val prefecture: String,
-    val publishStatus: String,
+    val participationStatus: String,
     val imageId: String?,
     val imageType: String?,
     val imageUrl: String?,

--- a/backend/common/src/main/kotlin/com/mametosho/infrastructure/persistence/mybatis/mapper/CoffeeBeanMapper.kt
+++ b/backend/common/src/main/kotlin/com/mametosho/infrastructure/persistence/mybatis/mapper/CoffeeBeanMapper.kt
@@ -9,6 +9,7 @@ import org.apache.ibatis.annotations.Insert
 import org.apache.ibatis.annotations.Mapper
 import org.apache.ibatis.annotations.Param
 import org.apache.ibatis.annotations.Select
+import org.apache.ibatis.annotations.Update
 
 @Mapper
 interface CoffeeBeanMapper {
@@ -91,6 +92,9 @@ interface CoffeeBeanMapper {
 
     @Delete("DELETE FROM coffee_beans WHERE id = #{id}")
     fun deleteCoffeeBeanById(id: String)
+
+    @Update("UPDATE coffee_beans SET publish_status = 'INVALIDATED' WHERE shop_id = #{shopId}")
+    fun invalidateByShopId(@Param("shopId") shopId: String)
 
     @Insert(
         """

--- a/backend/common/src/main/kotlin/com/mametosho/infrastructure/persistence/mybatis/mapper/ShopMapper.kt
+++ b/backend/common/src/main/kotlin/com/mametosho/infrastructure/persistence/mybatis/mapper/ShopMapper.kt
@@ -13,8 +13,8 @@ import org.apache.ibatis.annotations.Select
 interface ShopMapper {
     @Insert(
         """
-        INSERT INTO shops (id, shopify_shop_id, name, introduction, particular, shop_url, prefecture, publish_status)
-        VALUES (#{id}, #{shopifyShopId}, #{name}, #{introduction}, #{particular}, #{shopUrl}, #{prefecture}, #{publishStatus})
+        INSERT INTO shops (id, shopify_shop_id, name, introduction, particular, shop_url, prefecture, participation_status)
+        VALUES (#{id}, #{shopifyShopId}, #{name}, #{introduction}, #{particular}, #{shopUrl}, #{prefecture}, #{participationStatus})
         ON DUPLICATE KEY UPDATE
             shopify_shop_id = VALUES(shopify_shop_id),
             name = VALUES(name),
@@ -22,7 +22,7 @@ interface ShopMapper {
             particular = VALUES(particular),
             shop_url = VALUES(shop_url),
             prefecture = VALUES(prefecture),
-            publish_status = VALUES(publish_status)
+            participation_status = VALUES(participation_status)
         """,
     )
     fun upsertShop(entity: ShopEntity)
@@ -40,7 +40,7 @@ interface ShopMapper {
 
     @Select(
         """
-        SELECT s.id, s.shopify_shop_id, s.name, s.introduction, s.particular, s.shop_url, s.prefecture, s.publish_status,
+        SELECT s.id, s.shopify_shop_id, s.name, s.introduction, s.particular, s.shop_url, s.prefecture, s.participation_status,
                si.id AS image_id, si.type AS image_type, si.image_url
         FROM shops s
         LEFT JOIN shop_images si ON si.shop_id = s.id
@@ -55,7 +55,7 @@ interface ShopMapper {
     @Select(
         """
         <script>
-        SELECT s.id, s.shopify_shop_id, s.name, s.introduction, s.particular, s.shop_url, s.prefecture, s.publish_status,
+        SELECT s.id, s.shopify_shop_id, s.name, s.introduction, s.particular, s.shop_url, s.prefecture, s.participation_status,
                si.id AS image_id, si.type AS image_type, si.image_url
         FROM (
             SELECT id FROM shops
@@ -63,8 +63,8 @@ interface ShopMapper {
                 <if test="name != null">
                     AND name LIKE CONCAT('%', #{name}, '%')
                 </if>
-                <if test="publishStatus != null">
-                    AND publish_status = #{publishStatus}
+                <if test="participationStatus != null">
+                    AND participation_status = #{participationStatus}
                 </if>
             </where>
             ORDER BY created_at DESC
@@ -80,7 +80,7 @@ interface ShopMapper {
         @Param("size") size: Int,
         @Param("offset") offset: Int,
         @Param("name") name: String?,
-        @Param("publishStatus") publishStatus: String?,
+        @Param("participationStatus") participationStatus: String?,
     ): List<ShopListRow>
 
     @Select(
@@ -91,8 +91,8 @@ interface ShopMapper {
             <if test="name != null">
                 AND name LIKE CONCAT('%', #{name}, '%')
             </if>
-            <if test="publishStatus != null">
-                AND publish_status = #{publishStatus}
+            <if test="participationStatus != null">
+                AND participation_status = #{participationStatus}
             </if>
         </where>
         </script>
@@ -100,6 +100,6 @@ interface ShopMapper {
     )
     fun countByCondition(
         @Param("name") name: String?,
-        @Param("publishStatus") publishStatus: String?,
+        @Param("participationStatus") participationStatus: String?,
     ): Long
 }

--- a/backend/common/src/main/kotlin/com/mametosho/infrastructure/persistence/repository/CoffeeBeanRepositoryImpl.kt
+++ b/backend/common/src/main/kotlin/com/mametosho/infrastructure/persistence/repository/CoffeeBeanRepositoryImpl.kt
@@ -13,6 +13,7 @@ import com.mametosho.domain.model.coffeebean.ShopifyBeanId
 import com.mametosho.domain.model.shared.ImageUrl
 import com.mametosho.domain.model.shared.PublishStatus
 import com.mametosho.domain.model.shop.ShopId
+import org.springframework.transaction.annotation.Transactional
 import com.mametosho.domain.model.taste.TasteId
 import com.mametosho.domain.repository.CoffeeBeanRepository
 import com.mametosho.infrastructure.persistence.mybatis.entity.CoffeeBeanEntity
@@ -102,5 +103,10 @@ class CoffeeBeanRepositoryImpl(
         coffeeBeanMapper.deleteCoffeeBeanImagesByCoffeeBeanId(id.value)
         coffeeBeanMapper.deleteCoffeeBeanTastesByCoffeeBeanId(id.value)
         coffeeBeanMapper.deleteCoffeeBeanById(id.value)
+    }
+
+    @Transactional
+    override fun invalidateByShopId(shopId: ShopId) {
+        coffeeBeanMapper.invalidateByShopId(shopId.value)
     }
 }

--- a/backend/common/src/main/kotlin/com/mametosho/infrastructure/persistence/repository/ShopRepositoryImpl.kt
+++ b/backend/common/src/main/kotlin/com/mametosho/infrastructure/persistence/repository/ShopRepositoryImpl.kt
@@ -1,7 +1,7 @@
 package com.mametosho.infrastructure.persistence.repository
 
 import com.mametosho.domain.model.shared.ImageUrl
-import com.mametosho.domain.model.shared.PublishStatus
+import com.mametosho.domain.model.shared.ParticipationStatus
 import com.mametosho.domain.model.shop.Shop
 import com.mametosho.domain.model.shop.ShopId
 import com.mametosho.domain.model.shop.ShopImage
@@ -12,6 +12,7 @@ import com.mametosho.domain.model.shop.ShopifyShopId
 import com.mametosho.domain.repository.ShopRepository
 import com.mametosho.infrastructure.persistence.mybatis.entity.ShopEntity
 import com.mametosho.infrastructure.persistence.mybatis.entity.ShopImageEntity
+import com.mametosho.infrastructure.persistence.mybatis.entity.ShopListRow
 import com.mametosho.infrastructure.persistence.mybatis.mapper.ShopMapper
 import org.springframework.stereotype.Repository
 
@@ -29,7 +30,7 @@ class ShopRepositoryImpl(
                 particular = shop.particular,
                 shopUrl = shop.shopUrl,
                 prefecture = shop.prefecture.name,
-                publishStatus = shop.publishStatus.name,
+                participationStatus = shop.participationStatus.name,
             ),
         )
         shopMapper.deleteShopImagesByShopId(shop.id.value)
@@ -54,12 +55,12 @@ class ShopRepositoryImpl(
         page: Int,
         size: Int,
         name: String?,
-        publishStatus: PublishStatus?,
+        participationStatus: ParticipationStatus?,
     ): Pair<List<Shop>, Long> {
         val offset = page * size
-        val publishStatusName = publishStatus?.name
-        val rows = shopMapper.findListRows(size, offset, name, publishStatusName)
-        val totalCount = shopMapper.countByCondition(name, publishStatusName)
+        val participationStatusName = participationStatus?.name
+        val rows = shopMapper.findListRows(size, offset, name, participationStatusName)
+        val totalCount = shopMapper.countByCondition(name, participationStatusName)
         if (rows.isEmpty()) return Pair(emptyList(), totalCount)
         val shops = rows.groupBy { it.id }.map { (_, shopRows) -> mapRowsToShop(shopRows) }
         return Pair(shops, totalCount)
@@ -71,7 +72,7 @@ class ShopRepositoryImpl(
         return mapRowsToShop(rows)
     }
 
-    private fun mapRowsToShop(rows: List<com.mametosho.infrastructure.persistence.mybatis.entity.ShopListRow>): Shop {
+    private fun mapRowsToShop(rows: List<ShopListRow>): Shop {
         val first = rows.first()
         return Shop(
             id = ShopId(first.id),
@@ -81,7 +82,7 @@ class ShopRepositoryImpl(
             particular = first.particular,
             shopUrl = first.shopUrl,
             prefecture = Prefecture.valueOf(first.prefecture),
-            publishStatus = PublishStatus.valueOf(first.publishStatus),
+            participationStatus = ParticipationStatus.valueOf(first.participationStatus),
             images = rows
                 .filter { it.imageId != null }
                 .map { row ->

--- a/backend/common/src/test/kotlin/com/mametosho/architecture/FqcnUsageTest.kt
+++ b/backend/common/src/test/kotlin/com/mametosho/architecture/FqcnUsageTest.kt
@@ -38,12 +38,9 @@ class FqcnUsageTest {
 
                 sourceFile.readLines().forEachIndexed { lineIndex, line ->
                     val trimmed = line.trim()
-                    if (trimmed.startsWith("package ") ||
-                        trimmed.startsWith("import ") ||
-                        trimmed.startsWith("//") ||
-                        trimmed.startsWith("/*") ||
-                        trimmed.startsWith("*")
-                    ) return@forEachIndexed
+                    val isSkippable = listOf("package ", "import ", "//", "/*", "*")
+                        .any { trimmed.startsWith(it) }
+                    if (isSkippable) return@forEachIndexed
 
                     fqcnPattern.findAll(trimmed).forEach { match ->
                         events.add(

--- a/backend/common/src/test/kotlin/com/mametosho/architecture/FqcnUsageTest.kt
+++ b/backend/common/src/test/kotlin/com/mametosho/architecture/FqcnUsageTest.kt
@@ -1,0 +1,79 @@
+package com.mametosho.architecture
+
+import com.tngtech.archunit.core.domain.JavaClass
+import com.tngtech.archunit.core.importer.ClassFileImporter
+import com.tngtech.archunit.core.importer.ImportOption
+import com.tngtech.archunit.lang.ArchCondition
+import com.tngtech.archunit.lang.ConditionEvents
+import com.tngtech.archunit.lang.SimpleConditionEvent
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes
+import java.io.File
+import kotlin.test.Test
+
+/**
+ * com.mametosho パッケージ内で FQCN（完全修飾クラス名）を使わないことを保証するテスト。
+ *
+ * ソースファイルをクラスのパッケージ名とクラス名から導出することで、
+ * ArchUnit の source 属性が取れない場合でも確実に検査する。
+ *
+ * 対象: コードボディ内の FQCN 参照。
+ * 除外: package 宣言、import 文、コメント行（//、/＊、＊）。
+ *
+ * NG例: `require(x != com.mametosho.domain.model.shared.PublishStatus.INVALIDATED)`
+ * OK例: `import com.mametosho.domain.model.shared.PublishStatus` の後に `PublishStatus.INVALIDATED`
+ */
+class FqcnUsageTest {
+
+    private val importedClasses = ClassFileImporter()
+        .withImportOption(ImportOption.DoNotIncludeTests())
+        .importPackages("com.mametosho")
+
+    @Test
+    fun `コードボディにFQCNを使用しない`() {
+        val fqcnPattern = Regex("""(?<![.\w])com\.mametosho(?:\.[a-z][a-zA-Z0-9_]*)+\.[A-Z]\w*""")
+
+        val noFqcnCondition = object : ArchCondition<JavaClass>("コードボディにFQCNを使用しない") {
+            override fun check(item: JavaClass, events: ConditionEvents) {
+                val sourceFile = resolveSourceFile(item) ?: return
+
+                sourceFile.readLines().forEachIndexed { lineIndex, line ->
+                    val trimmed = line.trim()
+                    if (trimmed.startsWith("package ") ||
+                        trimmed.startsWith("import ") ||
+                        trimmed.startsWith("//") ||
+                        trimmed.startsWith("/*") ||
+                        trimmed.startsWith("*")
+                    ) return@forEachIndexed
+
+                    fqcnPattern.findAll(trimmed).forEach { match ->
+                        events.add(
+                            SimpleConditionEvent.violated(
+                                item,
+                                "${sourceFile.name}:${lineIndex + 1}: FQCNが使用されています → '${match.value}'" +
+                                    "（import文と短縮名を使用すること）",
+                            ),
+                        )
+                    }
+                }
+            }
+
+            /**
+             * クラス名とパッケージ名からソースファイルを導出する。
+             *
+             * Kotlin のファイルレベル宣言は `XxxKt` というクラス名になるため、
+             * `Kt` サフィックスを除去してファイル名を解決する。
+             */
+            private fun resolveSourceFile(item: JavaClass): File? {
+                val simpleName = item.simpleName.removeSuffix("Kt")
+                val packagePath = item.packageName.replace('.', File.separatorChar)
+                return File("src/main/kotlin/$packagePath/$simpleName.kt").takeIf { it.exists() }
+            }
+        }
+
+        classes()
+            .that().resideInAPackage("com.mametosho..")
+            .should(noFqcnCondition)
+            .because("コードボディでは import 文と短縮名を使用し、FQCNは使用しないこと")
+            .check(importedClasses)
+    }
+}

--- a/backend/common/src/test/kotlin/com/mametosho/domain/model/shop/ShopTest.kt
+++ b/backend/common/src/test/kotlin/com/mametosho/domain/model/shop/ShopTest.kt
@@ -1,7 +1,7 @@
 package com.mametosho.domain.model.shop
 
 import com.mametosho.domain.model.shared.ImageUrl
-import com.mametosho.domain.model.shared.PublishStatus
+import com.mametosho.domain.model.shared.ParticipationStatus
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.assertThrows
 import kotlin.test.Test
@@ -20,6 +20,7 @@ class ShopTest {
     private fun createShop(
         images: List<ShopImage> = listOf(defaultLogoImage),
         shopUrl: String = "https://example.com",
+        participationStatus: ParticipationStatus = ParticipationStatus.PARTICIPATING,
     ): Shop = Shop(
         id = ShopId("00000000-0000-4000-8000-000000000003"),
         shopifyShopId = ShopifyShopId("shopify-shop-1"),
@@ -28,7 +29,7 @@ class ShopTest {
         particular = "産地直送の豆を使用",
         shopUrl = shopUrl,
         prefecture = Prefecture.TOKYO,
-        publishStatus = PublishStatus.PUBLISHED,
+        participationStatus = participationStatus,
         images = images,
     )
 
@@ -74,7 +75,7 @@ class ShopTest {
 
         @Test
         fun `正常に店舗情報を更新できる`() {
-            val shop = createShop()
+            val shop = createShop(participationStatus = ParticipationStatus.BEFORE_PARTICIPATION)
             val updated = shop.update(
                 shopifyShopId = "updated-shop-id",
                 name = "更新店舗",
@@ -82,7 +83,7 @@ class ShopTest {
                 particular = "更新こだわり",
                 shopUrl = "https://updated.example.com",
                 prefecture = Prefecture.OSAKA,
-                publishStatus = "PUBLISHED",
+                participationStatus = "PARTICIPATING",
                 images = listOf("LOGO" to "https://example.com/logo.png", "MAIN" to "https://example.com/new.png"),
             )
 
@@ -105,7 +106,7 @@ class ShopTest {
                 particular = null,
                 shopUrl = "https://example.com",
                 prefecture = Prefecture.TOKYO,
-                publishStatus = "PUBLISHED",
+                participationStatus = "PARTICIPATING",
                 images = listOf("LOGO" to "https://example.com/logo.png"),
             )
 
@@ -122,12 +123,112 @@ class ShopTest {
                 particular = null,
                 shopUrl = "https://example.com",
                 prefecture = Prefecture.TOKYO,
-                publishStatus = "PUBLISHED",
+                participationStatus = "PARTICIPATING",
                 images = listOf("LOGO" to "https://example.com/logo.png", "MAIN" to "https://example.com/image.png"),
             )
 
             val uuidRegex = Regex("^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
             assertTrue(uuidRegex.matches(updated.images[0].id.value))
+        }
+
+        @Test
+        fun `BEFORE_PARTICIPATIONからPARTICIPATINGへの遷移ができる`() {
+            val shop = createShop(participationStatus = ParticipationStatus.BEFORE_PARTICIPATION)
+            val updated = shop.update(
+                shopifyShopId = "shopify-shop-1",
+                name = "珈琲工房まめ図書",
+                introduction = null,
+                particular = null,
+                shopUrl = "https://example.com",
+                prefecture = Prefecture.TOKYO,
+                participationStatus = "PARTICIPATING",
+                images = listOf("LOGO" to "https://example.com/logo.png"),
+            )
+            assertEquals(ParticipationStatus.PARTICIPATING, updated.participationStatus)
+        }
+
+        @Test
+        fun `PARTICIPATINGからDROPPEDへの遷移ができる`() {
+            val shop = createShop(participationStatus = ParticipationStatus.PARTICIPATING)
+            val updated = shop.update(
+                shopifyShopId = "shopify-shop-1",
+                name = "珈琲工房まめ図書",
+                introduction = null,
+                particular = null,
+                shopUrl = "https://example.com",
+                prefecture = Prefecture.TOKYO,
+                participationStatus = "DROPPED",
+                images = listOf("LOGO" to "https://example.com/logo.png"),
+            )
+            assertEquals(ParticipationStatus.DROPPED, updated.participationStatus)
+        }
+
+        @Test
+        fun `DROPPED状態からの変更は例外が発生する`() {
+            val shop = createShop(participationStatus = ParticipationStatus.DROPPED)
+            assertThrows<IllegalArgumentException> {
+                shop.update(
+                    shopifyShopId = "shopify-shop-1",
+                    name = "珈琲工房まめ図書",
+                    introduction = null,
+                    particular = null,
+                    shopUrl = "https://example.com",
+                    prefecture = Prefecture.TOKYO,
+                    participationStatus = "PARTICIPATING",
+                    images = listOf("LOGO" to "https://example.com/logo.png"),
+                )
+            }
+        }
+
+        @Test
+        fun `BEFORE_PARTICIPATIONからDROPPEDへの直接遷移は例外が発生する`() {
+            val shop = createShop(participationStatus = ParticipationStatus.BEFORE_PARTICIPATION)
+            assertThrows<IllegalArgumentException> {
+                shop.update(
+                    shopifyShopId = "shopify-shop-1",
+                    name = "珈琲工房まめ図書",
+                    introduction = null,
+                    particular = null,
+                    shopUrl = "https://example.com",
+                    prefecture = Prefecture.TOKYO,
+                    participationStatus = "DROPPED",
+                    images = listOf("LOGO" to "https://example.com/logo.png"),
+                )
+            }
+        }
+
+        @Test
+        fun `PARTICIPATINGからBEFORE_PARTICIPATIONへの逆遷移は例外が発生する`() {
+            val shop = createShop(participationStatus = ParticipationStatus.PARTICIPATING)
+            assertThrows<IllegalArgumentException> {
+                shop.update(
+                    shopifyShopId = "shopify-shop-1",
+                    name = "珈琲工房まめ図書",
+                    introduction = null,
+                    particular = null,
+                    shopUrl = "https://example.com",
+                    prefecture = Prefecture.TOKYO,
+                    participationStatus = "BEFORE_PARTICIPATION",
+                    images = listOf("LOGO" to "https://example.com/logo.png"),
+                )
+            }
+        }
+
+        @Test
+        fun `DROPPED状態でステータス変更なしでも例外が発生する`() {
+            val shop = createShop(participationStatus = ParticipationStatus.DROPPED)
+            assertThrows<IllegalArgumentException> {
+                shop.update(
+                    shopifyShopId = "shopify-shop-1",
+                    name = "珈琲工房まめ図書",
+                    introduction = null,
+                    particular = null,
+                    shopUrl = "https://example.com",
+                    prefecture = Prefecture.TOKYO,
+                    participationStatus = "DROPPED",
+                    images = listOf("LOGO" to "https://example.com/logo.png"),
+                )
+            }
         }
     }
 

--- a/backend/common/src/test/kotlin/com/mametosho/infrastructure/persistence/repository/ShopRepositoryImplTest.kt
+++ b/backend/common/src/test/kotlin/com/mametosho/infrastructure/persistence/repository/ShopRepositoryImplTest.kt
@@ -1,7 +1,7 @@
 package com.mametosho.infrastructure.persistence.repository
 
 import com.mametosho.domain.model.shared.ImageUrl
-import com.mametosho.domain.model.shared.PublishStatus
+import com.mametosho.domain.model.shared.ParticipationStatus
 import com.mametosho.domain.model.shop.Shop
 import com.mametosho.domain.model.shop.ShopId
 import com.mametosho.domain.model.shop.ShopImage
@@ -68,6 +68,7 @@ class ShopRepositoryImplTest {
         introduction: String? = "テスト紹介文",
         particular: String? = "テストこだわり",
         shopUrl: String = "https://example.com",
+        participationStatus: ParticipationStatus = ParticipationStatus.PARTICIPATING,
         images: List<ShopImage> = listOf(
             ShopImage(
                 id = ShopImageId("00000000-0000-4000-8000-000000000011"),
@@ -88,7 +89,7 @@ class ShopRepositoryImplTest {
         particular = particular,
         shopUrl = shopUrl,
         prefecture = Prefecture.TOKYO,
-        publishStatus = PublishStatus.PUBLISHED,
+        participationStatus = participationStatus,
         images = images,
     )
 

--- a/backend/cs-api/src/main/kotlin/com/mametosho/cs/application/query/result/CoffeeBeanSummaryResult.kt
+++ b/backend/cs-api/src/main/kotlin/com/mametosho/cs/application/query/result/CoffeeBeanSummaryResult.kt
@@ -2,6 +2,7 @@ package com.mametosho.cs.application.query.result
 
 data class CoffeeBeanSummaryResult(
     val id: String,
+    val shopifyBeanId: String,
     val name: String,
     val origin: String,
     val roastLevel: String,

--- a/backend/cs-api/src/main/kotlin/com/mametosho/cs/application/usecase/FindShopsUsecase.kt
+++ b/backend/cs-api/src/main/kotlin/com/mametosho/cs/application/usecase/FindShopsUsecase.kt
@@ -1,7 +1,7 @@
 package com.mametosho.cs.application.usecase
 
 import com.mametosho.cs.application.result.PagedResult
-import com.mametosho.domain.model.shared.PublishStatus
+import com.mametosho.domain.model.shared.ParticipationStatus
 import com.mametosho.domain.model.shop.Shop
 import com.mametosho.domain.repository.ShopRepository
 import org.springframework.stereotype.Service
@@ -13,8 +13,8 @@ class FindShopsUsecase(
 ) {
     @Transactional(readOnly = true)
     open fun execute(page: Int, size: Int): PagedResult<Shop> {
-        // CS（一般ユーザー向け）では公開済みの店舗のみを返す。下書きは除外する。
-        val (shops, totalCount) = shopRepository.findAll(page, size, publishStatus = PublishStatus.PUBLISHED)
+        // CS（一般ユーザー向け）では参画中の店舗のみを返す。参画前・参画落ちは除外する。
+        val (shops, totalCount) = shopRepository.findAll(page, size, participationStatus = ParticipationStatus.PARTICIPATING)
         return PagedResult(shops, totalCount, page, size)
     }
 }

--- a/backend/cs-api/src/main/kotlin/com/mametosho/cs/infrastructure/persistence/mybatis/entity/CoffeeBeanListRow.kt
+++ b/backend/cs-api/src/main/kotlin/com/mametosho/cs/infrastructure/persistence/mybatis/entity/CoffeeBeanListRow.kt
@@ -2,6 +2,7 @@ package com.mametosho.cs.infrastructure.persistence.mybatis.entity
 
 data class CoffeeBeanListRow(
     val id: String,
+    val shopifyBeanId: String,
     val name: String,
     val origin: String,
     val roastLevel: String,

--- a/backend/cs-api/src/main/kotlin/com/mametosho/cs/infrastructure/persistence/mybatis/mapper/CoffeeBeanQueryMapper.kt
+++ b/backend/cs-api/src/main/kotlin/com/mametosho/cs/infrastructure/persistence/mybatis/mapper/CoffeeBeanQueryMapper.kt
@@ -10,7 +10,7 @@ interface CoffeeBeanQueryMapper {
 
     @Select("""
         <script>
-        SELECT cb.id, cb.name, cb.origin, cb.roast_level, cb.processing_method, cb.is_specialty,
+        SELECT cb.id, cb.shopify_bean_id, cb.name, cb.origin, cb.roast_level, cb.processing_method, cb.is_specialty,
                cb.description, cbi.image_url, s.name AS shop_name, s.prefecture AS shop_prefecture, s.shop_url,
                t.name AS taste_name, cbt.evaluation_value
         FROM (

--- a/backend/cs-api/src/main/kotlin/com/mametosho/cs/infrastructure/persistence/mybatis/mapper/CoffeeBeanQueryMapper.kt
+++ b/backend/cs-api/src/main/kotlin/com/mametosho/cs/infrastructure/persistence/mybatis/mapper/CoffeeBeanQueryMapper.kt
@@ -21,6 +21,7 @@ interface CoffeeBeanQueryMapper {
                 ON cbi_inner.coffee_bean_id = cb_inner.id AND cbi_inner.type = 'MAIN'
             <where>
                 AND cb_inner.publish_status = 'PUBLISHED'
+                AND s_inner.participation_status = 'PARTICIPATING'
                 <if test="origin != null">AND cb_inner.origin LIKE CONCAT('%', #{origin}, '%')</if>
                 <if test="roastLevel != null">AND cb_inner.roast_level = #{roastLevel}</if>
                 <if test="prefecture != null">AND s_inner.prefecture = #{prefecture}</if>
@@ -52,6 +53,7 @@ interface CoffeeBeanQueryMapper {
         INNER JOIN coffee_bean_images cbi ON cbi.coffee_bean_id = cb.id AND cbi.type = 'MAIN'
         <where>
             AND cb.publish_status = 'PUBLISHED'
+            AND s.participation_status = 'PARTICIPATING'
             <if test="origin != null">AND cb.origin LIKE CONCAT('%', #{origin}, '%')</if>
             <if test="roastLevel != null">AND cb.roast_level = #{roastLevel}</if>
             <if test="prefecture != null">AND s.prefecture = #{prefecture}</if>

--- a/backend/cs-api/src/main/kotlin/com/mametosho/cs/infrastructure/persistence/query/CoffeeBeanQueryServiceImpl.kt
+++ b/backend/cs-api/src/main/kotlin/com/mametosho/cs/infrastructure/persistence/query/CoffeeBeanQueryServiceImpl.kt
@@ -30,6 +30,7 @@ class CoffeeBeanQueryServiceImpl(
                 val first = beanRows.first()
                 CoffeeBeanSummaryResult(
                     id = first.id,
+                    shopifyBeanId = first.shopifyBeanId,
                     name = first.name,
                     origin = first.origin,
                     roastLevel = first.roastLevel,

--- a/backend/cs-api/src/main/kotlin/com/mametosho/cs/presentation/dto/response/CoffeeBeanResponse.kt
+++ b/backend/cs-api/src/main/kotlin/com/mametosho/cs/presentation/dto/response/CoffeeBeanResponse.kt
@@ -8,6 +8,11 @@ import io.swagger.v3.oas.annotations.media.Schema
 data class CoffeeBeanResponse(
     @Schema(description = "珈琲豆ID", example = "00000000-0000-4000-8000-000000000071")
     val id: String,
+    @Schema(
+        description = "ShopifyのID（Shopify遷移時に使用する）",
+        example = "gid://shopify/Product/400001",
+    )
+    val shopifyBeanId: String,
     @Schema(description = "珈琲豆名", example = "エチオピア イルガチェフェ G1")
     val name: String,
     @Schema(description = "産地", example = "エチオピア")
@@ -43,6 +48,7 @@ data class CoffeeBeanResponse(
     companion object {
         fun from(result: CoffeeBeanSummaryResult): CoffeeBeanResponse = CoffeeBeanResponse(
             id = result.id,
+            shopifyBeanId = result.shopifyBeanId,
             name = result.name,
             origin = result.origin,
             roastLevel = result.roastLevel,

--- a/backend/cs-api/src/main/kotlin/com/mametosho/cs/presentation/dto/response/PlanResponse.kt
+++ b/backend/cs-api/src/main/kotlin/com/mametosho/cs/presentation/dto/response/PlanResponse.kt
@@ -8,6 +8,11 @@ import io.swagger.v3.oas.annotations.media.Schema
 data class PlanResponse(
     @Schema(description = "プランID", example = "00000000-0000-4000-8000-000000000024")
     val id: String,
+    @Schema(
+        description = "ShopifyのプランID（Shopify遷移時に使用する）",
+        example = "gid://shopify/SellingPlan/200004",
+    )
+    val shopifyPlanId: String,
     @Schema(description = "プラン表示名", example = "定番")
     val label: String,
     @Schema(description = "1種あたりのグラム数", example = "60")
@@ -25,6 +30,7 @@ data class PlanResponse(
     companion object {
         fun from(plan: Plan): PlanResponse = PlanResponse(
             id = plan.id.value,
+            shopifyPlanId = plan.shopifyPlanId.value,
             label = plan.label,
             gramWeight = plan.gramWeight,
             beanQuantity = plan.beanQuantity,

--- a/backend/cs-api/src/test/kotlin/com/mametosho/cs/application/usecase/FindCoffeeBeansUsecaseTest.kt
+++ b/backend/cs-api/src/test/kotlin/com/mametosho/cs/application/usecase/FindCoffeeBeansUsecaseTest.kt
@@ -21,6 +21,7 @@ class FindCoffeeBeansUsecaseTest {
         items = listOf(
             CoffeeBeanSummaryResult(
                 id = "00000000-0000-4000-8000-000000000001",
+                shopifyBeanId = "gid://shopify/Product/400001",
                 name = "テストコーヒー豆",
                 origin = "エチオピア",
                 roastLevel = "LIGHT",

--- a/backend/cs-api/src/test/kotlin/com/mametosho/cs/application/usecase/FindShopsUsecaseTest.kt
+++ b/backend/cs-api/src/test/kotlin/com/mametosho/cs/application/usecase/FindShopsUsecaseTest.kt
@@ -1,7 +1,7 @@
 package com.mametosho.cs.application.usecase
 
 import com.mametosho.domain.model.shared.ImageUrl
-import com.mametosho.domain.model.shared.PublishStatus
+import com.mametosho.domain.model.shared.ParticipationStatus
 import com.mametosho.domain.model.shop.Prefecture
 import com.mametosho.domain.model.shop.Shop
 import com.mametosho.domain.model.shop.ShopId
@@ -18,7 +18,7 @@ class FindShopsUsecaseTest {
 
     private var capturedPage: Int? = null
     private var capturedSize: Int? = null
-    private var capturedPublishStatus: PublishStatus? = null
+    private var capturedParticipationStatus: ParticipationStatus? = null
 
     private val sampleShop = Shop(
         id = ShopId("00000000-0000-4000-8000-000000000031"),
@@ -28,7 +28,7 @@ class FindShopsUsecaseTest {
         particular = null,
         shopUrl = "https://mametosho.example.com",
         prefecture = Prefecture.TOKYO,
-        publishStatus = PublishStatus.PUBLISHED,
+        participationStatus = ParticipationStatus.PARTICIPATING,
         images = listOf(
             ShopImage(
                 id = ShopImageId("00000000-0000-4000-8000-000000000091"),
@@ -50,11 +50,11 @@ class FindShopsUsecaseTest {
                 page: Int,
                 size: Int,
                 name: String?,
-                publishStatus: PublishStatus?,
+                participationStatus: ParticipationStatus?,
             ): Pair<List<Shop>, Long> {
                 capturedPage = page
                 capturedSize = size
-                capturedPublishStatus = publishStatus
+                capturedParticipationStatus = participationStatus
                 return Pair(shops, totalCount)
             }
         }
@@ -75,12 +75,12 @@ class FindShopsUsecaseTest {
         }
 
         @Test
-        fun `公開済みのみを取得するようpublishStatusがPUBLISHEDで渡される`() {
+        fun `参画中の店舗のみを取得するようparticipationStatusがPARTICIPATINGで渡される`() {
             val usecase = createUsecase()
 
             usecase.execute(page = 0, size = 20)
 
-            assertEquals(PublishStatus.PUBLISHED, capturedPublishStatus)
+            assertEquals(ParticipationStatus.PARTICIPATING, capturedParticipationStatus)
         }
 
         @Test

--- a/backend/cs-api/src/test/kotlin/com/mametosho/cs/architecture/FqcnUsageTest.kt
+++ b/backend/cs-api/src/test/kotlin/com/mametosho/cs/architecture/FqcnUsageTest.kt
@@ -32,12 +32,9 @@ class FqcnUsageTest {
 
                 sourceFile.readLines().forEachIndexed { lineIndex, line ->
                     val trimmed = line.trim()
-                    if (trimmed.startsWith("package ") ||
-                        trimmed.startsWith("import ") ||
-                        trimmed.startsWith("//") ||
-                        trimmed.startsWith("/*") ||
-                        trimmed.startsWith("*")
-                    ) return@forEachIndexed
+                    val isSkippable = listOf("package ", "import ", "//", "/*", "*")
+                        .any { trimmed.startsWith(it) }
+                    if (isSkippable) return@forEachIndexed
 
                     fqcnPattern.findAll(trimmed).forEach { match ->
                         events.add(

--- a/backend/cs-api/src/test/kotlin/com/mametosho/cs/architecture/FqcnUsageTest.kt
+++ b/backend/cs-api/src/test/kotlin/com/mametosho/cs/architecture/FqcnUsageTest.kt
@@ -1,0 +1,67 @@
+package com.mametosho.cs.architecture
+
+import com.tngtech.archunit.core.domain.JavaClass
+import com.tngtech.archunit.core.importer.ClassFileImporter
+import com.tngtech.archunit.core.importer.ImportOption
+import com.tngtech.archunit.lang.ArchCondition
+import com.tngtech.archunit.lang.ConditionEvents
+import com.tngtech.archunit.lang.SimpleConditionEvent
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes
+import java.io.File
+import kotlin.test.Test
+
+/**
+ * com.mametosho.cs パッケージ内で FQCN（完全修飾クラス名）を使わないことを保証するテスト。
+ *
+ * 対象: コードボディ内の FQCN 参照。
+ * 除外: package 宣言、import 文、コメント行（//、/＊、＊）。
+ */
+class FqcnUsageTest {
+
+    private val importedClasses = ClassFileImporter()
+        .withImportOption(ImportOption.DoNotIncludeTests())
+        .importPackages("com.mametosho.cs")
+
+    @Test
+    fun `コードボディにFQCNを使用しない`() {
+        val fqcnPattern = Regex("""(?<![.\w])com\.mametosho(?:\.[a-z][a-zA-Z0-9_]*)+\.[A-Z]\w*""")
+
+        val noFqcnCondition = object : ArchCondition<JavaClass>("コードボディにFQCNを使用しない") {
+            override fun check(item: JavaClass, events: ConditionEvents) {
+                val sourceFile = resolveSourceFile(item) ?: return
+
+                sourceFile.readLines().forEachIndexed { lineIndex, line ->
+                    val trimmed = line.trim()
+                    if (trimmed.startsWith("package ") ||
+                        trimmed.startsWith("import ") ||
+                        trimmed.startsWith("//") ||
+                        trimmed.startsWith("/*") ||
+                        trimmed.startsWith("*")
+                    ) return@forEachIndexed
+
+                    fqcnPattern.findAll(trimmed).forEach { match ->
+                        events.add(
+                            SimpleConditionEvent.violated(
+                                item,
+                                "${sourceFile.name}:${lineIndex + 1}: FQCNが使用されています → '${match.value}'" +
+                                    "（import文と短縮名を使用すること）",
+                            ),
+                        )
+                    }
+                }
+            }
+
+            private fun resolveSourceFile(item: JavaClass): File? {
+                val simpleName = item.simpleName.removeSuffix("Kt")
+                val packagePath = item.packageName.replace('.', File.separatorChar)
+                return File("src/main/kotlin/$packagePath/$simpleName.kt").takeIf { it.exists() }
+            }
+        }
+
+        classes()
+            .that().resideInAPackage("com.mametosho.cs..")
+            .should(noFqcnCondition)
+            .because("コードボディでは import 文と短縮名を使用し、FQCNは使用しないこと")
+            .check(importedClasses)
+    }
+}

--- a/backend/cs-api/src/test/kotlin/com/mametosho/cs/infrastructure/persistence/query/CoffeeBeanQueryServiceImplTest.kt
+++ b/backend/cs-api/src/test/kotlin/com/mametosho/cs/infrastructure/persistence/query/CoffeeBeanQueryServiceImplTest.kt
@@ -18,6 +18,7 @@ class CoffeeBeanQueryServiceImplTest {
 
     private val sampleRow = CoffeeBeanListRow(
         id = "00000000-0000-4000-8000-000000000001",
+        shopifyBeanId = "gid://shopify/Product/400001",
         name = "テストコーヒー豆",
         origin = "エチオピア",
         roastLevel = "LIGHT",

--- a/backend/cs-api/src/test/kotlin/com/mametosho/cs/presentation/controller/CoffeeBeanControllerTest.kt
+++ b/backend/cs-api/src/test/kotlin/com/mametosho/cs/presentation/controller/CoffeeBeanControllerTest.kt
@@ -74,8 +74,8 @@ class CoffeeBeanControllerTest {
         publishStatus: String = "PUBLISHED",
     ) {
         jdbcTemplate.execute(
-            "INSERT INTO shops (id, shopify_shop_id, name, shop_url, prefecture) " +
-                "VALUES ('$shopId', '$shopifyShopId', '$shopName', 'https://example.com', '$prefecture')",
+            "INSERT INTO shops (id, shopify_shop_id, name, shop_url, prefecture, participation_status) " +
+                "VALUES ('$shopId', '$shopifyShopId', '$shopName', 'https://example.com', '$prefecture', 'PARTICIPATING')",
         )
         jdbcTemplate.execute(
             "INSERT INTO tastes (id, name) VALUES ('$tasteId', '$tasteName')",

--- a/backend/cs-api/src/test/kotlin/com/mametosho/cs/presentation/controller/PlanControllerTest.kt
+++ b/backend/cs-api/src/test/kotlin/com/mametosho/cs/presentation/controller/PlanControllerTest.kt
@@ -74,6 +74,7 @@ class PlanControllerTest {
 
             val item = response.body?.get(0)
             assertEquals("00000000-0000-4000-8000-000000000024", item?.id)
+            assertEquals("shopify-plan-1", item?.shopifyPlanId)
             assertEquals("定番", item?.label)
             assertEquals(30, item?.gramWeight)
             assertEquals(4, item?.beanQuantity)

--- a/backend/cs-api/src/test/kotlin/com/mametosho/cs/presentation/controller/ShopControllerTest.kt
+++ b/backend/cs-api/src/test/kotlin/com/mametosho/cs/presentation/controller/ShopControllerTest.kt
@@ -62,11 +62,11 @@ class ShopControllerTest {
         shopUrl: String = "https://mametosho.example.com",
         prefecture: String = "TOKYO",
         logoImageUrl: String = "https://example.com/logo.png",
-        publishStatus: String = "PUBLISHED",
+        participationStatus: String = "PARTICIPATING",
     ) {
         jdbcTemplate.execute(
-            "INSERT INTO shops (id, shopify_shop_id, name, introduction, shop_url, prefecture, publish_status) " +
-                "VALUES ('$id', '$shopifyShopId', '$name', '$introduction', '$shopUrl', '$prefecture', '$publishStatus')",
+            "INSERT INTO shops (id, shopify_shop_id, name, introduction, shop_url, prefecture, participation_status) " +
+                "VALUES ('$id', '$shopifyShopId', '$name', '$introduction', '$shopUrl', '$prefecture', '$participationStatus')",
         )
         val imageId = id.take(24) + "9" + id.drop(25)
         jdbcTemplate.execute(
@@ -115,16 +115,16 @@ class ShopControllerTest {
         }
 
         @Test
-        fun `下書き状態の店舗は一覧に含まれない`() {
+        fun `参画前・参画落ちの店舗は一覧に含まれない`() {
             insertShopWithLogo(
                 id = "00000000-0000-4000-8000-000000000031",
-                shopifyShopId = "published-shop",
-                publishStatus = "PUBLISHED",
+                shopifyShopId = "participating-shop",
+                participationStatus = "PARTICIPATING",
             )
             insertShopWithLogo(
                 id = "00000000-0000-4000-8000-000000000032",
-                shopifyShopId = "draft-shop",
-                publishStatus = "DRAFT",
+                shopifyShopId = "before-shop",
+                participationStatus = "BEFORE_PARTICIPATION",
             )
 
             val response = shopController.listShops(page = 0, size = 20)

--- a/backend/cs-api/src/test/kotlin/com/mametosho/cs/presentation/dto/response/CoffeeBeanResponseTest.kt
+++ b/backend/cs-api/src/test/kotlin/com/mametosho/cs/presentation/dto/response/CoffeeBeanResponseTest.kt
@@ -11,6 +11,7 @@ class CoffeeBeanResponseTest {
         isSpecialty: Boolean = true,
     ): CoffeeBeanSummaryResult = CoffeeBeanSummaryResult(
         id = "00000000-0000-4000-8000-000000000001",
+        shopifyBeanId = "gid://shopify/Product/400001",
         name = "テストコーヒー豆",
         origin = "エチオピア",
         roastLevel = "LIGHT",

--- a/backend/docs/domainModel.md
+++ b/backend/docs/domainModel.md
@@ -159,10 +159,18 @@ classDiagram
       ...
       OKINAWA
     }
+
+    class ParticipationStatus {
+      <<Enum>>
+      BEFORE_PARTICIPATION
+      PARTICIPATING
+      DROPPED
+    }
   }
 
   Shop *-- ShopImage
   Shop --> Prefecture
+  Shop --> ParticipationStatus
   ShopImage --> ShopImageType
 
   namespace CoffeeBean集約 {
@@ -219,10 +227,18 @@ classDiagram
       wet_hulling
       honey
     }
+
+    class PublishStatus {
+      <<Enum>>
+      DRAFT
+      PUBLISHED
+      INVALIDATED
+    }
   }
 
   CoffeeBean --> RoastLevel
   CoffeeBean --> ProcessingMethod
+  CoffeeBean --> PublishStatus
   CoffeeBean o-- Shop : shopId
   CoffeeBeanImage --> CoffeeBeanImageType
   CoffeeBean *-- CoffeeBeanImage

--- a/backend/docs/domainModel.md
+++ b/backend/docs/domainModel.md
@@ -136,7 +136,7 @@ classDiagram
       particular: String?
       shopUrl: String
       prefecture: Prefecture
-      publishStatus: PublishStatus
+      participationStatus: ParticipationStatus
       images: List~ShopImage~
     }
 

--- a/backend/docs/domains/coffeeBean.md
+++ b/backend/docs/domains/coffeeBean.md
@@ -7,9 +7,10 @@ Shopifyの商品と1対1で紐づく。産地、焙煎度、精製方法、テ�
 
 ## ライフサイクル
 
-- **登録**: 管理者が管理画面から登録する。初期状態は任意に選択でき、デフォルトは下書き（draft）
+- **登録**: 管理者が管理画面から登録する。初期状態は任意に選択でき、デフォルトは下書き（DRAFT）
 - **更新**: 珈琲豆情報・画像・テイスト評価の変更
-- **公開状態の切り替え**: 管理者が draft ⇄ published を双方向に切り替えられる。draft の珈琲豆はCS（一般ユーザー向け）には公開されない
+- **公開状態の切り替え**: 管理者が DRAFT ⇄ PUBLISHED を双方向に切り替えられる。DRAFT の珈琲豆はCS（一般ユーザー向け）には公開されない
+- **自動無効化**: 提供元の店舗が参画落ち（DROPPED）になると、その店舗に属する全珈琲豆が INVALIDATED に自動設定される。INVALIDATED になると以降の更新は不可
 
 ## CoffeeBean
 
@@ -27,7 +28,7 @@ Shopifyの商品と1対1で紐づく。産地、焙煎度、精製方法、テ�
 | roastLevel | RoastLevel | 焙煎度（light / medium / city / french） |
 | processingMethod | ProcessingMethod | 精製方法（fully_washed / washed / thermal_shock_natural / natural / wet_hulling / honey） |
 | isSpecialty | Boolean | スペシャルティコーヒーかどうか |
-| publishStatus | PublishStatus | 公開状態（draft / published） |
+| publishStatus | PublishStatus | 公開状態（DRAFT / PUBLISHED / INVALIDATED） |
 | images | List\<CoffeeBeanImage\> | 珈琲豆画像一覧 |
 | tastes | List\<CoffeeBeanTaste\> | テイスト評価一覧 |
 
@@ -43,13 +44,18 @@ Shopifyの商品と1対1で紐づく。産地、焙煎度、精製方法、テ�
 - shopIdは存在するShopを参照しなければならない
 - **images は必須**。少なくとも1枚の画像を持たなければならない
 - **tastes は必須**。全テイスト種別（酸味・苦味・甘味・コク・香り）の評価値を持たなければならない
+- INVALIDATED 状態の珈琲豆は更新できない
 
 ## PublishStatus（Enum）
 
-公開状態を表すEnum。draft（下書き・非公開）と published（公開）の双方向の遷移が可能。
-draft の珈琲豆はCS（一般ユーザー向けAPI）には公開されない。Shop集約と共有する値オブジェクト。
+公開状態を表すEnum。INVALIDATED は店舗が参画落ち（DROPPED）になった際にシステムが自動設定する終端状態。
+PUBLISHED 以外の珈琲豆はCS（一般ユーザー向けAPI）には公開されない。
 
-`DRAFT`, `PUBLISHED`
+| 値 | 意味 | 設定者 |
+|---|---|---|
+| `DRAFT` | 下書き・非公開 | 管理者 |
+| `PUBLISHED` | 公開 | 管理者 |
+| `INVALIDATED` | 無効化（終端・変更不可） | システム自動設定（店舗DROPPED時） |
 
 ## CoffeeBeanImage（エンティティ）
 

--- a/backend/docs/domains/shop.md
+++ b/backend/docs/domains/shop.md
@@ -7,9 +7,9 @@ Shopifyのショップと1対1で紐づく。
 
 ## ライフサイクル
 
-- **登録**: 管理者が管理画面から登録する。初期状態は任意に選択でき、デフォルトは下書き（draft）
+- **登録**: 管理者が管理画面から登録する。初期状態は参画前（BEFORE_PARTICIPATION）または参画中（PARTICIPATING）を選択できる
 - **更新**: 店舗情報・画像の変更
-- **公開状態の切り替え**: 管理者が draft ⇄ published を双方向に切り替えられる。draft の店舗はCS（一般ユーザー向け）には公開されない
+- **参画ステータスの遷移**: 管理者が BEFORE_PARTICIPATION → PARTICIPATING → DROPPED の直線遷移のみ可能。DROPPED になると以降の変更は不可。PARTICIPATING の店舗のみ CS（一般ユーザー向け）に公開される
 
 ## Shop
 
@@ -24,7 +24,7 @@ Shopifyのショップと1対1で紐づく。
 | particular | String? | こだわり |
 | shopUrl | String | 店舗URL |
 | prefecture | Prefecture | 都道府県 |
-| publishStatus | PublishStatus | 公開状態（draft / published） |
+| participationStatus | ParticipationStatus | 参画ステータス |
 | images | List\<ShopImage\> | 店舗画像一覧 |
 
 ### 不変条件
@@ -37,12 +37,16 @@ Shopifyのショップと1対1で紐づく。
 - prefectureは必須
 - LOGO画像はちょうど1枚（必須）
 
-## PublishStatus（Enum）
+## ParticipationStatus（Enum）
 
-公開状態を表すEnum。draft（下書き・非公開）と published（公開）の双方向の遷移が可能。
-draft の店舗はCS（一般ユーザー向けAPI）には公開されない。
+参画ステータスを表すEnum。BEFORE_PARTICIPATION → PARTICIPATING → DROPPED の直線遷移のみ許可。
+DROPPED の店舗はステータス変更不可（終端状態）。PARTICIPATING の店舗のみ CS（一般ユーザー向けAPI）に公開される。
 
-`DRAFT`, `PUBLISHED`
+| 値 | ラベル | 説明 |
+|---|---|---|
+| `BEFORE_PARTICIPATION` | 参画前 | 登録済みだがまだ参画していない状態 |
+| `PARTICIPATING` | 参画中 | 参画中。CS APIに公開される |
+| `DROPPED` | 参画落ち | 参画から外れた終端状態。以降の変更不可 |
 
 ## Prefecture（Enum）
 

--- a/docs/swagger/admin-api.yml
+++ b/docs/swagger/admin-api.yml
@@ -572,7 +572,7 @@ paths:
                       particular: 厳選された豆のみを使用しています。
                       shopUrl: https://example.com
                       prefecture: TOKYO
-                      publishStatus: PUBLISHED
+                      participationStatus: PARTICIPATING
                     totalCount: 1
                     page: 0
                     size: 20
@@ -928,14 +928,15 @@ components:
           type: string
           description: 都道府県
           example: TOKYO
-        publishStatus:
+        participationStatus:
           type: string
-          description: "公開状態（DRAFT: 下書き / PUBLISHED: 公開）"
-          example: PUBLISHED
+          description: "参画ステータス（BEFORE_PARTICIPATION: 参画前 / PARTICIPATING: 参画中 / DROPPED:\
+            \ 参画落ち）"
+          example: PARTICIPATING
       required:
       - name
+      - participationStatus
       - prefecture
-      - publishStatus
       - shopUrl
       - shopifyShopId
     ShopResponse:
@@ -1146,14 +1147,14 @@ components:
           type: string
           description: 都道府県
           example: TOKYO
-        publishStatus:
+        participationStatus:
           type: string
-          description: "公開状態（DRAFT: 下書き / PUBLISHED: 公開）"
-          example: DRAFT
+          description: "参画ステータス（BEFORE_PARTICIPATION: 参画前 / PARTICIPATING: 参画中）"
+          example: BEFORE_PARTICIPATION
       required:
       - name
+      - participationStatus
       - prefecture
-      - publishStatus
       - shopUrl
       - shopifyShopId
     CreateCoffeeBeanRequest:
@@ -1310,15 +1311,16 @@ components:
           type: string
           description: 都道府県
           example: TOKYO
-        publishStatus:
+        participationStatus:
           type: string
-          description: "公開状態（DRAFT: 下書き / PUBLISHED: 公開）"
-          example: PUBLISHED
+          description: "参画ステータス（BEFORE_PARTICIPATION: 参画前 / PARTICIPATING: 参画中 / DROPPED:\
+            \ 参画落ち）"
+          example: PARTICIPATING
       required:
       - id
       - name
+      - participationStatus
       - prefecture
-      - publishStatus
       - shopUrl
       - shopifyShopId
     ImageDetail:
@@ -1373,10 +1375,11 @@ components:
           type: string
           description: 都道府県
           example: TOKYO
-        publishStatus:
+        participationStatus:
           type: string
-          description: "公開状態（DRAFT: 下書き / PUBLISHED: 公開）"
-          example: PUBLISHED
+          description: "参画ステータス（BEFORE_PARTICIPATION: 参画前 / PARTICIPATING: 参画中 / DROPPED:\
+            \ 参画落ち）"
+          example: PARTICIPATING
         images:
           type: array
           description: 画像一覧
@@ -1386,8 +1389,8 @@ components:
       - id
       - images
       - name
+      - participationStatus
       - prefecture
-      - publishStatus
       - shopUrl
       - shopifyShopId
     PlanListResponse:

--- a/frontend/src/app/lp/_lib/coffeeBeanApi.ts
+++ b/frontend/src/app/lp/_lib/coffeeBeanApi.ts
@@ -5,6 +5,7 @@ export type TasteProfile = {
 
 export interface BeanDetail {
   id: string;
+  shopifyBeanId: string;
   imageSrc: string;
   tag: string;
   tagColor: string;
@@ -33,6 +34,7 @@ type TasteProfileApiItem = {
 
 type CoffeeBeanApiItem = {
   id: string;
+  shopifyBeanId: string;
   name: string;
   origin: string;
   roastLevel: "LIGHT" | "MEDIUM" | "CITY" | "FRENCH";
@@ -121,6 +123,7 @@ function toBeanDetail(item: CoffeeBeanApiItem): BeanDetail {
   const tagColor = ROAST_TAG_COLOR[item.roastLevel] ?? "#A6683D";
   return {
     id: item.id,
+    shopifyBeanId: item.shopifyBeanId,
     imageSrc: item.imageUrl,
     tag: roastJP,
     tagColor,

--- a/frontend/src/app/lp/_lib/planApi.ts
+++ b/frontend/src/app/lp/_lib/planApi.ts
@@ -14,6 +14,7 @@ export type PlanGroup = {
 
 type PlanApiItem = {
   id: string;
+  shopifyPlanId: string;
   label: string;
   gramWeight: number;
   beanQuantity: number;
@@ -56,8 +57,8 @@ export async function fetchPlans(): Promise<PlanGroup[]> {
     const single = singleMap.get(key);
     if (!single) continue;
     groups.push({
-      subscriptionId: sub.id,
-      singleId: single.id,
+      subscriptionId: sub.shopifyPlanId,
+      singleId: single.shopifyPlanId,
       label: sub.label,
       gramWeight: sub.gramWeight as WeightGrams,
       beanQuantity: sub.beanQuantity,

--- a/frontend/src/app/lp/beans/BeansContent.tsx
+++ b/frontend/src/app/lp/beans/BeansContent.tsx
@@ -135,9 +135,12 @@ export default function BeansContent({ beans, planGroups }: BeansContentProps) {
           </>
         }
         ctaText="購入に進む"
-        onCtaClick={() =>
-          moveToCoffeeBeanListPage(planId ?? undefined, selectedIds)
-        }
+        onCtaClick={() => {
+          const shopifyBeanIds = selectedIds.map(
+            (id) => beans.find((b) => b.id === id)?.shopifyBeanId ?? id,
+          );
+          moveToCoffeeBeanListPage(planId ?? undefined, shopifyBeanIds);
+        }}
         showIcon={false}
         disabled={selectedIds.length === 0}
       />

--- a/frontend/src/app/lp/beans/BeansContent.tsx
+++ b/frontend/src/app/lp/beans/BeansContent.tsx
@@ -136,9 +136,9 @@ export default function BeansContent({ beans, planGroups }: BeansContentProps) {
         }
         ctaText="購入に進む"
         onCtaClick={() => {
-          const shopifyBeanIds = selectedIds.map(
-            (id) => beans.find((b) => b.id === id)?.shopifyBeanId ?? id,
-          );
+          const shopifyBeanIds = selectedIds
+            .map((id) => beans.find((b) => b.id === id)?.shopifyBeanId)
+            .filter((id): id is string => id !== undefined);
           moveToCoffeeBeanListPage(planId ?? undefined, shopifyBeanIds);
         }}
         showIcon={false}

--- a/frontend/src/app/lp/catalog/CatalogClient.tsx
+++ b/frontend/src/app/lp/catalog/CatalogClient.tsx
@@ -126,9 +126,9 @@ function CatalogContent({
     const planId = mode === "sub" ? plan.subscriptionId : plan.singleId;
     const shopifyBeanIds = omakase
       ? []
-      : [...selected].map(
-          (id) => beans.find((b) => b.id === id)?.shopifyBeanId ?? id,
-        );
+      : [...selected]
+          .map((id) => beans.find((b) => b.id === id)?.shopifyBeanId)
+          .filter((id): id is string => id !== undefined);
     moveToCoffeeBeanListPage(planId, shopifyBeanIds);
   };
 

--- a/frontend/src/app/lp/catalog/CatalogClient.tsx
+++ b/frontend/src/app/lp/catalog/CatalogClient.tsx
@@ -124,7 +124,12 @@ function CatalogContent({
   const handlePurchase = () => {
     if (!plan) return;
     const planId = mode === "sub" ? plan.subscriptionId : plan.singleId;
-    moveToCoffeeBeanListPage(planId, omakase ? [] : [...selected]);
+    const shopifyBeanIds = omakase
+      ? []
+      : [...selected].map(
+          (id) => beans.find((b) => b.id === id)?.shopifyBeanId ?? id,
+        );
+    moveToCoffeeBeanListPage(planId, shopifyBeanIds);
   };
 
   const handleSelectPlan = (p: PlanGroup) => {

--- a/infrastructure/db/local-data.sql
+++ b/infrastructure/db/local-data.sql
@@ -50,10 +50,10 @@ INSERT IGNORE INTO plans (id, shopify_plan_id, label, gram_weight, bean_quantity
 -- ------------------------------------------------------------
 -- shops（店舗）
 -- ------------------------------------------------------------
-INSERT IGNORE INTO shops (id, shopify_shop_id, name, introduction, particular, shop_url, prefecture, publish_status) VALUES
-('00000000-0000-4000-8000-000000000031', 'gid://shopify/Shop/300001', '珈琲工房 まめとしょ', '東京都渋谷区にある自家焙煎珈琲店。厳選されたスペシャルティコーヒーをお届けします。', 'シングルオリジンの豆を、注文後に焙煎してお届けします。', 'https://mametosho.example.com', 'TOKYO', 'PUBLISHED'),
-('00000000-0000-4000-8000-000000000032', 'gid://shopify/Shop/300002', 'CAFÉ LUMIÈRE', '京都の町家を改装した珈琲専門店。フレンチローストからライトローストまで幅広い焙煎度をご用意。', '契約農園から直接仕入れた高品質な生豆のみを使用しています。', 'https://cafe-lumiere.example.com', 'KYOTO', 'PUBLISHED'),
-('00000000-0000-4000-8000-000000000033', 'gid://shopify/Shop/300003', '豆蔵珈琲', '福岡の老舗珈琲焙煎所。創業以来変わらない焙煎技術で深みのある一杯を。', '炭火焙煎による独自の香ばしさが特徴です。', 'https://mamezou-coffee.example.com', 'FUKUOKA', 'DRAFT');
+INSERT IGNORE INTO shops (id, shopify_shop_id, name, introduction, particular, shop_url, prefecture, participation_status) VALUES
+('00000000-0000-4000-8000-000000000031', 'gid://shopify/Shop/300001', '珈琲工房 まめとしょ', '東京都渋谷区にある自家焙煎珈琲店。厳選されたスペシャルティコーヒーをお届けします。', 'シングルオリジンの豆を、注文後に焙煎してお届けします。', 'https://mametosho.example.com', 'TOKYO', 'PARTICIPATING'),
+('00000000-0000-4000-8000-000000000032', 'gid://shopify/Shop/300002', 'CAFÉ LUMIÈRE', '京都の町家を改装した珈琲専門店。フレンチローストからライトローストまで幅広い焙煎度をご用意。', '契約農園から直接仕入れた高品質な生豆のみを使用しています。', 'https://cafe-lumiere.example.com', 'KYOTO', 'PARTICIPATING'),
+('00000000-0000-4000-8000-000000000033', 'gid://shopify/Shop/300003', '豆蔵珈琲', '福岡の老舗珈琲焙煎所。創業以来変わらない焙煎技術で深みのある一杯を。', '炭火焙煎による独自の香ばしさが特徴です。', 'https://mamezou-coffee.example.com', 'FUKUOKA', 'BEFORE_PARTICIPATION');
 
 -- ------------------------------------------------------------
 -- tastes（テイスト）

--- a/infrastructure/db/schema.sql
+++ b/infrastructure/db/schema.sql
@@ -43,7 +43,7 @@ CREATE TABLE IF NOT EXISTS shops (
     particular      TEXT                                                       COMMENT 'こだわり',
     shop_url        VARCHAR(2048)  NOT NULL                                     COMMENT '店舗URL',
     prefecture      VARCHAR(255)  NOT NULL                                       COMMENT '都道府県',
-    publish_status  ENUM('DRAFT', 'PUBLISHED') NOT NULL DEFAULT 'DRAFT'          COMMENT '公開状態',
+    participation_status ENUM('BEFORE_PARTICIPATION', 'PARTICIPATING', 'DROPPED') NOT NULL DEFAULT 'BEFORE_PARTICIPATION' COMMENT '参画ステータス',
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP                             COMMENT '作成日時',
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新日時'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='店舗マスタテーブル';
@@ -79,7 +79,7 @@ CREATE TABLE IF NOT EXISTS coffee_beans (
     roast_level       ENUM('LIGHT', 'MEDIUM', 'CITY', 'FRENCH') NOT NULL       COMMENT '焙煎度',
     processing_method ENUM('FULLY_WASHED', 'WASHED', 'THERMAL_SHOCK_NATURAL', 'NATURAL', 'WET_HULLING', 'HONEY') NOT NULL COMMENT '精製方法',
     is_specialty      BOOLEAN       NOT NULL DEFAULT FALSE                     COMMENT 'スペシャルティコーヒーかどうか',
-    publish_status    ENUM('DRAFT', 'PUBLISHED') NOT NULL DEFAULT 'DRAFT'       COMMENT '公開状態',
+    publish_status    ENUM('DRAFT', 'PUBLISHED', 'INVALIDATED') NOT NULL DEFAULT 'DRAFT' COMMENT '公開状態',
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP                             COMMENT '作成日時',
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新日時',
     FOREIGN KEY (shop_id) REFERENCES shops (id)


### PR DESCRIPTION
## Summary

- 店舗の `publishStatus`（DRAFT/PUBLISHED）を `participationStatus`（参画前/参画中/参画落ち）に置き換え
- 参画落ち時に店舗のコーヒー豆を自動無効化（`ShopDropDomainService` として分離）
- 全モジュールに ArchUnit FQCN 禁止テストを追加

## 変更詳細

### 参画ステータス
| 値 | 意味 | CS公開 |
|---|---|---|
| `BEFORE_PARTICIPATION` | 参画前 | ✗ |
| `PARTICIPATING` | 参画中 | ✓ |
| `DROPPED` | 参画落ち（終端・変更不可） | ✗ |

状態遷移: `BEFORE_PARTICIPATION → PARTICIPATING → DROPPED` の直線のみ許可。

### コーヒー豆の自動無効化
- 店舗が `DROPPED` になると `ShopDropDomainService` が全豆を `INVALIDATED` に一括更新
- `INVALIDATED` になった豆はそれ以降の更新が不可（`CoffeeBean.update()` でバリデーション）
- フォームから `INVALIDATED` は設定不可（DRAFT/PUBLISHED のみ選択肢として表示）

### フロントエンド
- 店舗編集フォームのステータスを SelectField に変更（PARTICIPATING 時のみ DROPPED 選択肢を表示）
- `DROPPED` を選択して送信しようとすると確認ダイアログを表示
- `ParticipationStatusBadge` コンポーネント新規追加

### ArchUnit テスト
- `common` / `admin-api` / `cs-api` の 3 モジュールに FQCN 禁止ルールを追加
- クラス名からソースファイルを導出してコードボディ内の FQCN を検知（ソース属性非依存）

## Test plan
- [ ] `./gradlew test` が全て通ること
- [ ] 管理画面で店舗一覧の「参画ステータス」列が表示されること
- [ ] 店舗を `BEFORE_PARTICIPATION → PARTICIPATING → DROPPED` の順に変更できること
- [ ] `DROPPED` 変更前に確認ダイアログが表示されること
- [ ] `DROPPED` 後の店舗の豆が CS API に表示されないこと
- [ ] `DROPPED` 後の店舗の豆を更新しようとすると 422 が返ること
- [ ] `FqcnUsageTest` が FQCN を正しく検知すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)