### PR TITLE
fix: カタログページで豆カードをクリックすると500エラーになる問題を修正

### DIFF
--- a/frontend/src/app/lp/_components/BeanDetailModal/beanDetailModal.tsx
+++ b/frontend/src/app/lp/_components/BeanDetailModal/beanDetailModal.tsx
@@ -62,6 +62,7 @@ export default function BeanDetailModal({
                 alt={bean.name}
                 fill
                 sizes="(max-width: 440px) 100vw, 400px"
+                unoptimized
                 className={styles.hero}
               />
               {bean.isSpecialty && (


### PR DESCRIPTION
## 概要

`/lp/catalog` で豆のカードをクリックすると500エラーが発生する問題を修正。

## 原因

`BeanDetailModal` の `<Image>` コンポーネントに `unoptimized` が設定されていなかったため、Next.js の画像最適化API（`/_next/image`）が外部URL（S3等）の画像を処理しようとして500エラーが発生していた。

`next.config.ts` に `images.remotePatterns` が未設定なので、外部URLをそのまま渡すと最適化に失敗する。

## 修正内容

- `BeanDetailModal` の `<Image>` に `unoptimized` を追加
- カード一覧（`LibraryCard`）では既に `unoptimized` が設定されており、それと同様の扱いに統一

## テスト手順

- [ ] `/lp/catalog` にアクセスし、プランを選択して豆カードの一覧を表示する
- [ ] 豆カードをクリックしてモーダルが正常に開くことを確認する
- [ ] 画像が500エラーなく表示されることを確認する

🤖 Generated with [Claude Code](https://claude.com/claude-code)