### PR TITLE
fix: テイストプロファイルのバー幅計算を修正

### DIFF
--- a/frontend/src/app/lp/_components/BeanDetailModal/beanDetailModal.tsx
+++ b/frontend/src/app/lp/_components/BeanDetailModal/beanDetailModal.tsx
@@ -130,7 +130,7 @@ export default function BeanDetailModal({
                 <div className={styles.tasteBarBg}>
                   <div
                     className={styles.tasteBarFill}
-                    style={{ width: `${t.value}%` }}
+                    style={{ width: `${(t.value / 5) * 100}%` }}
                   />
                 </div>
               </div>


### PR DESCRIPTION
## Summary

- `BeanDetailModal`のテイストプロファイルバーの幅計算が誤っていたのを修正
- APIが返す`value`は1〜5のスケールだが、`${t.value}%`と直接%に渡していたため最大5%にしかならず、バーがほぼ見えない状態だった
- `(t.value / 5) * 100`%に変換することで正しく0〜100%の範囲で表示されるよう修正

## Test plan

- [ ] LPのコーヒー豆詳細モーダルを開き、テイストプロファイルのバーが値に応じた適切な幅で表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)