### PR TITLE
ci: ECRに同じタグが既に存在する場合はDockerイメージのビルド・プッシュをスキップ

### DIFF
--- a/.github/workflows/deploy-admin-api.yml
+++ b/.github/workflows/deploy-admin-api.yml
@@ -63,10 +63,25 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
 
+      - name: Check if image tag already exists in ECR
+        id: check-image
+        run: |
+          if aws ecr describe-images \
+            --repository-name admin-api-${{ inputs.environment }} \
+            --image-ids imageTag=${{ steps.set-tag.outputs.tag }} \
+            --region ${{ env.AWS_REGION }} > /dev/null 2>&1; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "Image tag ${{ steps.set-tag.outputs.tag }} already exists. Skipping build and push."
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Set up Docker Buildx
+        if: steps.check-image.outputs.exists != 'true'
         uses: docker/setup-buildx-action@v3
 
       - name: Build and Push Docker image
+        if: steps.check-image.outputs.exists != 'true'
         uses: docker/build-push-action@v6
         with:
           context: ./backend

--- a/.github/workflows/deploy-admin-frontend.yml
+++ b/.github/workflows/deploy-admin-frontend.yml
@@ -63,10 +63,25 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
 
+      - name: Check if image tag already exists in ECR
+        id: check-image
+        run: |
+          if aws ecr describe-images \
+            --repository-name admin-frontend-${{ inputs.environment }} \
+            --image-ids imageTag=${{ steps.set-tag.outputs.tag }} \
+            --region ${{ env.AWS_REGION }} > /dev/null 2>&1; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "Image tag ${{ steps.set-tag.outputs.tag }} already exists. Skipping build and push."
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Set up Docker Buildx
+        if: steps.check-image.outputs.exists != 'true'
         uses: docker/setup-buildx-action@v3
 
       - name: Build and Push Docker image
+        if: steps.check-image.outputs.exists != 'true'
         uses: docker/build-push-action@v6
         with:
           context: ./admin-frontend

--- a/.github/workflows/deploy-cs-api.yml
+++ b/.github/workflows/deploy-cs-api.yml
@@ -63,10 +63,25 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
 
+      - name: Check if image tag already exists in ECR
+        id: check-image
+        run: |
+          if aws ecr describe-images \
+            --repository-name cs-api-${{ inputs.environment }} \
+            --image-ids imageTag=${{ steps.set-tag.outputs.tag }} \
+            --region ${{ env.AWS_REGION }} > /dev/null 2>&1; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "Image tag ${{ steps.set-tag.outputs.tag }} already exists. Skipping build and push."
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Set up Docker Buildx
+        if: steps.check-image.outputs.exists != 'true'
         uses: docker/setup-buildx-action@v3
 
       - name: Build and Push Docker image
+        if: steps.check-image.outputs.exists != 'true'
         uses: docker/build-push-action@v6
         with:
           context: ./backend

--- a/.github/workflows/deploy-cs-frontend.yml
+++ b/.github/workflows/deploy-cs-frontend.yml
@@ -63,10 +63,25 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
 
+      - name: Check if image tag already exists in ECR
+        id: check-image
+        run: |
+          if aws ecr describe-images \
+            --repository-name cs-frontend-${{ inputs.environment }} \
+            --image-ids imageTag=${{ steps.set-tag.outputs.tag }} \
+            --region ${{ env.AWS_REGION }} > /dev/null 2>&1; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "Image tag ${{ steps.set-tag.outputs.tag }} already exists. Skipping build and push."
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Set up Docker Buildx
+        if: steps.check-image.outputs.exists != 'true'
         uses: docker/setup-buildx-action@v3
 
       - name: Build and Push Docker image
+        if: steps.check-image.outputs.exists != 'true'
         uses: docker/build-push-action@v6
         with:
           context: ./frontend


### PR DESCRIPTION
## Summary

- 全4つのデプロイワークフロー（admin-api, cs-api, admin-frontend, cs-frontend）に、ECRタグの存在チェックを追加
- 同じコミットSHAのタグが既にECRに存在する場合、`Set up Docker Buildx` と `Build and Push Docker image` をスキップしてデプロイステップへ進む
- ECRのImmutabilityが有効な環境で同一コミットを再デプロイする際にワークフローが失敗していた問題を修正

## Test plan

- [ ] 同じコミットを2回デプロイし、2回目はビルド・プッシュがスキップされてデプロイが成功することを確認
- [ ] 新しいコミットでは通常通りビルド・プッシュが実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)