### PR TITLE
fix: ALBアタッチメントのfor_each未知値エラーを修正

### DIFF
--- a/admin-frontend/package.json
+++ b/admin-frontend/package.json
@@ -2,6 +2,7 @@
   "name": "admin-frontend",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "pnpm@10.24.0",
   "scripts": {
     "dev": "next dev --port 3001",
     "build": "next build",

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,7 +4,7 @@
 # Base stage
 # ============================================
 FROM node:24-alpine AS base
-RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN corepack enable && corepack prepare pnpm@10.24.0 --activate
 
 # ============================================
 # Dependencies stage

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,7 @@
   "name": "frontend",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "pnpm@10.24.0",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,6 +31,8 @@
     "typescript": "^5"
   },
   "pnpm": {
-    "onlyBuiltDependencies": ["sharp"]
+    "onlyBuiltDependencies": [
+      "sharp"
+    ]
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,5 +28,8 @@
     "gh-pages": "^6.3.0",
     "openapi-typescript": "^7.13.0",
     "typescript": "^5"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": ["sharp"]
   }
 }

--- a/infrastructure/terraform/modules/alb_attachment/main.tf
+++ b/infrastructure/terraform/modules/alb_attachment/main.tf
@@ -40,7 +40,7 @@ resource "aws_lb_listener_rule" "this" {
 }
 
 resource "aws_lb_listener_certificate" "extra" {
-  for_each        = toset(var.extra_certificate_arns)
+  for_each        = { for idx, arn in var.extra_certificate_arns : tostring(idx) => arn }
   listener_arn    = var.listener_arn
   certificate_arn = each.value
 }


### PR DESCRIPTION
## Summary

- `aws_lb_listener_certificate.extra` の `for_each` で `toset(var.extra_certificate_arns)` を使用していたが、ACM証明書ARNはapply時にしか確定しないためplan時にエラーが発生していた
- インデックスをキーにしたmap（`{ for idx, arn in var.extra_certificate_arns : tostring(idx) => arn }`）に変換し、キーがplan時に確定するよう修正

## 注意事項

既存の `aws_lb_listener_certificate.extra` リソースがstateに存在する場合、キーが変わるため**再作成（destroy → create）が発生します**。

## Test plan

- [x] `terraform validate` (prod環境) → Success

🤖 Generated with [Claude Code](https://claude.com/claude-code)