### PR TITLE
chore: sampleテーブルのスキーマ定義と初期データを削除

### DIFF
--- a/infrastructure/db/local-data.sql
+++ b/infrastructure/db/local-data.sql
@@ -2,10 +2,6 @@
 -- ローカル開発用初期データ
 -- ============================================================
 
--- sample
-INSERT IGNORE INTO sample (id, name) VALUES (1, 'Sample Item 1');
-INSERT IGNORE INTO sample (id, name) VALUES (2, 'Sample Item 2');
-
 -- ------------------------------------------------------------
 -- administrators（管理者）
 -- ------------------------------------------------------------

--- a/infrastructure/db/schema.sql
+++ b/infrastructure/db/schema.sql
@@ -1,10 +1,3 @@
-CREATE TABLE IF NOT EXISTS sample (
-    id   BIGINT       AUTO_INCREMENT PRIMARY KEY                               COMMENT 'ID',
-    name VARCHAR(255) NOT NULL                                                 COMMENT '名前',
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP                             COMMENT '作成日時',
-    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新日時'
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='サンプルテーブル';
-
 CREATE TABLE IF NOT EXISTS administrators (
     id              CHAR(36)     NOT NULL PRIMARY KEY                          COMMENT '管理者ID',
     email           VARCHAR(255) NOT NULL UNIQUE                               COMMENT 'メールアドレス',


### PR DESCRIPTION
## Summary

- `infrastructure/db/schema.sql` からsampleテーブルの `CREATE TABLE` 定義を削除
- `infrastructure/db/local-data.sql` からsampleテーブルへの `INSERT` 文を削除

## Background

プロジェクト初期に作成したsampleテーブルのDB定義のみが残存していた。バックエンドの実装コード（Sample.kt, SampleController.kt等）とフロントエンドのコード（samples/ページ等）は既に削除済み。今回でsample関連の痕跡を完全に除去する。

## Test plan

- [ ] `grep -r "sample" infrastructure/db/` でヒットがないこと
- [ ] `./gradlew build` でビルドが通ること
- [ ] ローカルでDocker Compose起動 → DBが正常に初期化されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)