### PR TITLE
fix: mysqldefのDROPフラグを--enable-dropに修正

### DIFF
--- a/tools/sqldef/apply.sh
+++ b/tools/sqldef/apply.sh
@@ -120,7 +120,7 @@ if [[ "$APPLY" == false ]]; then
 else
   log "--- DDL を適用します (DROP: $([[ $ALLOW_DROP == true ]] && echo 有効 || echo スキップ)) ---"
   if [[ "$ALLOW_DROP" == true ]]; then
-    MYSQLDEF_ARGS+=(--enable-drop-table)
+    MYSQLDEF_ARGS+=(--enable-drop)
   fi
 fi
 


### PR DESCRIPTION
## Summary

- `apply.sh` で使用していた `--enable-drop-table` フラグが mysqldef v3.11.3 では未サポートだったため、正しいフラグ `--enable-drop` に修正

## 背景

過去のコミット (`a529bf9`) で `--skip-drop` → `--enable-drop-table` に変更されたが、サーバーにインストールされた mysqldef のバージョン (v3.11.3) では `--enable-drop-table` が存在せず `unknown flag` エラーが発生していた。正しいフラグは `--enable-drop`。

## Test plan

- [ ] `sh apply.sh prod --apply` で DROP がスキップされることを確認
- [ ] `sh apply.sh prod --apply --allow-drop` で DROP TABLE が実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)