### PR TITLE
fix: ALBヘルスチェックのタイムアウトを5秒から15秒に延長

### DIFF
--- a/infrastructure/terraform/modules/alb_attachment/main.tf
+++ b/infrastructure/terraform/modules/alb_attachment/main.tf
@@ -13,7 +13,7 @@ resource "aws_lb_target_group" "this" {
     path                = var.health_check_path
     port                = "traffic-port"
     protocol            = "HTTP"
-    timeout             = 5
+    timeout             = 15
     unhealthy_threshold = 2
   }
 }


### PR DESCRIPTION
## Summary

- ALBターゲットグループのヘルスチェック `timeout` を 5秒 → 15秒 に変更
- CS APIデプロイ時にヘルスチェックが失敗してロールバックされる問題を修正

## 原因

HikariCP は Spring Boot の `DataSourceBuilder` が引数なしコンストラクタで `HikariDataSource` を生成するため、デフォルトで **lazy 初期化**となる。最初の `getConnection()` はActuatorのヘルスチェックエンドポイント（`/actuator/health`）が初めて呼ばれたタイミングで実行され、RDSへの接続確立に **約4秒**かかる。

従来ALB（CS API専用）のヘルスチェック設定はこの時間を許容できていたが、`0e2bb4f` のALB統合で作成した新しいターゲットグループのタイムアウトが5秒と短く、ギリギリ超えてデプロイが失敗していた。

## Test plan

- [ ] `terraform plan` でターゲットグループの `timeout` が 15秒 に変わることを確認
- [ ] `terraform apply` 後、CS APIデプロイワークフローを再実行してヘルスチェックが通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)