### PR TITLE
feat: LP参加店舗セクションをAPIから動的取得し、全レスポンス型のrequiredModeを修正

### DIFF
--- a/admin-frontend/src/api/generated/admin-api.ts
+++ b/admin-frontend/src/api/generated/admin-api.ts
@@ -555,6 +555,19 @@ export interface components {
        */
       expiresIn: number;
     };
+    /** @description テイスト一覧アイテム */
+    TasteResponse: {
+      /**
+       * @description テイストID
+       * @example 00000000-0000-4000-8000-000000000041
+       */
+      id: string;
+      /**
+       * @description テイスト名
+       * @example 酸味
+       */
+      name: string;
+    };
     /** @description 店舗一覧レスポンス */
     ShopListResponse: {
       /** @description アイテム一覧 */
@@ -1537,7 +1550,7 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
-          "*/*": unknown;
+          "application/json": components["schemas"]["TasteResponse"][];
         };
       };
     };

--- a/admin-frontend/src/api/plans.ts
+++ b/admin-frontend/src/api/plans.ts
@@ -8,8 +8,6 @@ export type PlanListItem = components["schemas"]["PlanSummaryResponse"];
 export type PlanDetail = components["schemas"]["PlanDetailResponse"];
 export type PlanListResponse = components["schemas"]["PlanListResponse"];
 
-export type PlanType = "SUBSCRIPTION" | "SINGLE";
-
 export async function fetchPlans(
   page = 0,
   size = 20,

--- a/admin-frontend/src/api/tastes.ts
+++ b/admin-frontend/src/api/tastes.ts
@@ -1,13 +1,11 @@
 import "server-only";
 
 import { cookies } from "next/headers";
+import type { components } from "@/api/generated/admin-api";
 
 const API_BASE_URL = process.env.API_BASE_URL ?? "http://localhost:8081";
 
-export type TasteListItem = {
-  id: string;
-  name: string;
-};
+export type TasteListItem = components["schemas"]["TasteResponse"];
 
 /**
  * テイスト一覧を取得する。

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/controller/TasteController.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/controller/TasteController.kt
@@ -3,11 +3,14 @@ package com.mametosho.admin.presentation.controller
 import com.mametosho.admin.application.usecase.FindTastesUsecase
 import com.mametosho.admin.presentation.dto.response.TasteResponse
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -31,6 +34,8 @@ class TasteController(
                 description = "取得成功",
                 content = [
                     Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        array = ArraySchema(schema = Schema(implementation = TasteResponse::class)),
                         examples = [
                             ExampleObject(
                                 name = "success",

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/PagedResponse.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/PagedResponse.kt
@@ -5,13 +5,13 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "ページネーション付きレスポンス")
 data class PagedResponse<T>(
-    @Schema(description = "アイテム一覧")
+    @Schema(description = "アイテム一覧", requiredMode = Schema.RequiredMode.REQUIRED)
     val items: List<T>,
-    @Schema(description = "全件数", example = "42")
+    @Schema(description = "全件数", example = "42", requiredMode = Schema.RequiredMode.REQUIRED)
     val totalCount: Long,
-    @Schema(description = "現在のページ番号（0始まり）", example = "0")
+    @Schema(description = "現在のページ番号（0始まり）", example = "0", requiredMode = Schema.RequiredMode.REQUIRED)
     val page: Int,
-    @Schema(description = "1ページあたりの件数", example = "20")
+    @Schema(description = "1ページあたりの件数", example = "20", requiredMode = Schema.RequiredMode.REQUIRED)
     val size: Int,
 ) {
     companion object {

--- a/backend/cs-api/src/main/kotlin/com/mametosho/cs/presentation/dto/response/CoffeeBeanResponse.kt
+++ b/backend/cs-api/src/main/kotlin/com/mametosho/cs/presentation/dto/response/CoffeeBeanResponse.kt
@@ -6,42 +6,43 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "珈琲豆一覧アイテム")
 data class CoffeeBeanResponse(
-    @Schema(description = "珈琲豆ID", example = "00000000-0000-4000-8000-000000000071")
+    @Schema(description = "珈琲豆ID", example = "00000000-0000-4000-8000-000000000071", requiredMode = Schema.RequiredMode.REQUIRED)
     val id: String,
     @Schema(
         description = "ShopifyのID（Shopify遷移時に使用する）",
         example = "gid://shopify/Product/400001",
+        requiredMode = Schema.RequiredMode.REQUIRED,
     )
     val shopifyBeanId: String,
-    @Schema(description = "珈琲豆名", example = "エチオピア イルガチェフェ G1")
+    @Schema(description = "珈琲豆名", example = "エチオピア イルガチェフェ G1", requiredMode = Schema.RequiredMode.REQUIRED)
     val name: String,
-    @Schema(description = "産地", example = "エチオピア")
+    @Schema(description = "産地", example = "エチオピア", requiredMode = Schema.RequiredMode.REQUIRED)
     val origin: String,
-    @Schema(description = "焙煎度", example = "LIGHT")
+    @Schema(description = "焙煎度", example = "LIGHT", requiredMode = Schema.RequiredMode.REQUIRED)
     val roastLevel: String,
-    @Schema(description = "精製方法", example = "WASHED")
+    @Schema(description = "精製方法", example = "WASHED", requiredMode = Schema.RequiredMode.REQUIRED)
     val processingMethod: String,
-    @get:Schema(description = "スペシャルティ珈琲かどうか", example = "true")
+    @get:Schema(description = "スペシャルティ珈琲かどうか", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
     @get:JsonProperty("isSpecialty")
     val isSpecialty: Boolean,
-    @Schema(description = "説明文", example = "フルーティーな香りと明るい酸味が特徴の豆です。")
+    @Schema(description = "説明文", example = "フルーティーな香りと明るい酸味が特徴の豆です。", requiredMode = Schema.RequiredMode.REQUIRED)
     val description: String,
-    @Schema(description = "メイン画像URL", example = "https://example.com/images/coffee.jpg")
+    @Schema(description = "メイン画像URL", example = "https://example.com/images/coffee.jpg", requiredMode = Schema.RequiredMode.REQUIRED)
     val imageUrl: String,
-    @Schema(description = "ロースター名", example = "山田珈琲焙煎所")
+    @Schema(description = "ロースター名", example = "山田珈琲焙煎所", requiredMode = Schema.RequiredMode.REQUIRED)
     val shopName: String,
-    @Schema(description = "ロースターの都道府県", example = "TOKYO")
+    @Schema(description = "ロースターの都道府県", example = "TOKYO", requiredMode = Schema.RequiredMode.REQUIRED)
     val shopPrefecture: String,
-    @Schema(description = "ロースターのURL", example = "https://mametosho.example.com")
+    @Schema(description = "ロースターのURL", example = "https://mametosho.example.com", requiredMode = Schema.RequiredMode.REQUIRED)
     val shopUrl: String,
-    @Schema(description = "テイストプロファイル一覧")
+    @Schema(description = "テイストプロファイル一覧", requiredMode = Schema.RequiredMode.REQUIRED)
     val tasteProfiles: List<TasteProfileResponse>,
 ) {
     @Schema(description = "テイストプロファイル")
     data class TasteProfileResponse(
-        @Schema(description = "テイスト名", example = "酸味")
+        @Schema(description = "テイスト名", example = "酸味", requiredMode = Schema.RequiredMode.REQUIRED)
         val name: String,
-        @Schema(description = "評価値", example = "60")
+        @Schema(description = "評価値", example = "60", requiredMode = Schema.RequiredMode.REQUIRED)
         val value: Int,
     )
 

--- a/backend/cs-api/src/main/kotlin/com/mametosho/cs/presentation/dto/response/ErrorResponse.kt
+++ b/backend/cs-api/src/main/kotlin/com/mametosho/cs/presentation/dto/response/ErrorResponse.kt
@@ -14,6 +14,10 @@ data class ErrorResponse(
     @Schema(description = "エラー概要", example = "Not Found", requiredMode = Schema.RequiredMode.REQUIRED)
     val error: String,
 
-    @Schema(description = "リクエストパス", example = "/api/coffee-beans/00000000-0000-4000-8000-000000000099", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(
+        description = "リクエストパス",
+        example = "/api/coffee-beans/00000000-0000-4000-8000-000000000099",
+        requiredMode = Schema.RequiredMode.REQUIRED,
+    )
     val path: String,
 )

--- a/backend/cs-api/src/main/kotlin/com/mametosho/cs/presentation/dto/response/ErrorResponse.kt
+++ b/backend/cs-api/src/main/kotlin/com/mametosho/cs/presentation/dto/response/ErrorResponse.kt
@@ -5,15 +5,15 @@ import java.time.OffsetDateTime
 
 @Schema(description = "エラーレスポンス")
 data class ErrorResponse(
-    @Schema(description = "エラー発生日時", example = "2026-02-23T12:00:00.000+00:00")
+    @Schema(description = "エラー発生日時", example = "2026-02-23T12:00:00.000+00:00", requiredMode = Schema.RequiredMode.REQUIRED)
     val timestamp: OffsetDateTime,
 
-    @Schema(description = "HTTPステータスコード", example = "404")
+    @Schema(description = "HTTPステータスコード", example = "404", requiredMode = Schema.RequiredMode.REQUIRED)
     val status: Int,
 
-    @Schema(description = "エラー概要", example = "Not Found")
+    @Schema(description = "エラー概要", example = "Not Found", requiredMode = Schema.RequiredMode.REQUIRED)
     val error: String,
 
-    @Schema(description = "リクエストパス", example = "/api/coffee-beans/00000000-0000-4000-8000-000000000099")
+    @Schema(description = "リクエストパス", example = "/api/coffee-beans/00000000-0000-4000-8000-000000000099", requiredMode = Schema.RequiredMode.REQUIRED)
     val path: String,
 )

--- a/backend/cs-api/src/main/kotlin/com/mametosho/cs/presentation/dto/response/PagedResponse.kt
+++ b/backend/cs-api/src/main/kotlin/com/mametosho/cs/presentation/dto/response/PagedResponse.kt
@@ -5,13 +5,13 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "ページネーション付きレスポンス")
 data class PagedResponse<T>(
-    @Schema(description = "アイテム一覧")
+    @Schema(description = "アイテム一覧", requiredMode = Schema.RequiredMode.REQUIRED)
     val items: List<T>,
-    @Schema(description = "全件数", example = "42")
+    @Schema(description = "全件数", example = "42", requiredMode = Schema.RequiredMode.REQUIRED)
     val totalCount: Long,
-    @Schema(description = "現在のページ番号（0始まり）", example = "0")
+    @Schema(description = "現在のページ番号（0始まり）", example = "0", requiredMode = Schema.RequiredMode.REQUIRED)
     val page: Int,
-    @Schema(description = "1ページあたりの件数", example = "20")
+    @Schema(description = "1ページあたりの件数", example = "20", requiredMode = Schema.RequiredMode.REQUIRED)
     val size: Int,
 ) {
     companion object {

--- a/backend/cs-api/src/main/kotlin/com/mametosho/cs/presentation/dto/response/PlanResponse.kt
+++ b/backend/cs-api/src/main/kotlin/com/mametosho/cs/presentation/dto/response/PlanResponse.kt
@@ -6,24 +6,25 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "プラン一覧アイテム")
 data class PlanResponse(
-    @Schema(description = "プランID", example = "00000000-0000-4000-8000-000000000024")
+    @Schema(description = "プランID", example = "00000000-0000-4000-8000-000000000024", requiredMode = Schema.RequiredMode.REQUIRED)
     val id: String,
     @Schema(
         description = "ShopifyのプランID（Shopify遷移時に使用する）",
         example = "gid://shopify/SellingPlan/200004",
+        requiredMode = Schema.RequiredMode.REQUIRED,
     )
     val shopifyPlanId: String,
-    @Schema(description = "プラン表示名", example = "定番")
+    @Schema(description = "プラン表示名", example = "定番", requiredMode = Schema.RequiredMode.REQUIRED)
     val label: String,
-    @Schema(description = "1種あたりのグラム数", example = "60")
+    @Schema(description = "1種あたりのグラム数", example = "60", requiredMode = Schema.RequiredMode.REQUIRED)
     val gramWeight: Int,
-    @Schema(description = "豆の種類数", example = "4")
+    @Schema(description = "豆の種類数", example = "4", requiredMode = Schema.RequiredMode.REQUIRED)
     val beanQuantity: Int,
-    @Schema(description = "価格", example = "3800")
+    @Schema(description = "価格", example = "3800", requiredMode = Schema.RequiredMode.REQUIRED)
     val price: Int,
-    @Schema(description = "プラン種別（SUBSCRIPTION / SINGLE）", example = "SUBSCRIPTION")
+    @Schema(description = "プラン種別（SUBSCRIPTION / SINGLE）", example = "SUBSCRIPTION", requiredMode = Schema.RequiredMode.REQUIRED)
     val type: String,
-    @get:Schema(description = "おすすめバッジ", example = "true")
+    @get:Schema(description = "おすすめバッジ", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
     @get:JsonProperty("isRecommended")
     val isRecommended: Boolean,
 ) {

--- a/backend/cs-api/src/main/kotlin/com/mametosho/cs/presentation/dto/response/ShopResponse.kt
+++ b/backend/cs-api/src/main/kotlin/com/mametosho/cs/presentation/dto/response/ShopResponse.kt
@@ -6,17 +6,17 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "店舗一覧アイテム")
 data class ShopResponse(
-    @Schema(description = "店舗ID", example = "00000000-0000-4000-8000-000000000031")
+    @Schema(description = "店舗ID", example = "00000000-0000-4000-8000-000000000031", requiredMode = Schema.RequiredMode.REQUIRED)
     val id: String,
-    @Schema(description = "店舗名", example = "珈琲工房 まめとしょ")
+    @Schema(description = "店舗名", example = "珈琲工房 まめとしょ", requiredMode = Schema.RequiredMode.REQUIRED)
     val name: String,
-    @Schema(description = "店舗紹介文", example = "東京都渋谷区にある自家焙煎珈琲店。厳選されたスペシャルティコーヒーをお届けします。")
+    @Schema(description = "店舗紹介文", example = "東京都渋谷区にある自家焙煎珈琲店。厳選されたスペシャルティコーヒーをお届けします。", requiredMode = Schema.RequiredMode.REQUIRED)
     val introduction: String,
-    @Schema(description = "店舗URL", example = "https://mametosho.example.com")
+    @Schema(description = "店舗URL", example = "https://mametosho.example.com", requiredMode = Schema.RequiredMode.REQUIRED)
     val shopUrl: String,
-    @Schema(description = "都道府県", example = "TOKYO")
+    @Schema(description = "都道府県", example = "TOKYO", requiredMode = Schema.RequiredMode.REQUIRED)
     val prefecture: String,
-    @Schema(description = "ロゴ画像URL", example = "https://placehold.jp/100x100.png")
+    @Schema(description = "ロゴ画像URL", example = "https://placehold.jp/100x100.png", requiredMode = Schema.RequiredMode.REQUIRED)
     val logoImageUrl: String,
 ) {
     companion object {

--- a/docs/swagger/admin-api.yml
+++ b/docs/swagger/admin-api.yml
@@ -795,7 +795,11 @@ paths:
         "200":
           description: 取得成功
           content:
-            '*/*':
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/TasteResponse"
               examples:
                 success:
                   summary: 取得成功例
@@ -1258,6 +1262,21 @@ components:
       - accessToken
       - expiresIn
       - tokenType
+    TasteResponse:
+      type: object
+      description: テイスト一覧アイテム
+      properties:
+        id:
+          type: string
+          description: テイストID
+          example: 00000000-0000-4000-8000-000000000041
+        name:
+          type: string
+          description: テイスト名
+          example: 酸味
+      required:
+      - id
+      - name
     ShopListResponse:
       type: object
       description: 店舗一覧レスポンス

--- a/docs/swagger/cs-api.yml
+++ b/docs/swagger/cs-api.yml
@@ -297,6 +297,13 @@ components:
           type: string
           description: ロゴ画像URL
           example: https://placehold.jp/100x100.png
+      required:
+      - id
+      - introduction
+      - logoImageUrl
+      - name
+      - prefecture
+      - shopUrl
     PlanResponse:
       type: object
       description: プラン一覧アイテム
@@ -336,6 +343,15 @@ components:
           type: boolean
           description: おすすめバッジ
           example: true
+      required:
+      - beanQuantity
+      - gramWeight
+      - id
+      - isRecommended
+      - label
+      - price
+      - shopifyPlanId
+      - type
     CoffeeBeanListResponse:
       type: object
       description: 珈琲豆一覧レスポンス
@@ -422,6 +438,20 @@ components:
           type: boolean
           description: スペシャルティ珈琲かどうか
           example: true
+      required:
+      - description
+      - id
+      - imageUrl
+      - isSpecialty
+      - name
+      - origin
+      - processingMethod
+      - roastLevel
+      - shopName
+      - shopPrefecture
+      - shopUrl
+      - shopifyBeanId
+      - tasteProfiles
     TasteProfileResponse:
       type: object
       description: テイストプロファイル
@@ -435,3 +465,6 @@ components:
           format: int32
           description: 評価値
           example: 60
+      required:
+      - name
+      - value

--- a/frontend/src/api/generated/cs-api.ts
+++ b/frontend/src/api/generated/cs-api.ts
@@ -97,32 +97,32 @@ export interface components {
        * @description 店舗ID
        * @example 00000000-0000-4000-8000-000000000031
        */
-      id?: string;
+      id: string;
       /**
        * @description 店舗名
        * @example 珈琲工房 まめとしょ
        */
-      name?: string;
+      name: string;
       /**
        * @description 店舗紹介文
        * @example 東京都渋谷区にある自家焙煎珈琲店。厳選されたスペシャルティコーヒーをお届けします。
        */
-      introduction?: string;
+      introduction: string;
       /**
        * @description 店舗URL
        * @example https://mametosho.example.com
        */
-      shopUrl?: string;
+      shopUrl: string;
       /**
        * @description 都道府県
        * @example TOKYO
        */
-      prefecture?: string;
+      prefecture: string;
       /**
        * @description ロゴ画像URL
        * @example https://placehold.jp/100x100.png
        */
-      logoImageUrl?: string;
+      logoImageUrl: string;
     };
     /** @description プラン一覧アイテム */
     PlanResponse: {
@@ -130,45 +130,45 @@ export interface components {
        * @description プランID
        * @example 00000000-0000-4000-8000-000000000024
        */
-      id?: string;
+      id: string;
       /**
        * @description ShopifyのプランID（Shopify遷移時に使用する）
        * @example gid://shopify/SellingPlan/200004
        */
-      shopifyPlanId?: string;
+      shopifyPlanId: string;
       /**
        * @description プラン表示名
        * @example 定番
        */
-      label?: string;
+      label: string;
       /**
        * Format: int32
        * @description 1種あたりのグラム数
        * @example 60
        */
-      gramWeight?: number;
+      gramWeight: number;
       /**
        * Format: int32
        * @description 豆の種類数
        * @example 4
        */
-      beanQuantity?: number;
+      beanQuantity: number;
       /**
        * Format: int32
        * @description 価格
        * @example 3800
        */
-      price?: number;
+      price: number;
       /**
        * @description プラン種別（SUBSCRIPTION / SINGLE）
        * @example SUBSCRIPTION
        */
-      type?: string;
+      type: string;
       /**
        * @description おすすめバッジ
        * @example true
        */
-      isRecommended?: boolean;
+      isRecommended: boolean;
     };
     /** @description 珈琲豆一覧レスポンス */
     CoffeeBeanListResponse: {
@@ -199,64 +199,64 @@ export interface components {
        * @description 珈琲豆ID
        * @example 00000000-0000-4000-8000-000000000071
        */
-      id?: string;
+      id: string;
       /**
        * @description ShopifyのID（Shopify遷移時に使用する）
        * @example gid://shopify/Product/400001
        */
-      shopifyBeanId?: string;
+      shopifyBeanId: string;
       /**
        * @description 珈琲豆名
        * @example エチオピア イルガチェフェ G1
        */
-      name?: string;
+      name: string;
       /**
        * @description 産地
        * @example エチオピア
        */
-      origin?: string;
+      origin: string;
       /**
        * @description 焙煎度
        * @example LIGHT
        */
-      roastLevel?: string;
+      roastLevel: string;
       /**
        * @description 精製方法
        * @example WASHED
        */
-      processingMethod?: string;
+      processingMethod: string;
       /**
        * @description 説明文
        * @example フルーティーな香りと明るい酸味が特徴の豆です。
        */
-      description?: string;
+      description: string;
       /**
        * @description メイン画像URL
        * @example https://example.com/images/coffee.jpg
        */
-      imageUrl?: string;
+      imageUrl: string;
       /**
        * @description ロースター名
        * @example 山田珈琲焙煎所
        */
-      shopName?: string;
+      shopName: string;
       /**
        * @description ロースターの都道府県
        * @example TOKYO
        */
-      shopPrefecture?: string;
+      shopPrefecture: string;
       /**
        * @description ロースターのURL
        * @example https://mametosho.example.com
        */
-      shopUrl?: string;
+      shopUrl: string;
       /** @description テイストプロファイル一覧 */
-      tasteProfiles?: components["schemas"]["TasteProfileResponse"][];
+      tasteProfiles: components["schemas"]["TasteProfileResponse"][];
       /**
        * @description スペシャルティ珈琲かどうか
        * @example true
        */
-      isSpecialty?: boolean;
+      isSpecialty: boolean;
     };
     /** @description テイストプロファイル */
     TasteProfileResponse: {
@@ -264,13 +264,13 @@ export interface components {
        * @description テイスト名
        * @example 酸味
        */
-      name?: string;
+      name: string;
       /**
        * Format: int32
        * @description 評価値
        * @example 60
        */
-      value?: number;
+      value: number;
     };
   };
   responses: never;

--- a/frontend/src/app/lp/_components/BeanDetailModal/beanDetailModal.tsx
+++ b/frontend/src/app/lp/_components/BeanDetailModal/beanDetailModal.tsx
@@ -125,8 +125,8 @@ export default function BeanDetailModal({
           <h4 className={styles.tasteTitle}>テイストプロファイル</h4>
           <div className={styles.tasteGrid}>
             {bean.tasteProfile.map((t) => (
-              <div key={t.label} className={styles.tasteItem}>
-                <span className={styles.tasteLabel}>{t.label}</span>
+              <div key={t.name} className={styles.tasteItem}>
+                <span className={styles.tasteLabel}>{t.name}</span>
                 <div className={styles.tasteBarBg}>
                   <div
                     className={styles.tasteBarFill}

--- a/frontend/src/app/lp/_components/PartnerShops/partnerShops.tsx
+++ b/frontend/src/app/lp/_components/PartnerShops/partnerShops.tsx
@@ -1,55 +1,12 @@
 import Image from "next/image";
+import type { Shop } from "../../_lib/shopApi";
 import styles from "./partnerShops.module.css";
 
-const shops = [
-  {
-    name: "NORTHNODE COFFEE",
-    logoUrl: "/shopLogos/northNodeCoffee.jpg",
-    websiteUrl: "https://northnode.base.shop/",
-  },
-  {
-    name: "ゆるり珈琲",
-    logoUrl: "/shopLogos/yururi.png",
-    websiteUrl: "https://yururicoffee.shopselect.net/",
-  },
-  {
-    name: "MOSHIMOSHI COFFEE",
-    logoUrl: "/shopLogos/moshimoshiCoffee.png",
-    websiteUrl: "https://moshimoshi.buyshop.jp/",
-  },
-  {
-    name: "LUSH-COFFEE",
-    logoUrl: "/shopLogos/lushCoffee.png",
-    websiteUrl: "https://lush-coffee.com/",
-  },
-  {
-    name: "Tama Coffee Roaster",
-    logoUrl: "/shopLogos/TamaCoffeeRoaster.png",
-    websiteUrl: "https://www.tamacoffeeroaster.com/",
-  },
-  {
-    name: "maruca coffee",
-    logoUrl: "/shopLogos/marucaCoffee.png",
-    websiteUrl: "https://marucacoffee.com/",
-  },
-  {
-    name: "+ninth coffee",
-    logoUrl: "/shopLogos/addNinthCoffee.png",
-    websiteUrl: "https://www.addninthcoffee.com/",
-  },
-  {
-    name: "Black Sloth Coffee",
-    logoUrl: "/shopLogos/blackSlothCoffee.png",
-    websiteUrl: "https://bscnet.base.shop/",
-  },
-  {
-    name: "FIVE COFFEE STAND&ROASTERY",
-    logoUrl: "/shopLogos/fiveCoffeeStandAndRoastery.png",
-    websiteUrl: "https://www.fivecoffee.jp/",
-  },
-];
+interface PartnerShopsProps {
+  shops: Shop[];
+}
 
-export default function PartnerShops() {
+export default function PartnerShops({ shops }: PartnerShopsProps) {
   return (
     <section className={styles.section}>
       <p className={styles.eyebrow}>— ROASTERS</p>
@@ -58,17 +15,18 @@ export default function PartnerShops() {
       <div className={styles.grid}>
         {shops.map((shop) => (
           <a
-            key={shop.name}
-            href={shop.websiteUrl}
+            key={shop.id}
+            href={shop.shopUrl}
             target="_blank"
             rel="noopener noreferrer"
             className={styles.item}
           >
             <Image
-              src={shop.logoUrl}
+              src={shop.logoImageUrl}
               alt={shop.name}
               width={70}
               height={70}
+              unoptimized
               className={styles.logo}
             />
           </a>

--- a/frontend/src/app/lp/_lib/coffeeBeanApi.ts
+++ b/frontend/src/app/lp/_lib/coffeeBeanApi.ts
@@ -1,3 +1,5 @@
+import type { components } from "@/api/generated/cs-api";
+
 export type TasteProfile = {
   label: string;
   value: number;
@@ -27,33 +29,7 @@ export interface BeanDetail {
 
 export const SPECIALTY_TAG_COLOR = "#C4972A";
 
-type TasteProfileApiItem = {
-  name: string;
-  value: number;
-};
-
-type CoffeeBeanApiItem = {
-  id: string;
-  shopifyBeanId: string;
-  name: string;
-  origin: string;
-  roastLevel: "LIGHT" | "MEDIUM" | "CITY" | "FRENCH";
-  processingMethod: string;
-  isSpecialty: boolean;
-  description: string;
-  imageUrl: string;
-  shopName: string;
-  shopPrefecture: string;
-  shopUrl: string;
-  tasteProfiles: TasteProfileApiItem[];
-};
-
-type BeansApiResponse = {
-  items: CoffeeBeanApiItem[];
-  totalCount: number;
-  page: number;
-  size: number;
-};
+type CoffeeBeanApiItem = components["schemas"]["CoffeeBeanResponse"];
 
 const PREFECTURE_JP: Record<string, string> = {
   HOKKAIDO: "北海道",
@@ -154,7 +130,8 @@ export async function fetchCoffeeBeans(): Promise<BeanDetail[]> {
       cache: "no-store",
     });
     if (!res.ok) return [];
-    const data: BeansApiResponse = await res.json();
+    const data: components["schemas"]["CoffeeBeanListResponse"] =
+      await res.json();
     return data.items.map(toBeanDetail);
   } catch {
     return [];

--- a/frontend/src/app/lp/_lib/coffeeBeanApi.ts
+++ b/frontend/src/app/lp/_lib/coffeeBeanApi.ts
@@ -1,9 +1,7 @@
 import type { components } from "@/api/generated/cs-api";
 
-export type TasteProfile = {
-  label: string;
-  value: number;
-};
+export type TasteProfile =
+  components["schemas"]["CoffeeBeanResponse"]["tasteProfiles"][number];
 
 export interface BeanDetail {
   id: string;
@@ -115,10 +113,7 @@ function toBeanDetail(item: CoffeeBeanApiItem): BeanDetail {
     roaster: item.shopName,
     roasterLink: item.shopUrl,
     prefecture: PREFECTURE_JP[item.shopPrefecture] ?? item.shopPrefecture,
-    tasteProfile: item.tasteProfiles.map((t) => ({
-      label: t.name,
-      value: t.value,
-    })),
+    tasteProfile: item.tasteProfiles,
     isSpecialty: item.isSpecialty,
   };
 }

--- a/frontend/src/app/lp/_lib/planApi.ts
+++ b/frontend/src/app/lp/_lib/planApi.ts
@@ -1,3 +1,5 @@
+import type { components } from "@/api/generated/cs-api";
+
 export type WeightGrams = 30 | 60 | 90;
 
 export type PlanGroup = {
@@ -12,16 +14,7 @@ export type PlanGroup = {
   isRecommended: boolean;
 };
 
-type PlanApiItem = {
-  id: string;
-  shopifyPlanId: string;
-  label: string;
-  gramWeight: number;
-  beanQuantity: number;
-  price: number;
-  type: "SUBSCRIPTION" | "SINGLE";
-  isRecommended: boolean;
-};
+type PlanApiItem = components["schemas"]["PlanResponse"];
 
 export function groupPlansByGram(
   groups: PlanGroup[],

--- a/frontend/src/app/lp/_lib/shopApi.ts
+++ b/frontend/src/app/lp/_lib/shopApi.ts
@@ -1,0 +1,15 @@
+import type { components } from "@/api/generated/cs-api";
+
+export type Shop = components["schemas"]["ShopResponse"];
+
+export async function fetchShops(): Promise<Shop[]> {
+  const baseUrl = process.env.CS_API_BASE_URL ?? "http://localhost:8080";
+  try {
+    const res = await fetch(`${baseUrl}/api/shops`, { cache: "no-store" });
+    if (!res.ok) return [];
+    const data: components["schemas"]["ShopListResponse"] = await res.json();
+    return data.items;
+  } catch {
+    return [];
+  }
+}

--- a/frontend/src/app/lp/page.tsx
+++ b/frontend/src/app/lp/page.tsx
@@ -16,6 +16,7 @@ import TestimonialsCarousel from "./_components/TestimonialsCarousel/testimonial
 import { fetchCoffeeBeans } from "./_lib/coffeeBeanApi";
 import { JsonLd } from "./_lib/jsonLd";
 import { fetchPlans } from "./_lib/planApi";
+import { fetchShops } from "./_lib/shopApi";
 import "./globals.css";
 import pageStyles from "./page.module.css";
 
@@ -104,9 +105,10 @@ const testimonials = [
 ];
 
 export default async function LpPage() {
-  const [beans, planGroups] = await Promise.all([
+  const [beans, planGroups, shops] = await Promise.all([
     fetchCoffeeBeans(),
     fetchPlans(),
+    fetchShops(),
   ]);
 
   return (
@@ -123,7 +125,7 @@ export default async function LpPage() {
         <HowItWorks />
         <PricingSection planGroups={planGroups} />
         <TestimonialsCarousel testimonials={testimonials} />
-        <PartnerShops />
+        <PartnerShops shops={shops} />
         <CtaSection />
       </main>
       <div className={pageStyles.pageFooterWrap}>


### PR DESCRIPTION
## Summary

- **LP参加店舗をAPI動的取得に変更**: `PartnerShops` コンポーネントのハードコードを廃止し、`/api/shops` から取得するよう修正。`page.tsx` の `Promise.all` に追加して `fetchCoffeeBeans`・`fetchPlans` と並列実行
- **全 Response クラスの `requiredMode` を修正**: cs-api・admin-api の全 `@Schema` アノテーションに `requiredMode = Schema.RequiredMode.REQUIRED` を追加。これにより Swagger の `required:` リストが正しく生成され、生成 TypeScript 型が全フィールド non-optional になる
- **`TasteController` のレスポンス型を修正**: `Content` に `mediaType`・`ArraySchema` が欠けていたため `unknown` になっていたレスポンス型を `TasteResponse[]` に修正
- **フロントエンドの手書き型を生成型に統一**: `coffeeBeanApi.ts`・`planApi.ts`・`shopApi.ts`（新規）・`tastes.ts` の内部 API レスポンス型を `components["schemas"]["..."]` に置き換え

## 変更ファイル

**バックエンド**
- `cs-api`: `ShopResponse`・`CoffeeBeanResponse`・`PlanResponse`・`PagedResponse`・`ErrorResponse` に `requiredMode` 追加
- `admin-api`: `PagedResponse` に `requiredMode` 追加、`TasteController` に `mediaType`・`ArraySchema` 追加

**Swagger / 生成型**
- `docs/swagger/cs-api.yml`・`admin-api.yml` 再生成
- `frontend/src/api/generated/cs-api.ts`・`admin-frontend/src/api/generated/admin-api.ts` 再生成

**フロントエンド**
- `PartnerShops`: ハードコード廃止 → API データ表示
- `shopApi.ts`: 新規追加
- `coffeeBeanApi.ts`・`planApi.ts`・`tastes.ts`: 生成型に統一
- `plans.ts`: 未使用 `PlanType` 削除

## Test plan

- [ ] LP の「参加店舗」セクションが API から取得した店舗ロゴ・リンクを表示する
- [ ] `pnpm lint` が frontend・admin-frontend ともにエラーなし
- [ ] `./gradlew build` がエラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)