### PR TITLE
fix: CS FrontendのALBヘルスチェックパスを/から/api/healthに変更

### DIFF
--- a/infrastructure/terraform/environments/dev/main.tf
+++ b/infrastructure/terraform/environments/dev/main.tf
@@ -158,7 +158,7 @@ module "alb_attachment_cs_frontend" {
   certificate_arn   = module.acm_cs_frontend.certificate_arn
   container_port    = 3000
   host_header       = "${local.env}.mametosho.com"
-  health_check_path = "/"
+  health_check_path = "/api/health"
   priority          = 30
 }
 

--- a/infrastructure/terraform/environments/prod/.terraform.lock.hcl
+++ b/infrastructure/terraform/environments/prod/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.27.0"
+  constraints = "~> 6.27.0"
+  hashes = [
+    "h1:emgTfB1LXSFYh9uAwgsRMoMIN5Wz7jNNKq3rqC0EHWk=",
+    "zh:177a24b806c72e8484b5cabc93b2b38e3d770ae6f745a998b54d6619fd0e8129",
+    "zh:4ac4a85c14fb868a3306b542e6a56c10bd6c6d5a67bc0c9b8f6a9060cf5f3be7",
+    "zh:552652185bc85c8ba1da1d65dea47c454728a5c6839c458b6dcd3ce71c19ccfc",
+    "zh:60284b8172d09aee91eae0856f09855eaf040ce3a58d6933602ae17c53f8ed04",
+    "zh:6be38d156756ca61fb8e7c752cc5d769cd709686700ac4b230f40a6e95b5dbc9",
+    "zh:7a409138fae4ef42e3a637e37cb9efedf96459e28a3c764fc4e855e8db9a7485",
+    "zh:8070cf5224ed1ed3a3e9a59f7c30ff88bf071c7567165275d477c1738a56c064",
+    "zh:894439ef340a9a79f69cd759e27ad11c7826adeca27be1b1ca82b3c9702fa300",
+    "zh:89d035eebf08a97c89374ff06040955ddc09f275ecca609d0c9d58d149bef5cf",
+    "zh:985b1145d724fc1f38369099e4a5087141885740fd6c0b1dbc492171e73c2e49",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a80b47ae8d1475201c86bd94a5dcb9dd4da5e8b73102a90820b68b66b76d50fd",
+    "zh:d3395be1556210f82199b9166a6b2e677cee9c4b67e96e63f6c3a98325ad7ab0",
+    "zh:db0b869d09657f6f1e4110b56093c5fcdf9dbdd97c020db1e577b239c0adcbce",
+    "zh:ffc72e680370ae7c21f9bd3082c6317730df805c6797427839a6b6b7e9a26a01",
+  ]
+}

--- a/infrastructure/terraform/environments/prod/main.tf
+++ b/infrastructure/terraform/environments/prod/main.tf
@@ -164,7 +164,7 @@ module "alb_attachment_cs_frontend" {
   certificate_arn        = module.acm_cs_frontend.certificate_arn
   container_port         = 3000
   host_header            = "mametosho.com"
-  health_check_path      = "/"
+  health_check_path      = "/api/health"
   priority               = 30
   extra_host_headers     = ["preview.mametosho.com"]
   extra_certificate_arns = [module.acm_cs_frontend_preview.certificate_arn]


### PR DESCRIPTION
## Summary

- prod・dev両環境のTerraformで `alb_attachment_cs_frontend` のヘルスチェックパスを `/` → `/api/health` に変更
- `/` にはNext.jsのルートページが存在しないため404が返り、ECSタスクが異常終了してデプロイが毎回失敗していた
- `/api/health` エンドポイント（`frontend/src/app/api/health/route.tsx`）は既に実装済みで200を返す

## Test plan

- [ ] `terraform plan` でヘルスチェックパスの変更のみが差分として出ることを確認
- [ ] `terraform apply` 後にCS Frontendのデプロイを再実行し、ECSタスクがhealthyになることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)