### PR TITLE
fix: GHAロールにecr:DescribeImages権限を追加

### DIFF
--- a/infrastructure/terraform/modules/cd/iam.tf
+++ b/infrastructure/terraform/modules/cd/iam.tf
@@ -43,6 +43,7 @@ resource "aws_iam_role_policy" "ecr" {
           "ecr:BatchCheckLayerAvailability",
           "ecr:GetDownloadUrlForLayer",
           "ecr:BatchGetImage",
+          "ecr:DescribeImages",
           "ecr:PutImage",
           "ecr:InitiateLayerUpload",
           "ecr:UploadLayerPart",


### PR DESCRIPTION
## Summary

- `infrastructure/terraform/modules/cd/iam.tf` の `PushPullImages` ポリシーに `ecr:DescribeImages` を追加

## 背景

デプロイワークフローの「Check if image tag already exists in ECR」ステップで `aws ecr describe-images` を実行しているが、IAMロールに `ecr:DescribeImages` 権限がなかった。そのため常に `exists=false` と判定され、既存のImmutableタグに上書きプッシュしようとして失敗していた。

## Test plan

- [ ] `terraform apply` 後、同一コミットSHAで再デプロイを実行し「Check if image tag already exists in ECR」ステップが `exists=true` を返してビルドがスキップされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)