### PR TITLE
fix: ECSサービスのcapacity_provider_strategy変更時にforce_new_deploymentを追加

### DIFF
--- a/infrastructure/terraform/modules/ecs_fargate/main.tf
+++ b/infrastructure/terraform/modules/ecs_fargate/main.tf
@@ -160,5 +160,7 @@ resource "aws_ecs_service" "this" {
     }
   }
 
+  force_new_deployment = true
+
   depends_on = [aws_iam_role_policy_attachment.execution]
 }


### PR DESCRIPTION
## Summary
- `aws_ecs_service` リソースに `force_new_deployment = true` を追加
- `capacity_provider_strategy` を更新する際、Terraform が ECS サービスへの新デプロイを強制することが必須であるため対応

## 背景
Fargate Spot の設定変更時に以下のエラーが発生していた：
```
Error: force_new_deployment should be true when capacity_provider_strategy is being updated
```

## Test plan
- [ ] `terraform plan` でエラーが発生しないことを確認
- [ ] `terraform apply` で cs-api / cs-frontend の ECS サービスが正常に更新されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)