### PR TITLE
fix: TerraformがECSデプロイを上書きする問題を修正（lifecycle ignore_changes追加）

### DIFF
--- a/infrastructure/terraform/modules/ecs_fargate/main.tf
+++ b/infrastructure/terraform/modules/ecs_fargate/main.tf
@@ -160,10 +160,8 @@ resource "aws_ecs_service" "this" {
     }
   }
 
-  force_new_deployment = true
-
   lifecycle {
-    ignore_changes = [task_definition]
+    ignore_changes = [task_definition, desired_count]
   }
 
   depends_on = [aws_iam_role_policy_attachment.execution]

--- a/infrastructure/terraform/modules/ecs_fargate/main.tf
+++ b/infrastructure/terraform/modules/ecs_fargate/main.tf
@@ -162,5 +162,9 @@ resource "aws_ecs_service" "this" {
 
   force_new_deployment = true
 
+  lifecycle {
+    ignore_changes = [task_definition]
+  }
+
   depends_on = [aws_iam_role_policy_attachment.execution]
 }


### PR DESCRIPTION
## 問題

ecspresso（GHA）でデプロイ成功後、`terraform apply` のたびにECSサービスの `task_definition` がTerraform管理の `:latest` タグ（revision:1）に上書きされていた。

ECRの `latest` タグが存在するサービス（cs-api, admin-frontend, admin-api）では古いコードで起動、`latest` タグが存在しないcs-frontendではタスク起動が繰り返し失敗し続けていた。

## 根本原因（調査エージェントによる詳細分析）

### 直接原因: `force_new_deployment = true` による perpetual diff

`infrastructure/terraform/modules/ecs_fargate/main.tf` の `aws_ecs_service` に `force_new_deployment = true` が永続設定されていた。

この設定の問題：
1. `force_new_deployment` はTerraformの「一時的なトリガー」だが、AWS側には永続的なstateが存在しない
2. そのため **毎回の `terraform apply` で perpetual diff が発生**し、常に `update_service` API が呼ばれていた
3. `update_service` 呼び出し時に Terraform state に保存されている `task_definition = :1`（`latest`タグ）が送信される
4. GHA（ecspresso）が正しいバージョンにデプロイしても、次の `terraform apply` で `:1` に差し戻された

### 副次的原因: `lifecycle { ignore_changes }` の不在

`task_definition` が `ignore_changes` に含まれていなかったため、TerraformがECSサービスのタスク定義を常に管理対象としていた。

### タイムライン（2026-06-07 本日の出来事）

| 時刻 (JST) | 出来事 |
|---|---|
| 17:15〜17:24 | Terraform apply → 全サービス `:1`（`:latest`タグ）で初回作成 |
| 17:55〜18:52 | GHAデプロイ → `:2`〜`:3`（SHA タグ）で更新 |
| 21:27:01 | cs-frontend `:6`（sha:aca128b）が GHA でデプロイ完了 |
| 21:31:42 | `force_new_deployment = true` 追加コミット #145 がマージ |
| 21:32:12 | **terraform apply 開始**（ysato による手動実行） |
| 21:32:26 | **terraform apply 完了 → `:1`（`:latest`）に強制差し戻し** |
| 21:32:35 | cs-frontend でタスク起動失敗ループ開始 |

### `latest` タグが cs-frontend のみ存在しない理由

`commit 4134602`（18:36）で「ECR Immutability により `latest` タグ上書き不可のため全ワークフローから削除」された。cs-api/admin-frontend/admin-api はそれ以前に一度 `:latest` が push されていたが、cs-frontend は削除後の初回デプロイのため `:latest` が一度も ECR に存在しない。

## 修正内容

```hcl
# infrastructure/terraform/modules/ecs_fargate/main.tf

resource "aws_ecs_service" "this" {
  ...
  # force_new_deployment = true  ← 削除（perpetual diffの原因）

  lifecycle {
    ignore_changes = [task_definition, desired_count]  ← 追加
  }
}
```

## 役割分担（修正後）

| 責務 | 担当 |
|------|------|
| ECSサービスの初期作成・ネットワーク・IAM設定 | Terraform |
| タスク定義のバージョン管理・デプロイ | ecspresso（GHA） |
| スケール変更 | ecspresso or 手動（Terraformは無視） |

## 影響範囲

このモジュールを使用している全サービス（prod/dev両環境）:
- cs-frontend ← 今回の主な被害サービス
- cs-api
- admin-frontend
- admin-api

## この修正後に必要な対応

この PR を terraform apply した後、cs-api・admin-frontend・admin-api を最新コミットで再デプロイすること（GHAの Deploy ワークフロー実行）。現在これらのサービスは terraform apply による差し戻しで古いイメージ（`sha:0e2bb4f`）で動作している。

## 注意事項

- `force_new_deployment` 削除後、`capacity_provider_strategy` の変更はサービス再作成が必要になる場合がある（極めて稀なオペレーション）
- `desired_count` も `ignore_changes` に含めたため、`terraform apply` でのスケール変更は反映されない（ecspresso or 手動で変更すること）

🤖 Generated with [Claude Code](https://claude.com/claude-code)