### PR TITLE
fix: LPの参加店舗セクションに店舗が表示されない不具合を修正

### DIFF
--- a/frontend/src/app/lp/_lib/shopApi.ts
+++ b/frontend/src/app/lp/_lib/shopApi.ts
@@ -5,7 +5,7 @@ export type Shop = components["schemas"]["ShopResponse"];
 export async function fetchShops(): Promise<Shop[]> {
   const baseUrl = process.env.CS_API_BASE_URL ?? "http://localhost:8080";
   try {
-    const res = await fetch(`${baseUrl}/api/shops`, { cache: "no-store" });
+    const res = await fetch(`${baseUrl}/api/shops?page=0&size=100`, { cache: "no-store" });
     if (!res.ok) return [];
     const data: components["schemas"]["ShopListResponse"] = await res.json();
     return data.items;

--- a/frontend/src/app/lp/_lib/shopApi.ts
+++ b/frontend/src/app/lp/_lib/shopApi.ts
@@ -5,7 +5,9 @@ export type Shop = components["schemas"]["ShopResponse"];
 export async function fetchShops(): Promise<Shop[]> {
   const baseUrl = process.env.CS_API_BASE_URL ?? "http://localhost:8080";
   try {
-    const res = await fetch(`${baseUrl}/api/shops?page=0&size=100`, { cache: "no-store" });
+    const res = await fetch(`${baseUrl}/api/shops?page=0&size=100`, {
+      cache: "no-store",
+    });
     if (!res.ok) return [];
     const data: components["schemas"]["ShopListResponse"] = await res.json();
     return data.items;


### PR DESCRIPTION
## Summary

- LPの「参加店舗」セクションに店舗情報が表示されない不具合を修正
- `GET /api/shops` は `page` と `size` が必須クエリパラメータだが、`fetchShops()` がパラメータなしで呼び出していたため 400 エラーになり空配列が返っていた
- `?page=0&size=100` を追加して全参画店舗を一括取得するよう修正

## Test plan

- [ ] CS APIをローカル起動した状態でLPを開き、参加店舗セクションに店舗ロゴが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)