### PR TITLE
feat: prod cs-frontendのECSスペックを一段階引き上げ（256/512→512/1024）

### DIFF
--- a/infrastructure/terraform/environments/prod/main.tf
+++ b/infrastructure/terraform/environments/prod/main.tf
@@ -198,8 +198,8 @@ module "ecs_cs_frontend" {
   ingress_from_sg_id  = module.alb_admin.alb_security_group_id
   ingress_description = "Allow access from ALB"
   container_port      = 3000
-  cpu                 = 256
-  memory              = 512
+  cpu                 = 512
+  memory              = 1024
   image_url           = "${module.ecr_cs_frontend.repository_url}:latest"
   target_group_arn    = module.alb_attachment_cs_frontend.target_group_arn
   use_spot            = false


### PR DESCRIPTION
## Summary

- prod環境の `cs-frontend` ECSタスクのCPU・メモリを一段階引き上げ
  - CPU: 256 → 512
  - Memory: 512MB → 1024MB

## Test plan

- [ ] `terraform plan` でリソースの変更差分が意図通りであることを確認
- [ ] デプロイ後、cs-frontendのタスクが正常に起動していることをECSコンソールで確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)