### PR TITLE
fix: cs-frontend→cs-apiの内部DNS通信を許可するSGルールを追加

### DIFF
--- a/infrastructure/terraform/environments/dev/main.tf
+++ b/infrastructure/terraform/environments/dev/main.tf
@@ -237,6 +237,18 @@ module "ecs_cs_api" {
   ]
 }
 
+# cs-frontend から cs-api への Cloud Map 内部DNS(cs-api.<env>.local:8080)経由の通信を許可。
+# cs-api のSGは ALB からの ingress しか持たないため、cs-frontend のタスクSGからの8080を追加で開ける。
+resource "aws_security_group_rule" "cs_api_from_cs_frontend" {
+  type                     = "ingress"
+  from_port                = 8080
+  to_port                  = 8080
+  protocol                 = "tcp"
+  security_group_id        = module.ecs_cs_api.ecs_sg_id
+  source_security_group_id = module.ecs_cs_frontend.ecs_sg_id
+  description              = "Allow access from cs-frontend (internal DNS)"
+}
+
 # ============================================
 # ECS - Admin Frontend
 # ============================================

--- a/infrastructure/terraform/environments/prod/main.tf
+++ b/infrastructure/terraform/environments/prod/main.tf
@@ -247,6 +247,18 @@ module "ecs_cs_api" {
   ]
 }
 
+# cs-frontend から cs-api への Cloud Map 内部DNS(cs-api.<env>.local:8080)経由の通信を許可。
+# cs-api のSGは ALB からの ingress しか持たないため、cs-frontend のタスクSGからの8080を追加で開ける。
+resource "aws_security_group_rule" "cs_api_from_cs_frontend" {
+  type                     = "ingress"
+  from_port                = 8080
+  to_port                  = 8080
+  protocol                 = "tcp"
+  security_group_id        = module.ecs_cs_api.ecs_sg_id
+  source_security_group_id = module.ecs_cs_frontend.ecs_sg_id
+  description              = "Allow access from cs-frontend (internal DNS)"
+}
+
 # ============================================
 # ECS - Admin Frontend
 # ============================================


### PR DESCRIPTION
## 概要
cs-frontend から cs-api への Cloud Map 内部DNS 経由の通信が、セキュリティグループの口が開いていないために実際には到達できない不具合を修正します。

## 背景
`CS_API_BASE_URL = http://cs-api.<env>.local:8080` は Cloud Map（Service Discovery）の**プライベートDNS**で、インターネット経由ではなくVPC内部通信です。#133 でインターネット経由(`api.mametosho.com`)から内部DNSへ切り替えられました。

しかし内部DNS化の際、DNS名前空間と `service_registry_arn` の追加のみで、**SGのingress追加が漏れていました**。

- `cs-api` のSG ingress は `module.alb_admin.alb_security_group_id`（ALBのSG）からの8080のみ許可
- cs-frontend が `cs-api.<env>.local:8080` に直接アクセスすると送信元は cs-frontend のタスクSGになり、許可されていないため**接続がブロックされ通信不可**

admin 側（admin-frontend → admin-api）は admin-api の ingress が admin-frontend のSGを許可しており正しく組まれています。cs 側はこれに相当するルールが欠落していました。

## 変更内容
- prod / dev 双方の `main.tf` に、cs-api のSGへ cs-frontend のタスクSGからの 8080 ingress を許可する `aws_security_group_rule` を追加
- cs-api は ALB（`api.mametosho.com`／ターゲットグループ）からのアクセスも受けるため、既存のALBからのingressはそのまま維持

## 確認
- `terraform fmt` 差分なし
- cs-frontend ⇔ cs-api 間に循環依存はなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)