### PR TITLE
fix: prod admin-apiのECSスペックを256/512に統一（512/1024→256/512）

### DIFF
--- a/infrastructure/ecspresso/admin-api/ecs-task-def.json
+++ b/infrastructure/ecspresso/admin-api/ecs-task-def.json
@@ -2,8 +2,8 @@
   "family": "{{ must_env `AWS_ACCOUNT_ID` }}-{{ must_env `ENV` }}-admin-api",
   "networkMode": "awsvpc",
   "requiresCompatibilities": ["FARGATE"],
-  "cpu": "512",
-  "memory": "1024",
+  "cpu": "256",
+  "memory": "512",
   "executionRoleArn": "arn:aws:iam::{{ must_env `AWS_ACCOUNT_ID` }}:role/{{ must_env `AWS_ACCOUNT_ID` }}-{{ must_env `ENV` }}-admin-api-ecs-execution",
   "taskRoleArn": "arn:aws:iam::{{ must_env `AWS_ACCOUNT_ID` }}:role/{{ must_env `AWS_ACCOUNT_ID` }}-{{ must_env `ENV` }}-admin-api-ecs-task",
   "containerDefinitions": [


### PR DESCRIPTION
## 概要
本番(prod)の admin-api のECS(Fargate)タスク定義スペックを `512/1024` から `256/512` に変更し、他サービスと統一します。

## 背景
本番の各ECSサービスのスペックを `256/512` に揃える作業を実施中ですが、admin-api だけ ecspresso のタスク定義(`infrastructure/ecspresso/admin-api/ecs-task-def.json`)が `512/1024` のまま残っていました。

AWS上の実稼働値もデプロイ時にこの ecspresso 定義から決まるため（TerraformはECSサービスの `task_definition` を `ignore_changes` しており、実行スペックには関与しない）、本ファイルを直さない限り admin-api は `512/1024` のままになります。

### 変更前の本番実態
| サービス | CPU/メモリ |
|---|---|
| cs-frontend | 256 / 512 ✅ |
| cs-api | 256 / 512 ✅ |
| admin-frontend | 256 / 512 ✅ |
| **admin-api** | **512 / 1024** ❌ |

## 変更内容
- `infrastructure/ecspresso/admin-api/ecs-task-def.json`
  - `cpu`: `512` → `256`
  - `memory`: `1024` → `512`

## デプロイ
マージ後、`deploy-admin-api` ワークフローを `prod` で実行することで新リビジョンが `256/512` で登録され、4サービスすべてが `256/512` に統一されます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)