### PR TITLE
fix: ALB連携ECSサービスにhealthCheckGracePeriod(120s)を設定

### DIFF
--- a/infrastructure/terraform/modules/ecs_fargate/main.tf
+++ b/infrastructure/terraform/modules/ecs_fargate/main.tf
@@ -120,6 +120,9 @@ resource "aws_ecs_service" "this" {
   task_definition = aws_ecs_task_definition.this.arn
   desired_count   = 1
 
+  # 起動猶予はALB連携サービスのみ有効。LBが無いサービスに設定するとAWS APIエラーになるため null に落とす。
+  health_check_grace_period_seconds = var.target_group_arn != null ? var.health_check_grace_period_seconds : null
+
   dynamic "capacity_provider_strategy" {
     for_each = var.use_spot ? [1] : []
     content {

--- a/infrastructure/terraform/modules/ecs_fargate/variables.tf
+++ b/infrastructure/terraform/modules/ecs_fargate/variables.tf
@@ -123,3 +123,13 @@ variable "use_spot" {
   default     = true
   description = "true: FARGATE_SPOT 100% (コスト優先) / false: FARGATE オンデマンド 100% (可用性優先)"
 }
+
+# ALB連携サービスのみ有効。タスク起動からこの秒数の間はELBヘルスチェックの失敗を
+# カウントしない(起動猶予)。JVM(Spring Boot)は起動に60秒以上かかるため、これが0だと
+# 起動完了前にunhealthy判定されデプロイがタイムアウトする。target_group_arn が無い
+# サービス(admin-api等)ではAWS側でエラーになるため、モジュール内でnullに落とす。
+variable "health_check_grace_period_seconds" {
+  type        = number
+  default     = 120
+  description = "ELBヘルスチェックの起動猶予秒数 (ALB連携サービスのみ有効)"
+}


### PR DESCRIPTION
## 背景 / 問題

Deploy CS API のワークフロー（[該当run](https://github.com/LibraryOfCoffee/libraryOfCoffee/actions/runs/27095473791/job/79966939957)）が10分かかった末に失敗していた。

調査の結果:
- `ecspresso deploy` は新タスクがサービス安定状態になるまで待つ（`timeout: 10m`）
- cs-api は Spring Boot (JVM, Java 25) で、**タスク起動に約68秒**かかる（0.25 vCPUで特に遅い。WebApplicationContext初期化だけで32秒）
- ところがECSサービスの `healthCheckGracePeriodSeconds` が **0（未設定）** だったため、起動完了前からELBヘルスチェック失敗がカウントされ、新タスクが unhealthy → kill のループに陥る
- 結果、サービスが安定せず ecspresso が10分フルにタイムアウト → **デプロイ失敗**

なお旧タスク（512/1024）はそのまま稼働しており、本番ダウンはしていない（ロールフォワード失敗のみ）。

## 変更内容

`ecs_fargate` モジュールに `health_check_grace_period_seconds` 変数（default `120`）を追加し、**ALB連携サービスにのみ**適用する。

```hcl
health_check_grace_period_seconds = var.target_group_arn != null ? var.health_check_grace_period_seconds : null
```

- LBを持たない **admin-api** は AWS API でエラーになるため `null` に落とす（自動で対象外）
- 共通モジュールへの変更なので dev/prod 両環境に効く

## 影響範囲（`terraform plan` で確認済み）

| サービス | 変更 |
|---|---|
| ecs_cs_api | `health_check_grace_period_seconds 0 -> 120` |
| ecs_cs_frontend | `health_check_grace_period_seconds 0 -> 120` |
| ecs_admin_frontend | `health_check_grace_period_seconds 0 -> 120` |
| ecs_admin_api | 変更なし（LB無し） |

いずれも in-place 更新（サービス再作成なし）。`terraform apply` でサービスが直接更新されるため、ecspresso再デプロイは不要。適用後に失敗したワークフローを再実行すれば通る想定。

## 補足（このPRの対象外）

cs-api はそもそも 256/512 だと稼働中もメモリ逼迫リスクが残る（今回はgrace=0が直接の引き金）。容量自体の見直しは別途検討。

## 確認事項
- `terraform validate`: ✅ Success
- `terraform fmt -check`: ✅ 差分なし
- `terraform plan`: ✅ 上記3サービスの in-place 更新のみ（※ plan上に無関係な bastion の drift があるため、apply時は `-target` でECSサービスに限定推奨）

🤖 Generated with [Claude Code](https://claude.com/claude-code)