### PR TITLE
fix: プラン一覧の行クリック範囲を行全体に拡大

### DIFF
--- a/admin-frontend/src/app/(admin)/plans/_components/PlanListTable.tsx
+++ b/admin-frontend/src/app/(admin)/plans/_components/PlanListTable.tsx
@@ -72,11 +72,46 @@ export function PlanListTable({
                     {plan.label}
                   </Link>
                 </td>
-                <td>{PLAN_TYPE_LABELS[plan.type] ?? plan.type}</td>
-                <td>{plan.gramWeight}g</td>
-                <td>{plan.beanQuantity}種</td>
-                <td>¥{plan.price.toLocaleString()}</td>
-                <td>{plan.isRecommended ? "★" : "-"}</td>
+                <td>
+                  <Link
+                    href={`/plans/${plan.id}`}
+                    className={listStyles.rowLink}
+                  >
+                    {PLAN_TYPE_LABELS[plan.type] ?? plan.type}
+                  </Link>
+                </td>
+                <td>
+                  <Link
+                    href={`/plans/${plan.id}`}
+                    className={listStyles.rowLink}
+                  >
+                    {plan.gramWeight}g
+                  </Link>
+                </td>
+                <td>
+                  <Link
+                    href={`/plans/${plan.id}`}
+                    className={listStyles.rowLink}
+                  >
+                    {plan.beanQuantity}種
+                  </Link>
+                </td>
+                <td>
+                  <Link
+                    href={`/plans/${plan.id}`}
+                    className={listStyles.rowLink}
+                  >
+                    ¥{plan.price.toLocaleString()}
+                  </Link>
+                </td>
+                <td>
+                  <Link
+                    href={`/plans/${plan.id}`}
+                    className={listStyles.rowLink}
+                  >
+                    {plan.isRecommended ? "★" : "-"}
+                  </Link>
+                </td>
               </tr>
             ))}
           </tbody>


### PR DESCRIPTION
## 概要
管理画面のプラン一覧（`/plans`）で、行のうち「プラン表示名」セルしか詳細ページへのリンクになっておらず、クリックできる範囲が狭かった問題を修正します。

## 変更内容
- `PlanListTable.tsx` の残り5セル（種別 / グラム数 / 種類数 / 価格 / おすすめ）も `listStyles.rowLink` の `<Link>` でラップし、行全体をクリック可能に
- 店舗一覧（`ShopListTable`）・コーヒー豆一覧（`CoffeeBeanListTable`）と同じ既存パターンの踏襲で、CSSの変更なし

## 検証
- `pnpm lint` パス（Biome、85ファイル、エラーなし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)