### PR TITLE
fix: ECS SGのinline/独立ルール混在を解消しapply毎の競合を防止

### DIFF
--- a/infrastructure/terraform/environments/dev/main.tf
+++ b/infrastructure/terraform/environments/dev/main.tf
@@ -215,6 +215,12 @@ module "ecs_cs_api" {
   subnet_ids            = module.vpc.public_subnet_ids
   ingress_from_sg_id    = module.alb_admin.alb_security_group_id
   ingress_description   = "Allow access from ALB"
+  additional_ingress_sgs = [
+    {
+      sg_id       = module.ecs_cs_frontend.ecs_sg_id
+      description = "Allow access from cs-frontend (internal DNS)"
+    }
+  ]
   container_port        = 8080
   cpu                   = 256
   memory                = 512
@@ -235,18 +241,6 @@ module "ecs_cs_api" {
     { name = "DB_USERNAME", valueFrom = "${aws_secretsmanager_secret.cs_api_db.arn}:username::" },
     { name = "DB_PASSWORD", valueFrom = "${aws_secretsmanager_secret.cs_api_db.arn}:password::" },
   ]
-}
-
-# cs-frontend から cs-api への Cloud Map 内部DNS(cs-api.<env>.local:8080)経由の通信を許可。
-# cs-api のSGは ALB からの ingress しか持たないため、cs-frontend のタスクSGからの8080を追加で開ける。
-resource "aws_security_group_rule" "cs_api_from_cs_frontend" {
-  type                     = "ingress"
-  from_port                = 8080
-  to_port                  = 8080
-  protocol                 = "tcp"
-  security_group_id        = module.ecs_cs_api.ecs_sg_id
-  source_security_group_id = module.ecs_cs_frontend.ecs_sg_id
-  description              = "Allow access from cs-frontend (internal DNS)"
 }
 
 # ============================================

--- a/infrastructure/terraform/environments/prod/main.tf
+++ b/infrastructure/terraform/environments/prod/main.tf
@@ -250,6 +250,12 @@ module "ecs_cs_api" {
   subnet_ids            = module.vpc.public_subnet_ids
   ingress_from_sg_id    = module.alb_admin.alb_security_group_id
   ingress_description   = "Allow access from ALB"
+  additional_ingress_sgs = [
+    {
+      sg_id       = module.ecs_cs_frontend.ecs_sg_id
+      description = "Allow access from cs-frontend (internal DNS)"
+    }
+  ]
   container_port        = 8080
   cpu                   = 256
   memory                = 512
@@ -271,18 +277,6 @@ module "ecs_cs_api" {
     { name = "DB_USERNAME", valueFrom = "${aws_secretsmanager_secret.cs_api_db.arn}:username::" },
     { name = "DB_PASSWORD", valueFrom = "${aws_secretsmanager_secret.cs_api_db.arn}:password::" },
   ]
-}
-
-# cs-frontend から cs-api への Cloud Map 内部DNS(cs-api.<env>.local:8080)経由の通信を許可。
-# cs-api のSGは ALB からの ingress しか持たないため、cs-frontend のタスクSGからの8080を追加で開ける。
-resource "aws_security_group_rule" "cs_api_from_cs_frontend" {
-  type                     = "ingress"
-  from_port                = 8080
-  to_port                  = 8080
-  protocol                 = "tcp"
-  security_group_id        = module.ecs_cs_api.ecs_sg_id
-  source_security_group_id = module.ecs_cs_frontend.ecs_sg_id
-  description              = "Allow access from cs-frontend (internal DNS)"
 }
 
 # ============================================

--- a/infrastructure/terraform/modules/ecs_fargate/security-group.tf
+++ b/infrastructure/terraform/modules/ecs_fargate/security-group.tf
@@ -3,12 +3,25 @@ resource "aws_security_group" "ecs" {
   description = "Security group for ${var.service_name} ECS tasks"
   vpc_id      = var.vpc_id
 
-  ingress {
-    from_port       = var.container_port
-    to_port         = var.container_port
-    protocol        = "tcp"
-    security_groups = [var.ingress_from_sg_id]
-    description     = var.ingress_description
+  # ingressは全てこのSGリソースのinlineブロックで定義する。
+  # inlineの`ingress`と独立した`aws_security_group_rule`を同一SGに混在させると、
+  # applyのたびにinline側が「あるべき全ingress」とみなされ、独立ルールで足した分が
+  # revokeされてSGが空になる競合が起きる(Terraformが公式に禁止している組み合わせ)。
+  # そのため独立ルールは一切併用しない。
+  # 主たる許可元(ingress_from_sg_id)と追加の許可元(additional_ingress_sgs)を1つのリストに
+  # まとめ、単一のdynamicブロックで container_port への ingress を定義する。
+  dynamic "ingress" {
+    for_each = concat(
+      [{ sg_id = var.ingress_from_sg_id, description = var.ingress_description }],
+      var.additional_ingress_sgs,
+    )
+    content {
+      from_port       = var.container_port
+      to_port         = var.container_port
+      protocol        = "tcp"
+      security_groups = [ingress.value.sg_id]
+      description     = ingress.value.description
+    }
   }
 
   egress {
@@ -19,6 +32,8 @@ resource "aws_security_group" "ecs" {
   }
 }
 
+# RDSのSGへのingress(source = このECSのSG)。これは別SG(rds)に対する独立ルールであり、
+# ECSのSGのinline ingressとは別SGなので競合しない。
 resource "aws_security_group_rule" "to_rds" {
   count = var.enable_rds_access ? 1 : 0
 

--- a/infrastructure/terraform/modules/ecs_fargate/variables.tf
+++ b/infrastructure/terraform/modules/ecs_fargate/variables.tf
@@ -36,6 +36,15 @@ variable "ingress_description" {
   description = "ingressルールの説明"
 }
 
+variable "additional_ingress_sgs" {
+  type = list(object({
+    sg_id       = string
+    description = string
+  }))
+  default     = []
+  description = "container_portへのingressを追加で許可する元SGのリスト。独立ルールではなくinlineで定義され、inlineと独立ルールの混在競合を避ける。"
+}
+
 variable "container_port" {
   type = number
 }


### PR DESCRIPTION
## 背景 / 障害内容

`terraform apply` のたびに **cs-frontend → cs-api の内部DNS通信(8080)を許可するSGルールが消え**、LP(`/lp`)のSSRが cs-api に到達できず、参加店舗・プラン・豆などのデータが表示されなくなる障害が発生していました。

## 根本原因

`ecs_fargate` モジュールのSGで、**inlineの `ingress` ブロック**と、環境側で後付けした**独立リソース `aws_security_group_rule "cs_api_from_cs_frontend"`** を**同一SGに混在**させていたことが原因です。

これは Terraform が公式に禁止している組み合わせで、apply のたびに inline 側が「あるべき全ingress」とみなされ、独立ルールで追加した分が revoke されて SG が空になります。

## 変更内容

- `ecs_fargate` モジュールの ingress を**全て inline に統一**し、独立した `aws_security_group_rule` を廃止
- `additional_ingress_sgs` 変数を追加し、cs-frontend → cs-api の内部DNS通信も inline で定義（環境側の `cs_api_from_cs_frontend` を削除）
- 主たる許可元(`ingress_from_sg_id`)と追加の許可元(`additional_ingress_sgs`)を1つのリストにまとめ、**単一の `dynamic "ingress"` ブロック**に統合
- prod / dev 両環境に反映

## 適用状況・注意点

- **prod は本PRの最終状態に収束済み**（apply 済み、SG drift ゼロを確認）。本PRは prod の実態と一致するコードです。
- **dev は未 apply**。dev にも独立ルール `cs_api_from_cs_frontend` が存在するため、適用時は prod と同様に、AWS実体を inline 管理へ引き継ぐ `terraform state rm`（独立ルールを state から除去）が必要です。そのまま apply すると独立ルールの revoke で一時的にSGが空になり得ます。

## 確認

- `terraform validate` 成功
- prod `terraform plan` で **SG関連の差分ゼロ**（残差分は本件と無関係の bastion のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)