### PR TITLE
feat: CS向け店舗詳細API GET /api/shops/{shopId} を追加

### DIFF
--- a/backend/cs-api/src/main/kotlin/com/mametosho/cs/application/usecase/GetShopUsecase.kt
+++ b/backend/cs-api/src/main/kotlin/com/mametosho/cs/application/usecase/GetShopUsecase.kt
@@ -1,0 +1,20 @@
+package com.mametosho.cs.application.usecase
+
+import com.mametosho.domain.model.shared.ParticipationStatus
+import com.mametosho.domain.model.shop.Shop
+import com.mametosho.domain.model.shop.ShopId
+import com.mametosho.domain.repository.ShopRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class GetShopUsecase(
+    private val shopRepository: ShopRepository,
+) {
+    @Transactional(readOnly = true)
+    open fun execute(id: String): Shop? {
+        // CS（一般ユーザー向け）では参画中の店舗のみを公開する。参画前・参画落ち・存在しない場合は null（→ 404）とする。
+        return shopRepository.findById(ShopId(id))
+            ?.takeIf { it.participationStatus == ParticipationStatus.PARTICIPATING }
+    }
+}

--- a/backend/cs-api/src/main/kotlin/com/mametosho/cs/config/GlobalExceptionHandler.kt
+++ b/backend/cs-api/src/main/kotlin/com/mametosho/cs/config/GlobalExceptionHandler.kt
@@ -15,6 +15,23 @@ class GlobalExceptionHandler {
 
     private val log = LoggerFactory.getLogger(GlobalExceptionHandler::class.java)
 
+    @ExceptionHandler(IllegalArgumentException::class)
+    fun handleIllegalArgument(
+        ex: IllegalArgumentException,
+        request: HttpServletRequest,
+    ): ResponseEntity<ErrorResponse> {
+        log.warn("{} {}: {}", request.method, request.requestURI, ex.message)
+        val status = HttpStatus.BAD_REQUEST
+        return ResponseEntity.status(status).body(
+            ErrorResponse(
+                timestamp = OffsetDateTime.now(),
+                status = status.value(),
+                error = status.reasonPhrase,
+                path = request.requestURI,
+            ),
+        )
+    }
+
     @ExceptionHandler(NoResourceFoundException::class)
     fun handleNoResourceFound(
         ex: NoResourceFoundException,

--- a/backend/cs-api/src/main/kotlin/com/mametosho/cs/presentation/controller/ShopController.kt
+++ b/backend/cs-api/src/main/kotlin/com/mametosho/cs/presentation/controller/ShopController.kt
@@ -1,6 +1,8 @@
 package com.mametosho.cs.presentation.controller
 
 import com.mametosho.cs.application.usecase.FindShopsUsecase
+import com.mametosho.cs.application.usecase.GetShopUsecase
+import com.mametosho.cs.presentation.dto.response.ShopDetailResponse
 import com.mametosho.cs.presentation.dto.response.ShopListResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
@@ -12,6 +14,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
@@ -21,6 +24,7 @@ import org.springframework.web.bind.annotation.RestController
 @Tag(name = "Shop", description = "店舗API")
 class ShopController(
     private val findShopsUsecase: FindShopsUsecase,
+    private val getShopUsecase: GetShopUsecase,
 ) {
     @GetMapping
     @Operation(
@@ -80,5 +84,105 @@ class ShopController(
     ): ResponseEntity<ShopListResponse> {
         val result = findShopsUsecase.execute(page, size)
         return ResponseEntity.ok(ShopListResponse.from(result))
+    }
+
+    @GetMapping("/{shopId}")
+    @Operation(
+        summary = "店舗詳細取得",
+        description = "指定されたIDの店舗の詳細情報を取得します。参画中の店舗のみ取得できます。",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "取得成功",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(implementation = ShopDetailResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "success",
+                                summary = "取得成功例",
+                                value = """
+                                    {
+                                      "id": "00000000-0000-4000-8000-000000000031",
+                                      "name": "珈琲工房 まめとしょ",
+                                      "introduction": "東京都渋谷区にある自家焙煎珈琲店。厳選されたスペシャルティコーヒーをお届けします。",
+                                      "particular": "厳選された豆のみを使用しています。",
+                                      "shopUrl": "https://mametosho.example.com",
+                                      "prefecture": "TOKYO",
+                                      "images": [
+                                        {
+                                          "id": "00000000-0000-4000-8000-000000000010",
+                                          "type": "LOGO",
+                                          "imageUrl": "https://placehold.jp/100x100.png"
+                                        },
+                                        {
+                                          "id": "00000000-0000-4000-8000-000000000011",
+                                          "type": "MAIN",
+                                          "imageUrl": "https://placehold.jp/600x400.png"
+                                        }
+                                      ]
+                                    }
+                                """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "店舗IDの形式が不正",
+                content = [
+                    Content(
+                        examples = [
+                            ExampleObject(
+                                name = "bad_request",
+                                summary = "店舗IDがUUID形式でない場合",
+                                value = """
+                                    {
+                                      "timestamp": "2026-02-23T12:00:00.000+00:00",
+                                      "status": 400,
+                                      "error": "Bad Request",
+                                      "path": "/api/shops/invalid-id"
+                                    }
+                                """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "店舗が見つかりません（存在しない、または参画中でない）",
+                content = [
+                    Content(
+                        examples = [
+                            ExampleObject(
+                                name = "not_found",
+                                summary = "店舗が見つからない場合",
+                                value = """
+                                    {
+                                      "timestamp": "2026-02-23T12:00:00.000+00:00",
+                                      "status": 404,
+                                      "error": "Not Found",
+                                      "path": "/api/shops/00000000-0000-4000-8000-000000000999"
+                                    }
+                                """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+    fun getShop(
+        @Parameter(description = "店舗ID", required = true, example = "00000000-0000-4000-8000-000000000031")
+        @PathVariable shopId: String,
+    ): ResponseEntity<ShopDetailResponse> {
+        val shop = getShopUsecase.execute(shopId)
+            ?: return ResponseEntity.notFound().build()
+        return ResponseEntity.ok(ShopDetailResponse.from(shop))
     }
 }

--- a/backend/cs-api/src/main/kotlin/com/mametosho/cs/presentation/dto/response/ShopDetailResponse.kt
+++ b/backend/cs-api/src/main/kotlin/com/mametosho/cs/presentation/dto/response/ShopDetailResponse.kt
@@ -1,0 +1,57 @@
+package com.mametosho.cs.presentation.dto.response
+
+import com.mametosho.domain.model.shop.Shop
+import com.mametosho.domain.model.shop.ShopImage
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "店舗詳細レスポンス")
+data class ShopDetailResponse(
+    @Schema(description = "店舗ID", example = "00000000-0000-4000-8000-000000000031", requiredMode = Schema.RequiredMode.REQUIRED)
+    val id: String,
+    @Schema(description = "店舗名", example = "珈琲工房 まめとしょ", requiredMode = Schema.RequiredMode.REQUIRED)
+    val name: String,
+    @Schema(
+        description = "店舗紹介文",
+        example = "東京都渋谷区にある自家焙煎珈琲店。厳選されたスペシャルティコーヒーをお届けします。",
+        requiredMode = Schema.RequiredMode.REQUIRED,
+    )
+    val introduction: String,
+    @Schema(description = "こだわり", example = "厳選された豆のみを使用しています。", requiredMode = Schema.RequiredMode.REQUIRED)
+    val particular: String,
+    @Schema(description = "店舗URL", example = "https://mametosho.example.com", requiredMode = Schema.RequiredMode.REQUIRED)
+    val shopUrl: String,
+    @Schema(description = "都道府県", example = "TOKYO", requiredMode = Schema.RequiredMode.REQUIRED)
+    val prefecture: String,
+    @Schema(description = "画像一覧", requiredMode = Schema.RequiredMode.REQUIRED)
+    val images: List<ImageDetail>,
+) {
+    @Schema(description = "画像詳細")
+    data class ImageDetail(
+        @Schema(description = "画像ID", example = "00000000-0000-4000-8000-000000000010", requiredMode = Schema.RequiredMode.REQUIRED)
+        val id: String,
+        @Schema(description = "画像種別（LOGO: ロゴ / MAIN: メイン）", example = "LOGO", requiredMode = Schema.RequiredMode.REQUIRED)
+        val type: String,
+        @Schema(description = "画像URL", example = "https://placehold.jp/100x100.png", requiredMode = Schema.RequiredMode.REQUIRED)
+        val imageUrl: String,
+    ) {
+        companion object {
+            fun from(image: ShopImage): ImageDetail = ImageDetail(
+                id = image.id.value,
+                type = image.type.name,
+                imageUrl = image.image.url,
+            )
+        }
+    }
+
+    companion object {
+        fun from(shop: Shop): ShopDetailResponse = ShopDetailResponse(
+            id = shop.id.value,
+            name = shop.name,
+            introduction = shop.introduction ?: "",
+            particular = shop.particular ?: "",
+            shopUrl = shop.shopUrl,
+            prefecture = shop.prefecture.name,
+            images = shop.images.map { ImageDetail.from(it) },
+        )
+    }
+}

--- a/backend/cs-api/src/test/kotlin/com/mametosho/cs/application/usecase/GetShopUsecaseTest.kt
+++ b/backend/cs-api/src/test/kotlin/com/mametosho/cs/application/usecase/GetShopUsecaseTest.kt
@@ -1,0 +1,98 @@
+package com.mametosho.cs.application.usecase
+
+import com.mametosho.domain.model.shared.Image
+import com.mametosho.domain.model.shared.ParticipationStatus
+import com.mametosho.domain.model.shop.Prefecture
+import com.mametosho.domain.model.shop.Shop
+import com.mametosho.domain.model.shop.ShopId
+import com.mametosho.domain.model.shop.ShopImage
+import com.mametosho.domain.model.shop.ShopImageId
+import com.mametosho.domain.model.shop.ShopImageType
+import com.mametosho.domain.model.shop.ShopifyShopId
+import com.mametosho.domain.repository.ShopRepository
+import org.junit.jupiter.api.Nested
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+
+class GetShopUsecaseTest {
+
+    private fun sampleShop(participationStatus: ParticipationStatus) = Shop(
+        id = ShopId("00000000-0000-4000-8000-000000000031"),
+        shopifyShopId = ShopifyShopId("test-shop-001"),
+        name = "珈琲工房 まめとしょ",
+        introduction = "東京都渋谷区にある自家焙煎珈琲店。厳選されたスペシャルティコーヒーをお届けします。",
+        particular = "厳選された豆のみを使用しています。",
+        shopUrl = "https://mametosho.example.com",
+        prefecture = Prefecture.TOKYO,
+        participationStatus = participationStatus,
+        images = listOf(
+            ShopImage(
+                id = ShopImageId("00000000-0000-4000-8000-000000000091"),
+                type = ShopImageType.LOGO,
+                image = Image("https://placehold.jp/100x100.png"),
+            ),
+        ),
+    )
+
+    private fun createUsecase(shop: Shop?): GetShopUsecase {
+        val fakeRepository = object : ShopRepository {
+            override fun save(shop: Shop) = Unit
+            override fun findById(id: ShopId): Shop? = shop
+            override fun deleteById(id: ShopId) = Unit
+            override fun findAll(
+                page: Int,
+                size: Int,
+                name: String?,
+                participationStatus: ParticipationStatus?,
+            ): Pair<List<Shop>, Long> = Pair(emptyList(), 0L)
+        }
+        return GetShopUsecase(fakeRepository)
+    }
+
+    @Nested
+    inner class 正常系 {
+        @Test
+        fun `参画中の店舗を取得できる`() {
+            val usecase = createUsecase(sampleShop(ParticipationStatus.PARTICIPATING))
+
+            val result = usecase.execute("00000000-0000-4000-8000-000000000031")
+
+            assertEquals("00000000-0000-4000-8000-000000000031", result?.id?.value)
+        }
+    }
+
+    @Nested
+    inner class 異常系 {
+        @Test
+        fun `参画前の店舗はnullを返す`() {
+            val usecase = createUsecase(sampleShop(ParticipationStatus.BEFORE_PARTICIPATION))
+
+            assertNull(usecase.execute("00000000-0000-4000-8000-000000000031"))
+        }
+
+        @Test
+        fun `参画落ちの店舗はnullを返す`() {
+            val usecase = createUsecase(sampleShop(ParticipationStatus.DROPPED))
+
+            assertNull(usecase.execute("00000000-0000-4000-8000-000000000031"))
+        }
+
+        @Test
+        fun `存在しない店舗はnullを返す`() {
+            val usecase = createUsecase(null)
+
+            assertNull(usecase.execute("00000000-0000-4000-8000-000000000999"))
+        }
+
+        @Test
+        fun `UUID形式でないIDはIllegalArgumentExceptionを投げる`() {
+            val usecase = createUsecase(null)
+
+            assertFailsWith<IllegalArgumentException> {
+                usecase.execute("invalid-id")
+            }
+        }
+    }
+}

--- a/backend/cs-api/src/test/kotlin/com/mametosho/cs/config/GlobalExceptionHandlerTest.kt
+++ b/backend/cs-api/src/test/kotlin/com/mametosho/cs/config/GlobalExceptionHandlerTest.kt
@@ -1,0 +1,80 @@
+package com.mametosho.cs.config
+
+import org.junit.jupiter.api.Nested
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.web.servlet.resource.NoResourceFoundException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class GlobalExceptionHandlerTest {
+
+    private val handler = GlobalExceptionHandler()
+
+    private fun request(path: String = "/api/shops/invalid-id"): MockHttpServletRequest =
+        MockHttpServletRequest("GET", path)
+
+    @Nested
+    inner class IllegalArgumentExceptionの処理 {
+        @Test
+        fun `400 BadRequestを返す`() {
+            val response = handler.handleIllegalArgument(
+                IllegalArgumentException("ShopId must be a valid UUID format"),
+                request(),
+            )
+
+            assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+        }
+
+        @Test
+        fun `レスポンスボディにステータス・エラー概要・パスが設定される`() {
+            val response = handler.handleIllegalArgument(
+                IllegalArgumentException("ShopId must be a valid UUID format"),
+                request(path = "/api/shops/invalid-id"),
+            )
+
+            val body = response.body
+            assertNotNull(body)
+            assertEquals(400, body.status)
+            assertEquals("Bad Request", body.error)
+            assertEquals("/api/shops/invalid-id", body.path)
+            assertNotNull(body.timestamp)
+        }
+    }
+
+    @Nested
+    inner class NoResourceFoundExceptionの処理 {
+        @Test
+        fun `404 NotFoundを返す`() {
+            val response = handler.handleNoResourceFound(
+                NoResourceFoundException(
+                    HttpMethod.GET,
+                    "/api/shops/00000000-0000-4000-8000-000000000999",
+                    "shops/00000000-0000-4000-8000-000000000999",
+                ),
+                request(path = "/api/shops/00000000-0000-4000-8000-000000000999"),
+            )
+
+            assertEquals(HttpStatus.NOT_FOUND, response.statusCode)
+            assertEquals(404, response.body?.status)
+            assertEquals("Not Found", response.body?.error)
+        }
+    }
+
+    @Nested
+    inner class その他例外の処理 {
+        @Test
+        fun `500 InternalServerErrorを返す`() {
+            val response = handler.handleException(
+                RuntimeException("unexpected"),
+                request(path = "/api/shops"),
+            )
+
+            assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.statusCode)
+            assertEquals(500, response.body?.status)
+            assertEquals("Internal Server Error", response.body?.error)
+        }
+    }
+}

--- a/backend/cs-api/src/test/kotlin/com/mametosho/cs/presentation/controller/ShopControllerTest.kt
+++ b/backend/cs-api/src/test/kotlin/com/mametosho/cs/presentation/controller/ShopControllerTest.kt
@@ -14,6 +14,7 @@ import org.testcontainers.junit.jupiter.Container
 import org.testcontainers.junit.jupiter.Testcontainers
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 @SpringBootTest
 @Testcontainers
@@ -59,19 +60,33 @@ class ShopControllerTest {
         shopifyShopId: String = "test-shop-001",
         name: String = "珈琲工房 まめとしょ",
         introduction: String = "東京都渋谷区にある自家焙煎珈琲店。厳選されたスペシャルティコーヒーをお届けします。",
+        particular: String = "厳選された豆のみを使用しています。",
         shopUrl: String = "https://mametosho.example.com",
         prefecture: String = "TOKYO",
         logoImageUrl: String = "https://example.com/logo.png",
         participationStatus: String = "PARTICIPATING",
     ) {
         jdbcTemplate.execute(
-            "INSERT INTO shops (id, shopify_shop_id, name, introduction, shop_url, prefecture, participation_status) " +
-                "VALUES ('$id', '$shopifyShopId', '$name', '$introduction', '$shopUrl', '$prefecture', '$participationStatus')",
+            "INSERT INTO shops " +
+                "(id, shopify_shop_id, name, introduction, particular, shop_url, prefecture, participation_status) " +
+                "VALUES ('$id', '$shopifyShopId', '$name', '$introduction', '$particular', " +
+                "'$shopUrl', '$prefecture', '$participationStatus')",
         )
         val imageId = id.take(24) + "9" + id.drop(25)
         jdbcTemplate.execute(
             "INSERT INTO shop_images (id, shop_id, type, image_url) " +
                 "VALUES ('$imageId', '$id', 'LOGO', '$logoImageUrl')",
+        )
+    }
+
+    private fun insertMainImage(
+        shopId: String = "00000000-0000-4000-8000-000000000031",
+        imageId: String = "00000000-0000-4000-8000-000000000081",
+        imageUrl: String = "https://placehold.jp/600x400.png",
+    ) {
+        jdbcTemplate.execute(
+            "INSERT INTO shop_images (id, shop_id, type, image_url) " +
+                "VALUES ('$imageId', '$shopId', 'MAIN', '$imageUrl')",
         )
     }
 
@@ -148,6 +163,70 @@ class ShopControllerTest {
             assertEquals(2L, response.body?.totalCount)
             assertEquals(1, response.body?.page)
             assertEquals(1, response.body?.size)
+        }
+    }
+
+    @Nested
+    inner class 店舗詳細取得 {
+        @Test
+        fun `参画中の店舗を指定すると200が返る`() {
+            insertShopWithLogo()
+            val response = shopController.getShop("00000000-0000-4000-8000-000000000031")
+
+            assertEquals(HttpStatus.OK, response.statusCode)
+            assertEquals("00000000-0000-4000-8000-000000000031", response.body?.id)
+        }
+
+        @Test
+        fun `レスポンスボディの店舗フィールドが正しい`() {
+            insertShopWithLogo(
+                logoImageUrl = "https://placehold.jp/100x100.png",
+            )
+            insertMainImage(imageUrl = "https://placehold.jp/600x400.png")
+
+            val response = shopController.getShop("00000000-0000-4000-8000-000000000031")
+
+            val body = response.body
+            assertEquals("00000000-0000-4000-8000-000000000031", body?.id)
+            assertEquals("珈琲工房 まめとしょ", body?.name)
+            assertEquals("東京都渋谷区にある自家焙煎珈琲店。厳選されたスペシャルティコーヒーをお届けします。", body?.introduction)
+            assertEquals("厳選された豆のみを使用しています。", body?.particular)
+            assertEquals("https://mametosho.example.com", body?.shopUrl)
+            assertEquals("TOKYO", body?.prefecture)
+            assertEquals(2, body?.images?.size)
+            val typeToUrl = body?.images?.associate { it.type to it.imageUrl }
+            assertEquals("https://placehold.jp/100x100.png", typeToUrl?.get("LOGO"))
+            assertEquals("https://placehold.jp/600x400.png", typeToUrl?.get("MAIN"))
+        }
+
+        @Test
+        fun `参画前の店舗を指定すると404が返る`() {
+            insertShopWithLogo(participationStatus = "BEFORE_PARTICIPATION")
+            val response = shopController.getShop("00000000-0000-4000-8000-000000000031")
+
+            assertEquals(HttpStatus.NOT_FOUND, response.statusCode)
+        }
+
+        @Test
+        fun `参画落ちの店舗を指定すると404が返る`() {
+            insertShopWithLogo(participationStatus = "DROPPED")
+            val response = shopController.getShop("00000000-0000-4000-8000-000000000031")
+
+            assertEquals(HttpStatus.NOT_FOUND, response.statusCode)
+        }
+
+        @Test
+        fun `存在しないIDを指定すると404が返る`() {
+            val response = shopController.getShop("00000000-0000-4000-8000-000000000999")
+
+            assertEquals(HttpStatus.NOT_FOUND, response.statusCode)
+        }
+
+        @Test
+        fun `UUID形式でないIDを指定するとIllegalArgumentExceptionが投げられGlobalExceptionHandlerで400に変換される`() {
+            assertFailsWith<IllegalArgumentException> {
+                shopController.getShop("invalid-id")
+            }
         }
     }
 }

--- a/docs/swagger/cs-api.yml
+++ b/docs/swagger/cs-api.yml
@@ -68,6 +68,72 @@ paths:
                     totalCount: 3
                     page: 0
                     size: 20
+  /api/shops/{shopId}:
+    get:
+      tags:
+      - Shop
+      summary: 店舗詳細取得
+      description: 指定されたIDの店舗の詳細情報を取得します。参画中の店舗のみ取得できます。
+      operationId: getShop
+      parameters:
+      - name: shopId
+        in: path
+        description: 店舗ID
+        required: true
+        schema:
+          type: string
+        example: 00000000-0000-4000-8000-000000000031
+      responses:
+        "200":
+          description: 取得成功
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ShopDetailResponse"
+              examples:
+                success:
+                  summary: 取得成功例
+                  description: success
+                  value:
+                    id: 00000000-0000-4000-8000-000000000031
+                    name: 珈琲工房 まめとしょ
+                    introduction: 東京都渋谷区にある自家焙煎珈琲店。厳選されたスペシャルティコーヒーをお届けします。
+                    particular: 厳選された豆のみを使用しています。
+                    shopUrl: https://mametosho.example.com
+                    prefecture: TOKYO
+                    images:
+                    - id: 00000000-0000-4000-8000-000000000010
+                      type: LOGO
+                      imageUrl: https://placehold.jp/100x100.png
+                    - id: 00000000-0000-4000-8000-000000000011
+                      type: MAIN
+                      imageUrl: https://placehold.jp/600x400.png
+        "400":
+          description: 店舗IDの形式が不正
+          content:
+            '*/*':
+              examples:
+                bad_request:
+                  summary: 店舗IDがUUID形式でない場合
+                  description: bad_request
+                  value:
+                    timestamp: 2026-02-23T12:00:00.000+00:00
+                    status: 400
+                    error: Bad Request
+                    path: /api/shops/invalid-id
+        "404":
+          description: 店舗が見つかりません（存在しない、または参画中でない）
+          content:
+            '*/*':
+              examples:
+                not_found:
+                  summary: 店舗が見つからない場合
+                  description: not_found
+                  value:
+                    timestamp: 2026-02-23T12:00:00.000+00:00
+                    status: 404
+                    error: Not Found
+                    path: /api/shops/00000000-0000-4000-8000-000000000999
   /api/plans:
     get:
       tags:
@@ -303,6 +369,67 @@ components:
       - introduction
       - logoImageUrl
       - name
+      - prefecture
+      - shopUrl
+    ImageDetail:
+      type: object
+      description: 画像詳細
+      properties:
+        id:
+          type: string
+          description: 画像ID
+          example: 00000000-0000-4000-8000-000000000010
+        type:
+          type: string
+          description: "画像種別（LOGO: ロゴ / MAIN: メイン）"
+          example: LOGO
+        imageUrl:
+          type: string
+          description: 画像URL
+          example: https://placehold.jp/100x100.png
+      required:
+      - id
+      - imageUrl
+      - type
+    ShopDetailResponse:
+      type: object
+      description: 店舗詳細レスポンス
+      properties:
+        id:
+          type: string
+          description: 店舗ID
+          example: 00000000-0000-4000-8000-000000000031
+        name:
+          type: string
+          description: 店舗名
+          example: 珈琲工房 まめとしょ
+        introduction:
+          type: string
+          description: 店舗紹介文
+          example: 東京都渋谷区にある自家焙煎珈琲店。厳選されたスペシャルティコーヒーをお届けします。
+        particular:
+          type: string
+          description: こだわり
+          example: 厳選された豆のみを使用しています。
+        shopUrl:
+          type: string
+          description: 店舗URL
+          example: https://mametosho.example.com
+        prefecture:
+          type: string
+          description: 都道府県
+          example: TOKYO
+        images:
+          type: array
+          description: 画像一覧
+          items:
+            $ref: "#/components/schemas/ImageDetail"
+      required:
+      - id
+      - images
+      - introduction
+      - name
+      - particular
       - prefecture
       - shopUrl
     PlanResponse:


### PR DESCRIPTION
## 概要
CS（一般ユーザー）向けの店舗詳細ページ用に、店舗1件を取得するAPI `GET /api/shops/{shopId}` を追加します。デザイン未確定のため、まずバックエンドAPIのみ先行実装です。

現状 cs-api には `GET /api/shops`（参画中店舗の一覧）しか無く、特定店舗の詳細取得エンドポイントがありませんでした。

## 仕様
| ケース | 挙動 |
|---|---|
| 参画中(PARTICIPATING)の店舗 | 200 + 詳細 |
| 参画前 / 参画落ち / 存在しないID | 404 |
| UUID形式でないID | 400 |

- レスポンスは詳細用に全項目を返す: `id / name / introduction / particular / shopUrl / prefecture` + 画像一覧（LOGO/MAIN の `id / type / imageUrl`）
- `shopifyShopId`・`participationStatus` は内部情報のため含めない
- CS向けの「参画中のみ公開」方針は一覧 `FindShopsUsecase` と一貫

## 変更内容
**本体**
- `GetShopUsecase`（新規）: `ShopRepository.findById` で取得し、参画中以外は `null`（→404）
- `ShopDetailResponse`（新規）: ドメイン→DTO変換。`introduction`/`particular` の null は既存 `ShopResponse` と同様に空文字へ畳み込み
- `ShopController`: `@GetMapping("/{shopId}")` 追加（OpenAPI 200/400/404 アノテーション付き）
- `GlobalExceptionHandler`: `IllegalArgumentException → 400` ハンドラを追加。不正なUUID形式の `shopId` をドメインの `ShopId` バリデーションでリクエストレベルに弾く（admin-apiと同じ方式に統一）

**テスト**
- `GetShopUsecaseTest`（新規）: 参画中→取得 / 参画前・参画落ち・存在しない→null / 不正UUID→例外
- `GlobalExceptionHandlerTest`（新規）: 400/404/500 マッピングを検証
- `ShopControllerTest`: 詳細取得の `@Nested` を追加（200 全項目+画像 / 各種404 / 不正UUID）

**自動生成**
- `docs/swagger/cs-api.yml`: コードから再生成（手動編集なし）

## 検証
- `./gradlew :cs-api:test` ✅
- `./gradlew detekt` ✅
- `./gradlew :cs-api:generateOpenApiDocs` ✅（`/api/shops/{shopId}` が出力されることを確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)