### PR TITLE
feat: 精製方法4種を追加し表示名をbackend正本化・DTOをenum型に変更

### DIFF
--- a/admin-frontend/src/api/coffee-beans.ts
+++ b/admin-frontend/src/api/coffee-beans.ts
@@ -10,6 +10,8 @@ export type CoffeeBeanDetail =
   components["schemas"]["CoffeeBeanDetailResponse"];
 export type CoffeeBeanListResponse =
   components["schemas"]["CoffeeBeanListResponse"];
+export type ProcessingMethodOption =
+  components["schemas"]["ProcessingMethodResponse"];
 
 export async function fetchCoffeeBeans(
   page = 0,
@@ -22,6 +24,21 @@ export async function fetchCoffeeBeans(
 
   if (error) {
     throw new Error("コーヒー豆一覧の取得に失敗しました");
+  }
+
+  return data;
+}
+
+export async function fetchProcessingMethods(): Promise<
+  ProcessingMethodOption[]
+> {
+  const client = await createAuthenticatedApiClient();
+  const { data, error } = await client.GET(
+    "/api/admin/coffee-beans/processing-methods",
+  );
+
+  if (error) {
+    throw new Error("精製方法一覧の取得に失敗しました");
   }
 
   return data;

--- a/admin-frontend/src/api/generated/admin-api.ts
+++ b/admin-frontend/src/api/generated/admin-api.ts
@@ -192,6 +192,26 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/api/admin/coffee-beans/processing-methods": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * 精製方法一覧取得
+     * @description コーヒー豆の精製方法の選択肢一覧（値と表示名）を取得します。
+     */
+    get: operations["listProcessingMethods"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -384,8 +404,21 @@ export interface components {
       /**
        * @description 精製方法
        * @example WASHED
+       * @enum {string}
        */
-      processingMethod: string;
+      processingMethod:
+        | "FULLY_WASHED"
+        | "WASHED"
+        | "ANAEROBIC_WASHED"
+        | "THERMAL_SHOCK_NATURAL"
+        | "NATURAL"
+        | "ANAEROBIC_NATURAL"
+        | "DRY_ON_TREE_NATURAL"
+        | "LACTIC_NATURAL"
+        | "WET_HULLING"
+        | "HONEY"
+        | "LADO_A_LADO_PROCESS"
+        | "LADO_A_LADO_PROCESS_FULLY_WASHED";
       /**
        * @description 公開状態（DRAFT: 下書き / PUBLISHED: 公開）
        * @example PUBLISHED
@@ -501,8 +534,21 @@ export interface components {
       /**
        * @description 精製方法
        * @example WASHED
+       * @enum {string}
        */
-      processingMethod: string;
+      processingMethod:
+        | "FULLY_WASHED"
+        | "WASHED"
+        | "ANAEROBIC_WASHED"
+        | "THERMAL_SHOCK_NATURAL"
+        | "NATURAL"
+        | "ANAEROBIC_NATURAL"
+        | "DRY_ON_TREE_NATURAL"
+        | "LACTIC_NATURAL"
+        | "WET_HULLING"
+        | "HONEY"
+        | "LADO_A_LADO_PROCESS"
+        | "LADO_A_LADO_PROCESS_FULLY_WASHED";
       /**
        * @description 公開状態（DRAFT: 下書き / PUBLISHED: 公開）
        * @example DRAFT
@@ -880,8 +926,26 @@ export interface components {
       /**
        * @description 精製方法
        * @example WASHED
+       * @enum {string}
        */
-      processingMethod: string;
+      processingMethod:
+        | "FULLY_WASHED"
+        | "WASHED"
+        | "ANAEROBIC_WASHED"
+        | "THERMAL_SHOCK_NATURAL"
+        | "NATURAL"
+        | "ANAEROBIC_NATURAL"
+        | "DRY_ON_TREE_NATURAL"
+        | "LACTIC_NATURAL"
+        | "WET_HULLING"
+        | "HONEY"
+        | "LADO_A_LADO_PROCESS"
+        | "LADO_A_LADO_PROCESS_FULLY_WASHED";
+      /**
+       * @description 精製方法の表示名
+       * @example ウォッシュド
+       */
+      processingMethodName: string;
       /**
        * @description 公開状態（DRAFT: 下書き / PUBLISHED: 公開）
        * @example PUBLISHED
@@ -938,8 +1002,26 @@ export interface components {
       /**
        * @description 精製方法
        * @example WASHED
+       * @enum {string}
        */
-      processingMethod: string;
+      processingMethod:
+        | "FULLY_WASHED"
+        | "WASHED"
+        | "ANAEROBIC_WASHED"
+        | "THERMAL_SHOCK_NATURAL"
+        | "NATURAL"
+        | "ANAEROBIC_NATURAL"
+        | "DRY_ON_TREE_NATURAL"
+        | "LACTIC_NATURAL"
+        | "WET_HULLING"
+        | "HONEY"
+        | "LADO_A_LADO_PROCESS"
+        | "LADO_A_LADO_PROCESS_FULLY_WASHED";
+      /**
+       * @description 精製方法の表示名
+       * @example ウォッシュド
+       */
+      processingMethodName: string;
       /**
        * @description 公開状態（DRAFT: 下書き / PUBLISHED: 公開）
        * @example PUBLISHED
@@ -978,6 +1060,32 @@ export interface components {
        * @example 4
        */
       evaluationValue: number;
+    };
+    /** @description 精製方法 */
+    ProcessingMethodResponse: {
+      /**
+       * @description 精製方法の値
+       * @example WASHED
+       * @enum {string}
+       */
+      value:
+        | "FULLY_WASHED"
+        | "WASHED"
+        | "ANAEROBIC_WASHED"
+        | "THERMAL_SHOCK_NATURAL"
+        | "NATURAL"
+        | "ANAEROBIC_NATURAL"
+        | "DRY_ON_TREE_NATURAL"
+        | "LACTIC_NATURAL"
+        | "WET_HULLING"
+        | "HONEY"
+        | "LADO_A_LADO_PROCESS"
+        | "LADO_A_LADO_PROCESS_FULLY_WASHED";
+      /**
+       * @description 精製方法の表示名
+       * @example ウォッシュド
+       */
+      label: string;
     };
   };
   responses: never;
@@ -1587,6 +1695,26 @@ export interface operations {
         };
         content: {
           "*/*": components["schemas"]["PlanListResponse"];
+        };
+      };
+    };
+  };
+  listProcessingMethods: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 取得成功 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["ProcessingMethodResponse"][];
         };
       };
     };

--- a/admin-frontend/src/app/(admin)/coffee-beans/[id]/_components/CoffeeBeanActions.tsx
+++ b/admin-frontend/src/app/(admin)/coffee-beans/[id]/_components/CoffeeBeanActions.tsx
@@ -1,7 +1,10 @@
 "use client";
 
 import { useState } from "react";
-import type { CoffeeBeanDetail } from "@/api/coffee-beans";
+import type {
+  CoffeeBeanDetail,
+  ProcessingMethodOption,
+} from "@/api/coffee-beans";
 import type { TasteListItem } from "@/api/tastes";
 import styles from "@/components/actions.module.css";
 import { DeleteCoffeeBeanModal } from "./DeleteCoffeeBeanModal";
@@ -11,10 +14,12 @@ export function CoffeeBeanActions({
   coffeeBean,
   initialShops,
   tastes,
+  processingMethods,
 }: {
   coffeeBean: CoffeeBeanDetail;
   initialShops: { id: string; name: string }[];
   tastes: TasteListItem[];
+  processingMethods: ProcessingMethodOption[];
 }) {
   const [editOpen, setEditOpen] = useState(false);
   const [editKey, setEditKey] = useState(0);
@@ -54,6 +59,7 @@ export function CoffeeBeanActions({
         coffeeBean={coffeeBean}
         initialShops={initialShops}
         tastes={tastes}
+        processingMethods={processingMethods}
         open={editOpen}
         onClose={() => setEditOpen(false)}
       />

--- a/admin-frontend/src/app/(admin)/coffee-beans/[id]/_components/CoffeeBeanDetail.tsx
+++ b/admin-frontend/src/app/(admin)/coffee-beans/[id]/_components/CoffeeBeanDetail.tsx
@@ -1,12 +1,12 @@
 import Image from "next/image";
 import Link from "next/link";
-import type { CoffeeBeanDetail as CoffeeBeanDetailType } from "@/api/coffee-beans";
+import type {
+  CoffeeBeanDetail as CoffeeBeanDetailType,
+  ProcessingMethodOption,
+} from "@/api/coffee-beans";
 import type { TasteListItem } from "@/api/tastes";
 import { PublishStatusBadge } from "@/components/PublishStatusBadge";
-import {
-  getProcessingMethodLabel,
-  getRoastLevelLabel,
-} from "../../_lib/coffeeBeanLabels";
+import { getRoastLevelLabel } from "../../_lib/coffeeBeanLabels";
 import { CoffeeBeanActions } from "./CoffeeBeanActions";
 import styles from "./CoffeeBeanDetail.module.css";
 
@@ -14,10 +14,12 @@ export function CoffeeBeanDetail({
   coffeeBean,
   initialShops,
   tastes,
+  processingMethods,
 }: {
   coffeeBean: CoffeeBeanDetailType;
   initialShops: { id: string; name: string }[];
   tastes: TasteListItem[];
+  processingMethods: ProcessingMethodOption[];
 }) {
   return (
     <div className={styles.container}>
@@ -32,6 +34,7 @@ export function CoffeeBeanDetail({
           coffeeBean={coffeeBean}
           initialShops={initialShops}
           tastes={tastes}
+          processingMethods={processingMethods}
         />
       </div>
 
@@ -76,7 +79,7 @@ export function CoffeeBeanDetail({
           <div className={styles.field}>
             <dt className={styles.fieldLabel}>精製方法</dt>
             <dd className={styles.fieldValue}>
-              {getProcessingMethodLabel(coffeeBean.processingMethod)}
+              {coffeeBean.processingMethodName}
             </dd>
           </div>
 

--- a/admin-frontend/src/app/(admin)/coffee-beans/[id]/_components/EditCoffeeBeanModal.tsx
+++ b/admin-frontend/src/app/(admin)/coffee-beans/[id]/_components/EditCoffeeBeanModal.tsx
@@ -7,14 +7,14 @@ import {
   useId,
   useRef,
 } from "react";
-import type { CoffeeBeanDetail } from "@/api/coffee-beans";
+import type {
+  CoffeeBeanDetail,
+  ProcessingMethodOption,
+} from "@/api/coffee-beans";
 import type { TasteListItem } from "@/api/tastes";
 import { searchShopsAction } from "@/app/(admin)/coffee-beans/_components/searchShopsAction";
 import { TasteProfileField } from "@/app/(admin)/coffee-beans/_components/TasteProfileField";
-import {
-  PROCESSING_METHOD_LABELS,
-  ROAST_LEVEL_LABELS,
-} from "@/app/(admin)/coffee-beans/_lib/coffeeBeanLabels";
+import { ROAST_LEVEL_LABELS } from "@/app/(admin)/coffee-beans/_lib/coffeeBeanLabels";
 import { ImageUploadField } from "@/components/ImageUploadField";
 import modalStyles from "@/components/modal.module.css";
 import { ShopSearchSelect } from "@/components/ShopSearchSelect";
@@ -30,12 +30,14 @@ export function EditCoffeeBeanModal({
   coffeeBean,
   initialShops,
   tastes,
+  processingMethods,
   open,
   onClose,
 }: {
   coffeeBean: CoffeeBeanDetail;
   initialShops: { id: string; name: string }[];
   tastes: TasteListItem[];
+  processingMethods: ProcessingMethodOption[];
   open: boolean;
   onClose: () => void;
 }) {
@@ -246,7 +248,7 @@ export function EditCoffeeBeanModal({
             }
             className={modalStyles.select}
           >
-            {Object.entries(PROCESSING_METHOD_LABELS).map(([value, label]) => (
+            {processingMethods.map(({ value, label }) => (
               <option key={value} value={value}>
                 {label}
               </option>

--- a/admin-frontend/src/app/(admin)/coffee-beans/[id]/page.tsx
+++ b/admin-frontend/src/app/(admin)/coffee-beans/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { fetchCoffeeBean } from "@/api/coffee-beans";
+import { fetchCoffeeBean, fetchProcessingMethods } from "@/api/coffee-beans";
 import { fetchShops } from "@/api/shops";
 import { fetchTastes } from "@/api/tastes";
 import { CoffeeBeanDetail } from "./_components/CoffeeBeanDetail";
@@ -9,10 +9,11 @@ export default async function CoffeeBeanDetailPage({
   params: Promise<{ id: string }>;
 }) {
   const { id } = await params;
-  const [coffeeBean, shops, tastes] = await Promise.all([
+  const [coffeeBean, shops, tastes, processingMethods] = await Promise.all([
     fetchCoffeeBean(id),
     fetchShops(0, 10),
     fetchTastes().catch(() => []),
+    fetchProcessingMethods(),
   ]);
   const initialShops = shops.items.map((s) => ({ id: s.id, name: s.name }));
   return (
@@ -20,6 +21,7 @@ export default async function CoffeeBeanDetailPage({
       coffeeBean={coffeeBean}
       initialShops={initialShops}
       tastes={tastes}
+      processingMethods={processingMethods}
     />
   );
 }

--- a/admin-frontend/src/app/(admin)/coffee-beans/_components/CoffeeBeanListTable.tsx
+++ b/admin-frontend/src/app/(admin)/coffee-beans/_components/CoffeeBeanListTable.tsx
@@ -3,10 +3,7 @@ import type { CoffeeBeanListResponse } from "@/api/coffee-beans";
 import styles from "@/components/list-page.module.css";
 import { Pagination } from "@/components/Pagination";
 import { PublishStatusBadge } from "@/components/PublishStatusBadge";
-import {
-  getProcessingMethodLabel,
-  getRoastLevelLabel,
-} from "../_lib/coffeeBeanLabels";
+import { getRoastLevelLabel } from "../_lib/coffeeBeanLabels";
 import { CreateCoffeeBeanButton } from "./CreateCoffeeBeanButton";
 
 export function CoffeeBeanListTable({
@@ -80,7 +77,7 @@ export function CoffeeBeanListTable({
                     href={`/coffee-beans/${bean.id}`}
                     className={styles.rowLink}
                   >
-                    {getProcessingMethodLabel(bean.processingMethod)}
+                    {bean.processingMethodName}
                   </Link>
                 </td>
                 <td>

--- a/admin-frontend/src/app/(admin)/coffee-beans/_components/CreateCoffeeBeanButton.tsx
+++ b/admin-frontend/src/app/(admin)/coffee-beans/_components/CreateCoffeeBeanButton.tsx
@@ -1,11 +1,19 @@
+import { fetchProcessingMethods } from "@/api/coffee-beans";
 import { fetchShops } from "@/api/shops";
 import { fetchTastes } from "@/api/tastes";
 import { CreateCoffeeBeanButtonClient } from "./CreateCoffeeBeanButtonClient";
 
 export async function CreateCoffeeBeanButton() {
-  const [shops, tastes] = await Promise.all([
+  const [shops, tastes, processingMethods] = await Promise.all([
     fetchShops(0, 10),
     fetchTastes().catch(() => []),
+    fetchProcessingMethods(),
   ]);
-  return <CreateCoffeeBeanButtonClient shops={shops.items} tastes={tastes} />;
+  return (
+    <CreateCoffeeBeanButtonClient
+      shops={shops.items}
+      tastes={tastes}
+      processingMethods={processingMethods}
+    />
+  );
 }

--- a/admin-frontend/src/app/(admin)/coffee-beans/_components/CreateCoffeeBeanButtonClient.tsx
+++ b/admin-frontend/src/app/(admin)/coffee-beans/_components/CreateCoffeeBeanButtonClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import type { ProcessingMethodOption } from "@/api/coffee-beans";
 import type { ShopListItem } from "@/api/shops";
 import type { TasteListItem } from "@/api/tastes";
 import styles from "@/components/list-page.module.css";
@@ -9,9 +10,11 @@ import { CreateCoffeeBeanModal } from "./CreateCoffeeBeanModal";
 export function CreateCoffeeBeanButtonClient({
   shops,
   tastes,
+  processingMethods,
 }: {
   shops: ShopListItem[];
   tastes: TasteListItem[];
+  processingMethods: ProcessingMethodOption[];
 }) {
   const [open, setOpen] = useState(false);
   const [modalKey, setModalKey] = useState(0);
@@ -34,6 +37,7 @@ export function CreateCoffeeBeanButtonClient({
         key={modalKey}
         shops={shops}
         tastes={tastes}
+        processingMethods={processingMethods}
         open={open}
         onClose={() => setOpen(false)}
       />

--- a/admin-frontend/src/app/(admin)/coffee-beans/_components/CreateCoffeeBeanModal.tsx
+++ b/admin-frontend/src/app/(admin)/coffee-beans/_components/CreateCoffeeBeanModal.tsx
@@ -7,16 +7,11 @@ import {
   useId,
   useRef,
 } from "react";
+import type { ProcessingMethodOption } from "@/api/coffee-beans";
 import type { ShopListItem } from "@/api/shops";
 import type { TasteListItem } from "@/api/tastes";
-import type {
-  ProcessingMethod,
-  RoastLevel,
-} from "@/app/(admin)/coffee-beans/_lib/coffeeBeanLabels";
-import {
-  PROCESSING_METHOD_LABELS,
-  ROAST_LEVEL_LABELS,
-} from "@/app/(admin)/coffee-beans/_lib/coffeeBeanLabels";
+import type { RoastLevel } from "@/app/(admin)/coffee-beans/_lib/coffeeBeanLabels";
+import { ROAST_LEVEL_LABELS } from "@/app/(admin)/coffee-beans/_lib/coffeeBeanLabels";
 import { ImageUploadField } from "@/components/ImageUploadField";
 import modalStyles from "@/components/modal.module.css";
 import { ShopSearchSelect } from "@/components/ShopSearchSelect";
@@ -33,11 +28,13 @@ const initialState: CreateCoffeeBeanState = {};
 export function CreateCoffeeBeanModal({
   shops,
   tastes,
+  processingMethods,
   open,
   onClose,
 }: {
   shops: ShopListItem[];
   tastes: TasteListItem[];
+  processingMethods: ProcessingMethodOption[];
   open: boolean;
   onClose: () => void;
 }) {
@@ -250,12 +247,7 @@ export function CreateCoffeeBeanModal({
             <option value="" disabled>
               精製方法を選択してください
             </option>
-            {(
-              Object.entries(PROCESSING_METHOD_LABELS) as [
-                ProcessingMethod,
-                string,
-              ][]
-            ).map(([value, label]) => (
+            {processingMethods.map(({ value, label }) => (
               <option key={value} value={value}>
                 {label}
               </option>

--- a/admin-frontend/src/app/(admin)/coffee-beans/_lib/coffeeBeanFormSchema.ts
+++ b/admin-frontend/src/app/(admin)/coffee-beans/_lib/coffeeBeanFormSchema.ts
@@ -1,5 +1,5 @@
 import { z } from "zod/v4";
-import { PROCESSING_METHODS, ROAST_LEVELS } from "./coffeeBeanLabels";
+import { ROAST_LEVELS } from "./coffeeBeanLabels";
 
 export const coffeeBeanFieldsSchema = z.object({
   shopId: z.string().min(1, "店舗を選択してください。"),
@@ -27,9 +27,8 @@ export const coffeeBeanFieldsSchema = z.object({
   roastLevel: z.enum(ROAST_LEVELS, {
     error: "焙煎度を選択してください。",
   }),
-  processingMethod: z.enum(PROCESSING_METHODS, {
-    error: "精製方法を選択してください。",
-  }),
+  // 有効値はAdmin APIの精製方法一覧が正本。不正値はAPI側で400になる
+  processingMethod: z.string().min(1, "精製方法を選択してください。"),
   isSpecialty: z
     .enum(["true", "false"], {
       error: "スペシャルティを選択してください。",

--- a/admin-frontend/src/app/(admin)/coffee-beans/_lib/coffeeBeanLabels.ts
+++ b/admin-frontend/src/app/(admin)/coffee-beans/_lib/coffeeBeanLabels.ts
@@ -15,33 +15,6 @@ export const ROAST_LEVEL_LABELS: Record<RoastLevel, string> = {
   FRENCH: "深煎り",
 };
 
-export const PROCESSING_METHODS = [
-  "FULLY_WASHED",
-  "WASHED",
-  "THERMAL_SHOCK_NATURAL",
-  "NATURAL",
-  "ANAEROBIC_NATURAL",
-  "DRY_ON_TREE_NATURAL",
-  "WET_HULLING",
-  "HONEY",
-] as const;
-export type ProcessingMethod = (typeof PROCESSING_METHODS)[number];
-
-export const PROCESSING_METHOD_LABELS: Record<ProcessingMethod, string> = {
-  FULLY_WASHED: "フリーウォッシュド",
-  WASHED: "ウォッシュド",
-  THERMAL_SHOCK_NATURAL: "サーマルショック・ナチュラル",
-  NATURAL: "ナチュラル",
-  ANAEROBIC_NATURAL: "アナエロビックナチュラル",
-  DRY_ON_TREE_NATURAL: "ドライオンツリーナチュラル",
-  WET_HULLING: "スマトラ式",
-  HONEY: "ハニー",
-};
-
 export function getRoastLevelLabel(value: string): string {
   return ROAST_LEVEL_LABELS[value as RoastLevel] ?? value;
-}
-
-export function getProcessingMethodLabel(value: string): string {
-  return PROCESSING_METHOD_LABELS[value as ProcessingMethod] ?? value;
 }

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/application/usecase/CreateCoffeeBeanUsecase.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/application/usecase/CreateCoffeeBeanUsecase.kt
@@ -36,7 +36,7 @@ class CreateCoffeeBeanUsecase(
             origin = request.origin,
             farm = request.farm,
             roastLevel = request.roastLevel,
-            processingMethod = request.processingMethod,
+            processingMethod = request.processingMethod.name,
             isSpecialty = request.isSpecialty,
             publishStatus = request.publishStatus,
             images = images,

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/application/usecase/UpdateCoffeeBeanUsecase.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/application/usecase/UpdateCoffeeBeanUsecase.kt
@@ -41,7 +41,7 @@ class UpdateCoffeeBeanUsecase(
             origin = request.origin,
             farm = request.farm,
             roastLevel = request.roastLevel,
-            processingMethod = request.processingMethod,
+            processingMethod = request.processingMethod.name,
             isSpecialty = request.isSpecialty,
             publishStatus = request.publishStatus,
             images = finalImages,

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/controller/CoffeeBeanController.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/controller/CoffeeBeanController.kt
@@ -13,7 +13,10 @@ import com.mametosho.admin.presentation.dto.response.CoffeeBeanListResponse
 import com.mametosho.admin.presentation.dto.response.CoffeeBeanSummaryResponse
 import com.mametosho.admin.presentation.dto.response.CoffeeBeanResponse
 import com.mametosho.admin.presentation.dto.response.ErrorResponse
+import com.mametosho.admin.presentation.dto.response.ProcessingMethodResponse
+import com.mametosho.domain.model.coffeebean.ProcessingMethod
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.ExampleObject
 import io.swagger.v3.oas.annotations.media.Schema
@@ -99,6 +102,48 @@ class CoffeeBeanController(
     ): ResponseEntity<CoffeeBeanListResponse> {
         val result = findCoffeeBeansUsecase.execute(page, size)
         return ResponseEntity.ok(CoffeeBeanListResponse.from(result))
+    }
+
+    @GetMapping("/processing-methods")
+    @Operation(
+        summary = "精製方法一覧取得",
+        description = "コーヒー豆の精製方法の選択肢一覧（値と表示名）を取得します。",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "取得成功",
+                content = [
+                    Content(
+                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                        array = ArraySchema(schema = Schema(implementation = ProcessingMethodResponse::class)),
+                        examples = [
+                            ExampleObject(
+                                name = "success",
+                                summary = "取得成功例",
+                                value = """
+                                    [
+                                      {
+                                        "value": "FULLY_WASHED",
+                                        "label": "フリーウォッシュド"
+                                      },
+                                      {
+                                        "value": "WASHED",
+                                        "label": "ウォッシュド"
+                                      }
+                                    ]
+                                """,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+    fun listProcessingMethods(): ResponseEntity<List<ProcessingMethodResponse>> {
+        val responses = ProcessingMethod.entries.map { ProcessingMethodResponse.from(it) }
+        return ResponseEntity.ok(responses)
     }
 
     @GetMapping("/{id}")

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/request/CreateCoffeeBeanRequest.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/request/CreateCoffeeBeanRequest.kt
@@ -1,6 +1,7 @@
 package com.mametosho.admin.presentation.dto.request
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.mametosho.domain.model.coffeebean.ProcessingMethod
 import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "コーヒー豆登録リクエスト")
@@ -27,7 +28,7 @@ data class CreateCoffeeBeanRequest(
     val roastLevel: String,
 
     @Schema(description = "精製方法", example = "WASHED", requiredMode = Schema.RequiredMode.REQUIRED)
-    val processingMethod: String,
+    val processingMethod: ProcessingMethod,
 
     @get:Schema(description = "スペシャルティコーヒーかどうか", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
     @get:JsonProperty("isSpecialty")

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/request/UpdateCoffeeBeanRequest.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/request/UpdateCoffeeBeanRequest.kt
@@ -1,6 +1,7 @@
 package com.mametosho.admin.presentation.dto.request
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.mametosho.domain.model.coffeebean.ProcessingMethod
 import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "コーヒー豆更新リクエスト")
@@ -27,7 +28,7 @@ data class UpdateCoffeeBeanRequest(
     val roastLevel: String,
 
     @Schema(description = "精製方法", example = "WASHED", requiredMode = Schema.RequiredMode.REQUIRED)
-    val processingMethod: String,
+    val processingMethod: ProcessingMethod,
 
     @get:Schema(description = "スペシャルティコーヒーかどうか", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
     @get:JsonProperty("isSpecialty")

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/CoffeeBeanDetailResponse.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/CoffeeBeanDetailResponse.kt
@@ -2,6 +2,7 @@ package com.mametosho.admin.presentation.dto.response
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.mametosho.admin.application.query.result.CoffeeBeanDetailResult
+import com.mametosho.domain.model.coffeebean.ProcessingMethod
 import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "コーヒー豆詳細レスポンス")
@@ -23,7 +24,9 @@ data class CoffeeBeanDetailResponse(
     @Schema(description = "焙煎度", example = "MEDIUM", requiredMode = Schema.RequiredMode.REQUIRED)
     val roastLevel: String,
     @Schema(description = "精製方法", example = "WASHED", requiredMode = Schema.RequiredMode.REQUIRED)
-    val processingMethod: String,
+    val processingMethod: ProcessingMethod,
+    @Schema(description = "精製方法の表示名", example = "ウォッシュド", requiredMode = Schema.RequiredMode.REQUIRED)
+    val processingMethodName: String,
     @get:Schema(description = "スペシャルティコーヒーかどうか", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
     @get:JsonProperty("isSpecialty")
     val isSpecialty: Boolean,
@@ -61,22 +64,26 @@ data class CoffeeBeanDetailResponse(
     )
 
     companion object {
-        fun from(result: CoffeeBeanDetailResult): CoffeeBeanDetailResponse = CoffeeBeanDetailResponse(
-            id = result.id,
-            shopId = result.shopId,
-            shopifyBeanId = result.shopifyBeanId,
-            name = result.name,
-            description = result.description,
-            origin = result.origin,
-            farm = result.farm,
-            roastLevel = result.roastLevel,
-            processingMethod = result.processingMethod,
-            isSpecialty = result.isSpecialty,
-            publishStatus = result.publishStatus,
-            images = result.images.map { ImageDetail(id = it.id, type = it.type, imageUrl = it.imageUrl) },
-            tastes = result.tastes.map {
-                TasteDetail(id = it.id, tasteId = it.tasteId, tasteName = it.tasteName, evaluationValue = it.evaluationValue)
-            },
-        )
+        fun from(result: CoffeeBeanDetailResult): CoffeeBeanDetailResponse {
+            val processingMethod = ProcessingMethod.valueOf(result.processingMethod)
+            return CoffeeBeanDetailResponse(
+                id = result.id,
+                shopId = result.shopId,
+                shopifyBeanId = result.shopifyBeanId,
+                name = result.name,
+                description = result.description,
+                origin = result.origin,
+                farm = result.farm,
+                roastLevel = result.roastLevel,
+                processingMethod = processingMethod,
+                processingMethodName = processingMethod.label,
+                isSpecialty = result.isSpecialty,
+                publishStatus = result.publishStatus,
+                images = result.images.map { ImageDetail(id = it.id, type = it.type, imageUrl = it.imageUrl) },
+                tastes = result.tastes.map {
+                    TasteDetail(id = it.id, tasteId = it.tasteId, tasteName = it.tasteName, evaluationValue = it.evaluationValue)
+                },
+            )
+        }
     }
 }

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/CoffeeBeanSummaryResponse.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/CoffeeBeanSummaryResponse.kt
@@ -2,6 +2,7 @@ package com.mametosho.admin.presentation.dto.response
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.mametosho.admin.application.query.result.CoffeeBeanSummaryResult
+import com.mametosho.domain.model.coffeebean.ProcessingMethod
 import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "コーヒー豆一覧アイテム")
@@ -23,7 +24,9 @@ data class CoffeeBeanSummaryResponse(
     @Schema(description = "焙煎度", example = "MEDIUM", requiredMode = Schema.RequiredMode.REQUIRED)
     val roastLevel: String,
     @Schema(description = "精製方法", example = "WASHED", requiredMode = Schema.RequiredMode.REQUIRED)
-    val processingMethod: String,
+    val processingMethod: ProcessingMethod,
+    @Schema(description = "精製方法の表示名", example = "ウォッシュド", requiredMode = Schema.RequiredMode.REQUIRED)
+    val processingMethodName: String,
     @get:Schema(description = "スペシャルティコーヒーかどうか", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
     @get:JsonProperty("isSpecialty")
     val isSpecialty: Boolean,
@@ -35,18 +38,22 @@ data class CoffeeBeanSummaryResponse(
     val publishStatus: String,
 ) {
     companion object {
-        fun from(result: CoffeeBeanSummaryResult): CoffeeBeanSummaryResponse = CoffeeBeanSummaryResponse(
-            id = result.id,
-            shopId = result.shopId,
-            shopifyBeanId = result.shopifyBeanId,
-            name = result.name,
-            description = result.description,
-            origin = result.origin,
-            farm = result.farm,
-            roastLevel = result.roastLevel,
-            processingMethod = result.processingMethod,
-            isSpecialty = result.isSpecialty,
-            publishStatus = result.publishStatus,
-        )
+        fun from(result: CoffeeBeanSummaryResult): CoffeeBeanSummaryResponse {
+            val processingMethod = ProcessingMethod.valueOf(result.processingMethod)
+            return CoffeeBeanSummaryResponse(
+                id = result.id,
+                shopId = result.shopId,
+                shopifyBeanId = result.shopifyBeanId,
+                name = result.name,
+                description = result.description,
+                origin = result.origin,
+                farm = result.farm,
+                roastLevel = result.roastLevel,
+                processingMethod = processingMethod,
+                processingMethodName = processingMethod.label,
+                isSpecialty = result.isSpecialty,
+                publishStatus = result.publishStatus,
+            )
+        }
     }
 }

--- a/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/ProcessingMethodResponse.kt
+++ b/backend/admin-api/src/main/kotlin/com/mametosho/admin/presentation/dto/response/ProcessingMethodResponse.kt
@@ -1,0 +1,19 @@
+package com.mametosho.admin.presentation.dto.response
+
+import com.mametosho.domain.model.coffeebean.ProcessingMethod
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "精製方法")
+data class ProcessingMethodResponse(
+    @Schema(description = "精製方法の値", example = "WASHED", requiredMode = Schema.RequiredMode.REQUIRED)
+    val value: ProcessingMethod,
+    @Schema(description = "精製方法の表示名", example = "ウォッシュド", requiredMode = Schema.RequiredMode.REQUIRED)
+    val label: String,
+) {
+    companion object {
+        fun from(processingMethod: ProcessingMethod): ProcessingMethodResponse = ProcessingMethodResponse(
+            value = processingMethod,
+            label = processingMethod.label,
+        )
+    }
+}

--- a/backend/admin-api/src/test/kotlin/com/mametosho/admin/application/usecase/CreateCoffeeBeanUsecaseTest.kt
+++ b/backend/admin-api/src/test/kotlin/com/mametosho/admin/application/usecase/CreateCoffeeBeanUsecaseTest.kt
@@ -43,7 +43,7 @@ class CreateCoffeeBeanUsecaseTest {
         origin: String = "エチオピア",
         farm: String? = "テスト農園",
         roastLevel: String = "MEDIUM",
-        processingMethod: String = "WASHED",
+        processingMethod: ProcessingMethod = ProcessingMethod.WASHED,
         isSpecialty: Boolean = true,
         publishStatus: String = "PUBLISHED",
         tastes: List<CreateCoffeeBeanRequest.TasteRequest> = listOf(
@@ -155,13 +155,6 @@ class CreateCoffeeBeanUsecaseTest {
         fun `不正な焙煎度の場合は例外が発生する`() {
             assertThrows<IllegalArgumentException> {
                 usecase.execute(createRequest(roastLevel = "INVALID"), listOf(ImageUpload("MAIN", imageFile)))
-            }
-        }
-
-        @Test
-        fun `不正な精製方法の場合は例外が発生する`() {
-            assertThrows<IllegalArgumentException> {
-                usecase.execute(createRequest(processingMethod = "INVALID"), listOf(ImageUpload("MAIN", imageFile)))
             }
         }
 

--- a/backend/admin-api/src/test/kotlin/com/mametosho/admin/application/usecase/UpdateCoffeeBeanUsecaseTest.kt
+++ b/backend/admin-api/src/test/kotlin/com/mametosho/admin/application/usecase/UpdateCoffeeBeanUsecaseTest.kt
@@ -65,7 +65,7 @@ class UpdateCoffeeBeanUsecaseTest {
         origin: String = "ブラジル",
         farm: String? = "更新後農園",
         roastLevel: String = "FRENCH",
-        processingMethod: String = "NATURAL",
+        processingMethod: ProcessingMethod = ProcessingMethod.NATURAL,
         isSpecialty: Boolean = true,
         publishStatus: String = "PUBLISHED",
         tastes: List<UpdateCoffeeBeanRequest.TasteRequest> = listOf(
@@ -256,18 +256,6 @@ class UpdateCoffeeBeanUsecaseTest {
                 usecase.execute(
                     existingBean.id.value,
                     createRequest(roastLevel = "INVALID"),
-                    listOf(ImageUpload("MAIN", imageFile)),
-                    emptyList(),
-                )
-            }
-        }
-
-        @Test
-        fun `不正な精製方法の場合は例外が発生する`() {
-            assertThrows<IllegalArgumentException> {
-                usecase.execute(
-                    existingBean.id.value,
-                    createRequest(processingMethod = "INVALID"),
                     listOf(ImageUpload("MAIN", imageFile)),
                     emptyList(),
                 )

--- a/backend/admin-api/src/test/kotlin/com/mametosho/admin/presentation/controller/CoffeeBeanControllerTest.kt
+++ b/backend/admin-api/src/test/kotlin/com/mametosho/admin/presentation/controller/CoffeeBeanControllerTest.kt
@@ -3,6 +3,7 @@ package com.mametosho.admin.presentation.controller
 import com.mametosho.admin.presentation.dto.request.CreateCoffeeBeanRequest
 import com.mametosho.admin.presentation.dto.request.UpdateCoffeeBeanRequest
 import com.mametosho.admin.test.FakeImageStorageConfig
+import com.mametosho.domain.model.coffeebean.ProcessingMethod
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.springframework.beans.factory.annotation.Autowired
@@ -113,7 +114,7 @@ class CoffeeBeanControllerTest {
         origin = "エチオピア",
         farm = "テスト農園",
         roastLevel = "MEDIUM",
-        processingMethod = "WASHED",
+        processingMethod = ProcessingMethod.WASHED,
         isSpecialty = true,
         publishStatus = "PUBLISHED",
         tastes = listOf(CreateCoffeeBeanRequest.TasteRequest(tasteId = tasteId, evaluationValue = 4)),
@@ -132,13 +133,27 @@ class CoffeeBeanControllerTest {
         origin = "ブラジル",
         farm = "更新農園",
         roastLevel = "FRENCH",
-        processingMethod = "NATURAL",
+        processingMethod = ProcessingMethod.NATURAL,
         isSpecialty = true,
         publishStatus = "PUBLISHED",
         tastes = listOf(UpdateCoffeeBeanRequest.TasteRequest(tasteId = tasteId, evaluationValue = 3)),
         imageTypes = imageTypes,
         keepImageIds = keepImageIds,
     )
+
+    @Nested
+    inner class 精製方法一覧取得 {
+        @Test
+        fun `正常に精製方法一覧を取得すると200が返る`() {
+            val response = coffeeBeanController.listProcessingMethods()
+
+            assertEquals(HttpStatus.OK, response.statusCode)
+            val body = response.body
+            assertEquals(ProcessingMethod.entries.size, body?.size)
+            assertEquals(ProcessingMethod.FULLY_WASHED, body?.first()?.value)
+            assertEquals("フリーウォッシュド", body?.first()?.label)
+        }
+    }
 
     @Nested
     inner class コーヒー豆一覧取得 {

--- a/backend/admin-api/src/test/kotlin/com/mametosho/admin/presentation/dto/response/CoffeeBeanDetailResponseTest.kt
+++ b/backend/admin-api/src/test/kotlin/com/mametosho/admin/presentation/dto/response/CoffeeBeanDetailResponseTest.kt
@@ -1,6 +1,7 @@
 package com.mametosho.admin.presentation.dto.response
 
 import com.mametosho.admin.application.query.result.CoffeeBeanDetailResult
+import com.mametosho.domain.model.coffeebean.ProcessingMethod
 import org.junit.jupiter.api.Nested
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -55,7 +56,8 @@ class CoffeeBeanDetailResponseTest {
             assertEquals("エチオピア", response.origin)
             assertEquals("テスト農園", response.farm)
             assertEquals("MEDIUM", response.roastLevel)
-            assertEquals("WASHED", response.processingMethod)
+            assertEquals(ProcessingMethod.WASHED, response.processingMethod)
+            assertEquals("ウォッシュド", response.processingMethodName)
             assertEquals(true, response.isSpecialty)
             assertEquals("PUBLISHED", response.publishStatus)
             assertEquals(1, response.images.size)

--- a/backend/common/src/main/kotlin/com/mametosho/domain/model/coffeebean/ProcessingMethod.kt
+++ b/backend/common/src/main/kotlin/com/mametosho/domain/model/coffeebean/ProcessingMethod.kt
@@ -1,13 +1,23 @@
 package com.mametosho.domain.model.coffeebean
 
-/** コーヒー豆の精製方法。 */
-enum class ProcessingMethod {
-    FULLY_WASHED,
-    WASHED,
-    THERMAL_SHOCK_NATURAL,
-    NATURAL,
-    ANAEROBIC_NATURAL,
-    DRY_ON_TREE_NATURAL,
-    WET_HULLING,
-    HONEY,
+/**
+ * コーヒー豆の精製方法。
+ *
+ * @property label 日本語表示名（正本: docs/ubiquitousLanguage.md）
+ */
+enum class ProcessingMethod(val label: String) {
+    FULLY_WASHED("フリーウォッシュド"),
+    WASHED("ウォッシュド"),
+    ANAEROBIC_WASHED("アナエロビックウォッシュド"),
+    THERMAL_SHOCK_NATURAL("サーマルショックナチュラル"),
+    NATURAL("ナチュラル"),
+    ANAEROBIC_NATURAL("アナエロビックナチュラル"),
+    DRY_ON_TREE_NATURAL("ドライオンツリーナチュラル"),
+    LACTIC_NATURAL("ラクティックナチュラル"),
+    WET_HULLING("スマトラ式"),
+    HONEY("ハニー"),
+    LADO_A_LADO_PROCESS("ラドラドプロセス"),
+
+    /** ブレンドコーヒーの精製方法を表すための一時的な複合種別。 */
+    LADO_A_LADO_PROCESS_FULLY_WASHED("ラドラドプロセス/フリーウォッシュド"),
 }

--- a/backend/common/src/test/kotlin/com/mametosho/infrastructure/persistence/repository/CoffeeBeanRepositoryImplTest.kt
+++ b/backend/common/src/test/kotlin/com/mametosho/infrastructure/persistence/repository/CoffeeBeanRepositoryImplTest.kt
@@ -301,7 +301,7 @@ class CoffeeBeanRepositoryImplTest {
         fun `全精製方法を大文字で保存できる`() {
             ProcessingMethod.entries.forEachIndexed { index, method ->
                 val coffeeBean = CoffeeBean(
-                    id = CoffeeBeanId("00000000-0000-4000-8000-00000000200$index"),
+                    id = CoffeeBeanId("00000000-0000-4000-8000-0000000020%02d".format(index)),
                     shopId = ShopId("00000000-0000-4000-8000-000000000001"),
                     shopifyBeanId = ShopifyBeanId("test-bean-proc-$index"),
                     name = "テスト豆",

--- a/backend/cs-api/src/main/kotlin/com/mametosho/cs/presentation/dto/response/CoffeeBeanResponse.kt
+++ b/backend/cs-api/src/main/kotlin/com/mametosho/cs/presentation/dto/response/CoffeeBeanResponse.kt
@@ -2,6 +2,7 @@ package com.mametosho.cs.presentation.dto.response
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.mametosho.cs.application.query.result.CoffeeBeanSummaryResult
+import com.mametosho.domain.model.coffeebean.ProcessingMethod
 import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "珈琲豆一覧アイテム")
@@ -21,7 +22,9 @@ data class CoffeeBeanResponse(
     @Schema(description = "焙煎度", example = "LIGHT", requiredMode = Schema.RequiredMode.REQUIRED)
     val roastLevel: String,
     @Schema(description = "精製方法", example = "WASHED", requiredMode = Schema.RequiredMode.REQUIRED)
-    val processingMethod: String,
+    val processingMethod: ProcessingMethod,
+    @Schema(description = "精製方法の表示名", example = "ウォッシュド", requiredMode = Schema.RequiredMode.REQUIRED)
+    val processingMethodName: String,
     @get:Schema(description = "スペシャルティ珈琲かどうか", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
     @get:JsonProperty("isSpecialty")
     val isSpecialty: Boolean,
@@ -47,22 +50,26 @@ data class CoffeeBeanResponse(
     )
 
     companion object {
-        fun from(result: CoffeeBeanSummaryResult): CoffeeBeanResponse = CoffeeBeanResponse(
-            id = result.id,
-            shopifyBeanId = result.shopifyBeanId,
-            name = result.name,
-            origin = result.origin,
-            roastLevel = result.roastLevel,
-            processingMethod = result.processingMethod,
-            isSpecialty = result.isSpecialty,
-            description = result.description,
-            imageUrl = result.imageUrl,
-            shopName = result.shopName,
-            shopPrefecture = result.shopPrefecture,
-            shopUrl = result.shopUrl,
-            tasteProfiles = result.tasteProfiles.map { taste ->
-                TasteProfileResponse(name = taste.name, value = taste.value)
-            },
-        )
+        fun from(result: CoffeeBeanSummaryResult): CoffeeBeanResponse {
+            val processingMethod = ProcessingMethod.valueOf(result.processingMethod)
+            return CoffeeBeanResponse(
+                id = result.id,
+                shopifyBeanId = result.shopifyBeanId,
+                name = result.name,
+                origin = result.origin,
+                roastLevel = result.roastLevel,
+                processingMethod = processingMethod,
+                processingMethodName = processingMethod.label,
+                isSpecialty = result.isSpecialty,
+                description = result.description,
+                imageUrl = result.imageUrl,
+                shopName = result.shopName,
+                shopPrefecture = result.shopPrefecture,
+                shopUrl = result.shopUrl,
+                tasteProfiles = result.tasteProfiles.map { taste ->
+                    TasteProfileResponse(name = taste.name, value = taste.value)
+                },
+            )
+        }
     }
 }

--- a/backend/cs-api/src/test/kotlin/com/mametosho/cs/presentation/controller/CoffeeBeanControllerTest.kt
+++ b/backend/cs-api/src/test/kotlin/com/mametosho/cs/presentation/controller/CoffeeBeanControllerTest.kt
@@ -12,6 +12,7 @@ import org.springframework.test.context.DynamicPropertySource
 import org.testcontainers.containers.MySQLContainer
 import org.testcontainers.junit.jupiter.Container
 import org.testcontainers.junit.jupiter.Testcontainers
+import com.mametosho.domain.model.coffeebean.ProcessingMethod
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -126,7 +127,7 @@ class CoffeeBeanControllerTest {
             assertEquals("エチオピア イルガチェフェ G1", item?.name)
             assertEquals("エチオピア", item?.origin)
             assertEquals("LIGHT", item?.roastLevel)
-            assertEquals("WASHED", item?.processingMethod)
+            assertEquals(ProcessingMethod.WASHED, item?.processingMethod)
             assertEquals(true, item?.isSpecialty)
         }
 

--- a/backend/cs-api/src/test/kotlin/com/mametosho/cs/presentation/dto/response/CoffeeBeanResponseTest.kt
+++ b/backend/cs-api/src/test/kotlin/com/mametosho/cs/presentation/dto/response/CoffeeBeanResponseTest.kt
@@ -1,6 +1,7 @@
 package com.mametosho.cs.presentation.dto.response
 
 import com.mametosho.cs.application.query.result.CoffeeBeanSummaryResult
+import com.mametosho.domain.model.coffeebean.ProcessingMethod
 import org.junit.jupiter.api.Nested
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -38,7 +39,8 @@ class CoffeeBeanResponseTest {
             assertEquals("テストコーヒー豆", response.name)
             assertEquals("エチオピア", response.origin)
             assertEquals("LIGHT", response.roastLevel)
-            assertEquals("WASHED", response.processingMethod)
+            assertEquals(ProcessingMethod.WASHED, response.processingMethod)
+            assertEquals("ウォッシュド", response.processingMethodName)
             assertEquals(true, response.isSpecialty)
             assertEquals("テスト用の説明文です。", response.description)
             assertEquals("https://example.com/images/test.jpg", response.imageUrl)

--- a/backend/docs/domainModel.md
+++ b/backend/docs/domainModel.md
@@ -224,12 +224,16 @@ classDiagram
       <<Enum>>
       fully_washed
       washed
+      anaerobic_washed
       thermal_shock_natural
       natural
       anaerobic_natural
       dry_on_tree_natural
+      lactic_natural
       wet_hulling
       honey
+      lado_a_lado_process
+      lado_a_lado_process_fully_washed
     }
 
     class PublishStatus {

--- a/backend/docs/domains/coffeeBean.md
+++ b/backend/docs/domains/coffeeBean.md
@@ -26,7 +26,7 @@ Shopifyの商品と1対1で紐づく。産地、焙煎度、精製方法、テ�
 | origin | String | 産地 |
 | farm | String? | 農園 |
 | roastLevel | RoastLevel | 焙煎度（light / cinnamon / medium / city / french） |
-| processingMethod | ProcessingMethod | 精製方法（fully_washed / washed / thermal_shock_natural / natural / anaerobic_natural / dry_on_tree_natural / wet_hulling / honey） |
+| processingMethod | ProcessingMethod | 精製方法（fully_washed / washed / anaerobic_washed / thermal_shock_natural / natural / anaerobic_natural / dry_on_tree_natural / lactic_natural / wet_hulling / honey / lado_a_lado_process / lado_a_lado_process_fully_washed（ブレンドコーヒー向けの一時的な複合種別）） |
 | isSpecialty | Boolean | スペシャルティコーヒーかどうか |
 | publishStatus | PublishStatus | 公開状態（DRAFT / PUBLISHED / INVALIDATED） |
 | images | List\<CoffeeBeanImage\> | 珈琲豆画像一覧 |

--- a/docs/swagger/admin-api.yml
+++ b/docs/swagger/admin-api.yml
@@ -872,6 +872,31 @@ paths:
                     totalCount: 1
                     page: 0
                     size: 20
+  /api/admin/coffee-beans/processing-methods:
+    get:
+      tags:
+      - CoffeeBean
+      summary: 精製方法一覧取得
+      description: コーヒー豆の精製方法の選択肢一覧（値と表示名）を取得します。
+      operationId: listProcessingMethods
+      responses:
+        "200":
+          description: 取得成功
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ProcessingMethodResponse"
+              examples:
+                success:
+                  summary: 取得成功例
+                  description: success
+                  value:
+                  - value: FULLY_WASHED
+                    label: フリーウォッシュド
+                  - value: WASHED
+                    label: ウォッシュド
 components:
   schemas:
     UpdateShopRequest:
@@ -1070,6 +1095,19 @@ components:
         processingMethod:
           type: string
           description: 精製方法
+          enum:
+          - FULLY_WASHED
+          - WASHED
+          - ANAEROBIC_WASHED
+          - THERMAL_SHOCK_NATURAL
+          - NATURAL
+          - ANAEROBIC_NATURAL
+          - DRY_ON_TREE_NATURAL
+          - LACTIC_NATURAL
+          - WET_HULLING
+          - HONEY
+          - LADO_A_LADO_PROCESS
+          - LADO_A_LADO_PROCESS_FULLY_WASHED
           example: WASHED
         publishStatus:
           type: string
@@ -1197,6 +1235,19 @@ components:
         processingMethod:
           type: string
           description: 精製方法
+          enum:
+          - FULLY_WASHED
+          - WASHED
+          - ANAEROBIC_WASHED
+          - THERMAL_SHOCK_NATURAL
+          - NATURAL
+          - ANAEROBIC_NATURAL
+          - DRY_ON_TREE_NATURAL
+          - LACTIC_NATURAL
+          - WET_HULLING
+          - HONEY
+          - LADO_A_LADO_PROCESS
+          - LADO_A_LADO_PROCESS_FULLY_WASHED
           example: WASHED
         publishStatus:
           type: string
@@ -1613,7 +1664,24 @@ components:
         processingMethod:
           type: string
           description: 精製方法
+          enum:
+          - FULLY_WASHED
+          - WASHED
+          - ANAEROBIC_WASHED
+          - THERMAL_SHOCK_NATURAL
+          - NATURAL
+          - ANAEROBIC_NATURAL
+          - DRY_ON_TREE_NATURAL
+          - LACTIC_NATURAL
+          - WET_HULLING
+          - HONEY
+          - LADO_A_LADO_PROCESS
+          - LADO_A_LADO_PROCESS_FULLY_WASHED
           example: WASHED
+        processingMethodName:
+          type: string
+          description: 精製方法の表示名
+          example: ウォッシュド
         publishStatus:
           type: string
           description: "公開状態（DRAFT: 下書き / PUBLISHED: 公開）"
@@ -1629,6 +1697,7 @@ components:
       - name
       - origin
       - processingMethod
+      - processingMethodName
       - publishStatus
       - roastLevel
       - shopId
@@ -1672,7 +1741,24 @@ components:
         processingMethod:
           type: string
           description: 精製方法
+          enum:
+          - FULLY_WASHED
+          - WASHED
+          - ANAEROBIC_WASHED
+          - THERMAL_SHOCK_NATURAL
+          - NATURAL
+          - ANAEROBIC_NATURAL
+          - DRY_ON_TREE_NATURAL
+          - LACTIC_NATURAL
+          - WET_HULLING
+          - HONEY
+          - LADO_A_LADO_PROCESS
+          - LADO_A_LADO_PROCESS_FULLY_WASHED
           example: WASHED
+        processingMethodName:
+          type: string
+          description: 精製方法の表示名
+          example: ウォッシュド
         publishStatus:
           type: string
           description: "公開状態（DRAFT: 下書き / PUBLISHED: 公開）"
@@ -1699,6 +1785,7 @@ components:
       - name
       - origin
       - processingMethod
+      - processingMethodName
       - publishStatus
       - roastLevel
       - shopId
@@ -1730,6 +1817,34 @@ components:
       - id
       - tasteId
       - tasteName
+    ProcessingMethodResponse:
+      type: object
+      description: 精製方法
+      properties:
+        value:
+          type: string
+          description: 精製方法の値
+          enum:
+          - FULLY_WASHED
+          - WASHED
+          - ANAEROBIC_WASHED
+          - THERMAL_SHOCK_NATURAL
+          - NATURAL
+          - ANAEROBIC_NATURAL
+          - DRY_ON_TREE_NATURAL
+          - LACTIC_NATURAL
+          - WET_HULLING
+          - HONEY
+          - LADO_A_LADO_PROCESS
+          - LADO_A_LADO_PROCESS_FULLY_WASHED
+          example: WASHED
+        label:
+          type: string
+          description: 精製方法の表示名
+          example: ウォッシュド
+      required:
+      - label
+      - value
   securitySchemes:
     Bearer:
       type: http

--- a/docs/swagger/cs-api.yml
+++ b/docs/swagger/cs-api.yml
@@ -8,6 +8,10 @@ info:
 servers:
 - url: /
   description: Current Server
+security:
+- X-Client-Id: []
+  X-Timestamp: []
+  X-Signature: []
 tags:
 - name: Plan
   description: プランAPI
@@ -536,7 +540,24 @@ components:
         processingMethod:
           type: string
           description: 精製方法
+          enum:
+          - FULLY_WASHED
+          - WASHED
+          - ANAEROBIC_WASHED
+          - THERMAL_SHOCK_NATURAL
+          - NATURAL
+          - ANAEROBIC_NATURAL
+          - DRY_ON_TREE_NATURAL
+          - LACTIC_NATURAL
+          - WET_HULLING
+          - HONEY
+          - LADO_A_LADO_PROCESS
+          - LADO_A_LADO_PROCESS_FULLY_WASHED
           example: WASHED
+        processingMethodName:
+          type: string
+          description: 精製方法の表示名
+          example: ウォッシュド
         description:
           type: string
           description: 説明文
@@ -574,6 +595,7 @@ components:
       - name
       - origin
       - processingMethod
+      - processingMethodName
       - roastLevel
       - shopName
       - shopPrefecture
@@ -596,3 +618,19 @@ components:
       required:
       - name
       - value
+  securitySchemes:
+    X-Client-Id:
+      type: apiKey
+      description: クライアント識別子
+      name: X-Client-Id
+      in: header
+    X-Timestamp:
+      type: apiKey
+      description: UNIXエポック秒
+      name: X-Timestamp
+      in: header
+    X-Signature:
+      type: apiKey
+      description: HMAC-SHA256署名(hex)
+      name: X-Signature
+      in: header

--- a/docs/ubiquitousLanguage.md
+++ b/docs/ubiquitousLanguage.md
@@ -33,12 +33,16 @@
 | 精製方法 | processing method | 珈琲豆の精製方法 | |
 | フリーウォッシュド | fully washed | 精製方法。水洗式の完全版 | FW |
 | ウォッシュド | washed | 精製方法。水洗式 | W |
+| アナエロビックウォッシュド | anaerobic washed | 精製方法。嫌気性発酵を行ったウォッシュド | |
 | サーマルショックナチュラル | thermal shock natural | 精製方法。熱衝撃を与えたナチュラル | TSN |
 | ナチュラル | natural | 精製方法。自然乾燥式 | N |
 | アナエロビックナチュラル | anaerobic natural | 精製方法。嫌気性発酵を行ったナチュラル | |
 | ドライオンツリーナチュラル | dry on tree natural | 精製方法。果実を樹上で乾燥させるナチュラル | |
+| ラクティックナチュラル | lactic natural | 精製方法。乳酸発酵を行ったナチュラル | |
 | スマトラ式 | wet hulling | 精製方法。半水洗式 | |
 | ハニー | honey | 精製方法。半水洗式の一種 | |
+| ラドラドプロセス | lado a lado process | 精製方法。特殊精製の一種 | |
+| ラドラドプロセス/フリーウォッシュド | lado a lado process / fully washed | 精製方法。ブレンドコーヒーの精製方法を表すための一時的な複合種別 | |
 
 ---
 

--- a/frontend/src/api/generated/cs-api.ts
+++ b/frontend/src/api/generated/cs-api.ts
@@ -24,6 +24,26 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/api/shops/{shopId}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * 店舗詳細取得
+     * @description 指定されたIDの店舗の詳細情報を取得します。参画中の店舗のみ取得できます。
+     */
+    get: operations["getShop"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   "/api/plans": {
     parameters: {
       query?: never;
@@ -124,6 +144,59 @@ export interface components {
        */
       logoImageUrl: string;
     };
+    /** @description 画像詳細 */
+    ImageDetail: {
+      /**
+       * @description 画像ID
+       * @example 00000000-0000-4000-8000-000000000010
+       */
+      id: string;
+      /**
+       * @description 画像種別（LOGO: ロゴ / MAIN: メイン）
+       * @example LOGO
+       */
+      type: string;
+      /**
+       * @description 画像URL
+       * @example https://placehold.jp/100x100.png
+       */
+      imageUrl: string;
+    };
+    /** @description 店舗詳細レスポンス */
+    ShopDetailResponse: {
+      /**
+       * @description 店舗ID
+       * @example 00000000-0000-4000-8000-000000000031
+       */
+      id: string;
+      /**
+       * @description 店舗名
+       * @example 珈琲工房 まめとしょ
+       */
+      name: string;
+      /**
+       * @description 店舗紹介文
+       * @example 東京都渋谷区にある自家焙煎珈琲店。厳選されたスペシャルティコーヒーをお届けします。
+       */
+      introduction: string;
+      /**
+       * @description こだわり
+       * @example 厳選された豆のみを使用しています。
+       */
+      particular: string;
+      /**
+       * @description 店舗URL
+       * @example https://mametosho.example.com
+       */
+      shopUrl: string;
+      /**
+       * @description 都道府県
+       * @example TOKYO
+       */
+      prefecture: string;
+      /** @description 画像一覧 */
+      images: components["schemas"]["ImageDetail"][];
+    };
     /** @description プラン一覧アイテム */
     PlanResponse: {
       /**
@@ -223,8 +296,26 @@ export interface components {
       /**
        * @description 精製方法
        * @example WASHED
+       * @enum {string}
        */
-      processingMethod: string;
+      processingMethod:
+        | "FULLY_WASHED"
+        | "WASHED"
+        | "ANAEROBIC_WASHED"
+        | "THERMAL_SHOCK_NATURAL"
+        | "NATURAL"
+        | "ANAEROBIC_NATURAL"
+        | "DRY_ON_TREE_NATURAL"
+        | "LACTIC_NATURAL"
+        | "WET_HULLING"
+        | "HONEY"
+        | "LADO_A_LADO_PROCESS"
+        | "LADO_A_LADO_PROCESS_FULLY_WASHED";
+      /**
+       * @description 精製方法の表示名
+       * @example ウォッシュド
+       */
+      processingMethodName: string;
       /**
        * @description 説明文
        * @example フルーティーな香りと明るい酸味が特徴の豆です。
@@ -308,6 +399,50 @@ export interface operations {
         };
         content: {
           "application/json": components["schemas"]["ShopListResponse"];
+        };
+      };
+    };
+  };
+  getShop: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /**
+         * @description 店舗ID
+         * @example 00000000-0000-4000-8000-000000000031
+         */
+        shopId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description 取得成功 */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["ShopDetailResponse"];
+        };
+      };
+      /** @description 店舗IDの形式が不正 */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": unknown;
+        };
+      };
+      /** @description 店舗が見つかりません（存在しない、または参画中でない） */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "*/*": unknown;
         };
       };
     };

--- a/frontend/src/app/lp/_lib/coffeeBeanApi.ts
+++ b/frontend/src/app/lp/_lib/coffeeBeanApi.ts
@@ -95,17 +95,6 @@ const ROAST_TAG_COLOR: Record<string, string> = {
   FRENCH: "#321E14",
 };
 
-const PROCESSING_METHOD_JP: Record<string, string> = {
-  FULLY_WASHED: "フリーウォッシュド",
-  WASHED: "ウォッシュド",
-  THERMAL_SHOCK_NATURAL: "サーマルショック・ナチュラル",
-  NATURAL: "ナチュラル",
-  ANAEROBIC_NATURAL: "アナエロビックナチュラル",
-  DRY_ON_TREE_NATURAL: "ドライオンツリーナチュラル",
-  WET_HULLING: "スマトラ式",
-  HONEY: "ハニー",
-};
-
 function toBeanDetail(item: CoffeeBeanApiItem): BeanDetail {
   const roastJP = ROAST_LEVEL_JP[item.roastLevel] ?? item.roastLevel;
   const tagColor = ROAST_TAG_COLOR[item.roastLevel] ?? "#A6683D";
@@ -123,8 +112,7 @@ function toBeanDetail(item: CoffeeBeanApiItem): BeanDetail {
     origin: item.origin,
     farm: "",
     roastLevel: roastJP,
-    processing:
-      PROCESSING_METHOD_JP[item.processingMethod] ?? item.processingMethod,
+    processing: item.processingMethodName,
     roaster: item.shopName,
     roasterLink: item.shopUrl,
     prefecture: PREFECTURE_JP[item.shopPrefecture] ?? item.shopPrefecture,

--- a/infrastructure/db/schema.sql
+++ b/infrastructure/db/schema.sql
@@ -70,7 +70,7 @@ CREATE TABLE IF NOT EXISTS coffee_beans (
     origin            VARCHAR(255)  NOT NULL                                   COMMENT '産地',
     farm              VARCHAR(255)                                             COMMENT '農園',
     roast_level       ENUM('LIGHT', 'CINNAMON', 'MEDIUM', 'CITY', 'FRENCH') NOT NULL COMMENT '焙煎度',
-    processing_method ENUM('FULLY_WASHED', 'WASHED', 'THERMAL_SHOCK_NATURAL', 'NATURAL', 'ANAEROBIC_NATURAL', 'DRY_ON_TREE_NATURAL', 'WET_HULLING', 'HONEY') NOT NULL COMMENT '精製方法',
+    processing_method ENUM('FULLY_WASHED', 'WASHED', 'ANAEROBIC_WASHED', 'THERMAL_SHOCK_NATURAL', 'NATURAL', 'ANAEROBIC_NATURAL', 'DRY_ON_TREE_NATURAL', 'LACTIC_NATURAL', 'WET_HULLING', 'HONEY', 'LADO_A_LADO_PROCESS', 'LADO_A_LADO_PROCESS_FULLY_WASHED') NOT NULL COMMENT '精製方法（LADO_A_LADO_PROCESS_FULLY_WASHEDはブレンドコーヒー向けの一時的な複合種別）',
     is_specialty      BOOLEAN       NOT NULL DEFAULT FALSE                     COMMENT 'スペシャルティコーヒーかどうか',
     publish_status    ENUM('DRAFT', 'PUBLISHED', 'INVALIDATED') NOT NULL DEFAULT 'DRAFT' COMMENT '公開状態',
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP                             COMMENT '作成日時',


### PR DESCRIPTION
## 概要

精製方法(ProcessingMethod)に4種を追加し、あわせて精製方法まわりの二重管理を解消しました。

### 精製方法の追加

| 日本語名 | enum値 |
|---|---|
| アナエロビックウォッシュド | `ANAEROBIC_WASHED` |
| ラクティックナチュラル | `LACTIC_NATURAL` |
| ラドラドプロセス | `LADO_A_LADO_PROCESS` |
| ラドラドプロセス/フリーウォッシュド | `LADO_A_LADO_PROCESS_FULLY_WASHED` ※ |

※ブレンドコーヒーの精製方法を表すための**一時的な複合種別**(enum定義・DDLにコメント明記済み)

また「サーマルショック・ナチュラル」の表記を正本(ubiquitousLanguage.md)に合わせ「サーマルショックナチュラル」に修正しました。

### 表示名のbackend正本化

これまでfrontend(LP)とadmin-frontendに同一内容の日本語ラベル表がコピペ二重管理されており、実際に表記ドリフトが発生していたため、backendを正本に一本化しました。

- `ProcessingMethod` enumに表示名(`label`)を追加
- CS/Admin両APIのレスポンスに `processingMethodName`(表示名)を追加し、フロントは表示するだけに変更
- Admin APIに選択肢一覧 `GET /api/admin/coffee-beans/processing-methods` を新設。管理画面フォームのプルダウンはAPI取得に変更し、両フロントの手書きラベル表を削除

### DTOのenum型化

リクエスト/レスポンスDTOの `processingMethod` を `String` → `ProcessingMethod` 型に変更。Swaggerにenumが出力され、生成TSクライアントがunion型を持つため、今後の値追加漏れが型で検出できます。不正値はデシリアライズ時に400となるため、usecase層の不正値テストは削除しました。

### その他

- 既存テストの潜在バグ修正: 全精製方法保存テストがenum11個目以降でUUIDが36文字を超えて壊れる問題を修正
- Swagger YML・生成TSクライアントは再生成済み

## 注意事項

- **既存環境(dev/prod)のDBには `coffee_beans.processing_method` ENUMへの手動ALTERが別途必要です**(#161と同様)
- `roastLevel` にも同じラベル二重管理構造が残っています。同じパターンで横展開可能です(別タスク)

## テスト

- backend: `./gradlew build`(全テスト+detekt)成功
- admin-frontend / frontend: `pnpm lint` / `pnpm build`(型チェック含む)成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)