### PR TITLE
fix: LPの豆表示タイトルを産地からコーヒー名に修正

### DIFF
--- a/frontend/src/app/lp/_components/BeanCard/beanCard.module.css
+++ b/frontend/src/app/lp/_components/BeanCard/beanCard.module.css
@@ -132,12 +132,6 @@
   font-weight: 500;
 }
 
-.region {
-  font-size: 11px;
-  color: var(--mt-ink-3);
-  margin-left: 6px;
-}
-
 .desc {
   margin-top: 4px;
   font-size: 11px;

--- a/frontend/src/app/lp/_components/BeanCard/beanCard.tsx
+++ b/frontend/src/app/lp/_components/BeanCard/beanCard.tsx
@@ -19,7 +19,6 @@ interface BeanCardProps {
   imageSrc: string;
   tag: string;
   name: string;
-  region: string;
   description: string;
   roaster: string;
   isSpecialty?: boolean;
@@ -30,7 +29,6 @@ export default function BeanCard({
   imageSrc,
   tag,
   name,
-  region,
   description,
   roaster,
   isSpecialty,
@@ -71,10 +69,7 @@ export default function BeanCard({
               {tag}
             </span>
           </div>
-          <h3 className={styles.name}>
-            {name}
-            <span className={styles.region}>{region}</span>
-          </h3>
+          <h3 className={styles.name}>{name}</h3>
           <p className={styles.desc}>{description}</p>
           <div className={styles.footer}>
             <span>

--- a/frontend/src/app/lp/_components/BeanDetailModal/beanDetailModal.module.css
+++ b/frontend/src/app/lp/_components/BeanDetailModal/beanDetailModal.module.css
@@ -114,14 +114,6 @@
   padding: 4px 10px;
 }
 
-.subtitle {
-  font-size: 14px;
-  font-weight: 600;
-  color: var(--color-text);
-  margin: 0;
-  margin-top: -8px;
-}
-
 .desc {
   font-size: 13px;
   color: var(--color-text-secondary);

--- a/frontend/src/app/lp/_components/BeanDetailModal/beanDetailModal.tsx
+++ b/frontend/src/app/lp/_components/BeanDetailModal/beanDetailModal.tsx
@@ -80,8 +80,6 @@ export default function BeanDetailModal({
             </span>
           </div>
 
-          {bean.subName && <p className={styles.subtitle}>{bean.subName}</p>}
-
           <p className={styles.desc}>{bean.detailDescription}</p>
 
           <div className={styles.separator} />

--- a/frontend/src/app/lp/_components/BeanShowcase/beanShowcase.tsx
+++ b/frontend/src/app/lp/_components/BeanShowcase/beanShowcase.tsx
@@ -41,12 +41,12 @@ export default function BeanShowcase({ beans, plans }: BeanShowcaseProps) {
         ),
     ),
   );
-  const countries = Array.from(new Set(beans.map((b) => b.name)));
+  const countries = Array.from(new Set(beans.map((b) => b.origin)));
   const roastLevels = Array.from(new Set(beans.map((b) => b.tag)));
 
   const filtered = beans.filter((b) => {
     if (prefFilter && b.prefecture !== prefFilter) return false;
-    if (countryFilter && b.name !== countryFilter) return false;
+    if (countryFilter && b.origin !== countryFilter) return false;
     if (roastFilter && b.tag !== roastFilter) return false;
     return true;
   });
@@ -189,7 +189,6 @@ export default function BeanShowcase({ beans, plans }: BeanShowcaseProps) {
               imageSrc={b.imageSrc}
               tag={b.tag}
               name={b.name}
-              region={b.region}
               description={b.description}
               roaster={b.roaster}
               isSpecialty={b.isSpecialty}

--- a/frontend/src/app/lp/_lib/coffeeBeanApi.ts
+++ b/frontend/src/app/lp/_lib/coffeeBeanApi.ts
@@ -11,8 +11,6 @@ export interface BeanDetail {
   tag: string;
   tagColor: string;
   name: string;
-  subName: string;
-  region: string;
   description: string;
   detailDescription: string;
   origin: string;
@@ -104,9 +102,7 @@ function toBeanDetail(item: CoffeeBeanApiItem): BeanDetail {
     imageSrc: item.imageUrl,
     tag: roastJP,
     tagColor,
-    name: item.origin,
-    subName: item.name,
-    region: item.name,
+    name: item.name,
     description: item.description,
     detailDescription: item.description,
     origin: item.origin,

--- a/frontend/src/app/lp/catalog/CatalogClient.tsx
+++ b/frontend/src/app/lp/catalog/CatalogClient.tsx
@@ -50,7 +50,7 @@ function CatalogContent({
   const prefectures = Array.from(
     new Set(beans.map((b) => b.prefecture).filter((p): p is string => !!p)),
   );
-  const countries = Array.from(new Set(beans.map((b) => b.name)));
+  const countries = Array.from(new Set(beans.map((b) => b.origin)));
   const roastLevels = Array.from(new Set(beans.map((b) => b.tag)));
 
   const router = useRouter();
@@ -97,7 +97,7 @@ function CatalogContent({
 
   const filtered = beans.filter((b) => {
     if (prefFilter && b.prefecture !== prefFilter) return false;
-    if (countryFilter && b.name !== countryFilter) return false;
+    if (countryFilter && b.origin !== countryFilter) return false;
     if (roastFilter && b.tag !== roastFilter) return false;
     return true;
   });
@@ -622,10 +622,7 @@ function LibraryCard({
               {bean.tag}
             </span>
           </div>
-          <h3 className={styles.libCardName}>
-            {bean.name}
-            <span className={styles.libCardRegion}>{bean.region}</span>
-          </h3>
+          <h3 className={styles.libCardName}>{bean.name}</h3>
           <p className={styles.libCardDesc}>{bean.description}</p>
           <div className={styles.libCardFooter}>
             <span className={styles.libCardRoaster}>

--- a/frontend/src/app/lp/catalog/catalog.module.css
+++ b/frontend/src/app/lp/catalog/catalog.module.css
@@ -725,12 +725,6 @@
   font-weight: 500;
 }
 
-.libCardRegion {
-  font-size: 11px;
-  color: var(--mt-ink-3);
-  margin-left: 6px;
-}
-
 .libCardDesc {
   margin-top: 4px;
   font-size: 11px;


### PR DESCRIPTION
## 概要
LP(CS Frontend)の豆詳細モーダル・豆カードで、タイトルにコーヒー名ではなく産地が表示されていた問題を修正しました。

## 原因
`coffeeBeanApi.ts` のAPIレスポンス→表示用モデルのマッピングで、タイトル用の `name` フィールドに産地(`item.origin`)、サブタイトル用の `subName` と `region` にコーヒー名(`item.name`)が入れ違いに詰められていました。

## 変更内容
- `coffeeBeanApi.ts`: `name` にコーヒー名(`item.name`)を割り当て。不要になった `subName` / `region` フィールドを削除
- 豆詳細モーダル: タイトルがコーヒー名になり、サブタイトル行を削除(産地は情報欄に引き続き表示)
- 豆カード(トップのショーケース / カタログ): タイトルがコーヒー名になり、タイトル横の産地小ラベルを削除
- 産地フィルタ: 参照先を `b.name` から `b.origin` に変更(値は同じため挙動は従来どおり)

## 確認
- `pnpm lint` (biome check) パス
- `tsc --noEmit` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)