### PR TITLE
fix: 管理画面のServer Actionボディ上限を10MBに引き上げ・エラーバウンダリを追加

### DIFF
--- a/admin-frontend/next.config.ts
+++ b/admin-frontend/next.config.ts
@@ -7,6 +7,10 @@ const nextConfig: NextConfig = {
     staleTimes: {
       dynamic: 0,
     },
+    serverActions: {
+      // 画像アップロードを含むFormData送信がデフォルト上限(1MB)を超えるため引き上げる
+      bodySizeLimit: "10mb",
+    },
   },
   images: {
     remotePatterns: [

--- a/admin-frontend/src/app/error.module.css
+++ b/admin-frontend/src/app/error.module.css
@@ -1,0 +1,37 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  gap: 16px;
+  padding: 24px;
+  background: var(--color-bg-page);
+}
+
+.title {
+  font-size: 20px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.description {
+  font-size: 14px;
+  color: var(--color-text-secondary);
+  text-align: center;
+}
+
+.retryButton {
+  padding: 10px 24px;
+  font-size: 14px;
+  font-weight: 600;
+  color: #ffffff;
+  background: var(--color-brand);
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.retryButton:hover {
+  background: var(--color-brand-hover);
+}

--- a/admin-frontend/src/app/error.tsx
+++ b/admin-frontend/src/app/error.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import styles from "@/app/error.module.css";
+
+export default function ErrorPage({
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className={styles.container}>
+      <h1 className={styles.title}>エラーが発生しました</h1>
+      <p className={styles.description}>
+        問題が解決しない場合は、ページを再読み込みしてください。
+      </p>
+      <button type="button" className={styles.retryButton} onClick={reset}>
+        再試行
+      </button>
+    </div>
+  );
+}

--- a/admin-frontend/src/app/global-error.tsx
+++ b/admin-frontend/src/app/global-error.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+export default function GlobalError({
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  // global-errorはルートレイアウトごと置き換わるためCSS Modulesに依存しない
+  return (
+    <html lang="ja">
+      <body>
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            minHeight: "100vh",
+            gap: "16px",
+            padding: "24px",
+          }}
+        >
+          <h1 style={{ fontSize: "20px", fontWeight: 600 }}>
+            エラーが発生しました
+          </h1>
+          <p style={{ fontSize: "14px", color: "#666" }}>
+            問題が解決しない場合は、ページを再読み込みしてください。
+          </p>
+          <button
+            type="button"
+            onClick={reset}
+            style={{
+              padding: "10px 24px",
+              fontSize: "14px",
+              fontWeight: 600,
+              color: "#ffffff",
+              background: "#8b6914",
+              border: "none",
+              borderRadius: "6px",
+              cursor: "pointer",
+            }}
+          >
+            再試行
+          </button>
+        </div>
+      </body>
+    </html>
+  );
+}


### PR DESCRIPTION
## 背景

管理画面で新しいコーヒー豆を登録しようとすると、たまに「Application error: a client-side exception has occurred」というエラー画面が表示される問題の修正。

## 原因

- 豆の登録/編集フォームは画像ファイルを含む FormData を Server Action に送信しているが、Next.js の Server Action にはリクエストボディ全体で **デフォルト1MBの上限** がある
- クライアント側のバリデーション（`ImageUploadField`）は「画像1枚が1MB以下」しかチェックしないため、1MB近い画像＋他のフォーム項目でリクエスト全体が1MBを超えると Next.js サーバーがリクエストを拒否する
- その結果 `useActionState` 経由のアクション呼び出しがクライアント側で未捕捉例外となり、`error.tsx` / `global-error.tsx` が存在しないため Next.js デフォルトのエラー画面がそのまま表示されていた

画像サイズが1MB付近のときだけ発生するため「たまに」起きるように見えていた。

## 変更内容

- `next.config.ts` に `experimental.serverActions.bodySizeLimit: "10mb"` を設定（根本対応）
- `src/app/error.tsx` / `global-error.tsx` を追加し、万一の未捕捉例外でも再試行ボタン付きのエラー画面を表示するようにした

## 確認

- `pnpm lint` ✅
- `pnpm build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)