### PR TITLE
fix: LPの価格表記を実際の価格に修正

### DIFF
--- a/frontend/src/app/lp/_components/HeroSection/heroSection.tsx
+++ b/frontend/src/app/lp/_components/HeroSection/heroSection.tsx
@@ -32,7 +32,7 @@ export default function HeroSection() {
         </LinkWithLoading>
         <p className={styles.priceNote}>
           <span className={styles.priceNoteEn}>
-            定期便 ¥1,500〜/月 · 単品購入 ¥1,650〜
+            定期便 ¥1,580〜/月 · 単品購入 ¥1,700〜
           </span>
         </p>
         <a href="#beans" className={styles.subCta}>

--- a/frontend/src/app/lp/page.tsx
+++ b/frontend/src/app/lp/page.tsx
@@ -48,8 +48,8 @@ const productJsonLd = {
   image: "https://mametosho.com/ogImageRectangle.jpeg",
   offers: {
     "@type": "AggregateOffer",
-    lowPrice: "1500",
-    highPrice: "6750",
+    lowPrice: "1580",
+    highPrice: "6830",
     priceCurrency: "JPY",
     offerCount: "9",
     availability: "https://schema.org/InStock",


### PR DESCRIPTION
## 概要
LPヒーローセクションの価格表記が実際の価格と異なっていたため修正。

## 変更内容
- ヒーローの表示文言: 定期便 ¥1,500〜/月 → **¥1,580〜/月**、単品購入 ¥1,650〜 → **¥1,700〜**
- JSON-LD構造化データ（定期便のAggregateOffer）: lowPrice 1500 → **1580**、highPrice 6750 → **6830**

※ 単品購入のmax（¥7,500）はJSON-LDの対象（サブスクリプション商品）外のため未反映。

🤖 Generated with [Claude Code](https://claude.com/claude-code)