### PR TITLE
feat: GA/Clarity IDをSecrets Manager経由でcs-frontendに注入するインフラ定義を追加

### DIFF
--- a/.github/workflows/deploy-cs-frontend.yml
+++ b/.github/workflows/deploy-cs-frontend.yml
@@ -117,10 +117,16 @@ jobs:
             echo "site_url=https://${ENV}.mametosho.com" >> $GITHUB_OUTPUT
           fi
 
-          HMAC_SSR_KEY_SECRET_ARN=$(aws ssm get-parameter \
-            --name "/${ENV}/cs-frontend/hmac-ssr-key-secret-arn" \
-            --query 'Parameter.Value' --output text)
+          get_param() {
+            aws ssm get-parameter --name "$1" --query 'Parameter.Value' --output text
+          }
+          HMAC_SSR_KEY_SECRET_ARN=$(get_param "/${ENV}/cs-frontend/hmac-ssr-key-secret-arn")
+          GA_ID_SECRET_ARN=$(get_param "/${ENV}/cs-frontend/google-ga-id-secret-arn")
+          CLARITY_ID_SECRET_ARN=$(get_param "/${ENV}/cs-frontend/microsoft-clarity-id-secret-arn")
+
           echo "hmac_ssr_key_secret_arn=${HMAC_SSR_KEY_SECRET_ARN}" >> $GITHUB_OUTPUT
+          echo "ga_id_secret_arn=${GA_ID_SECRET_ARN}" >> $GITHUB_OUTPUT
+          echo "clarity_id_secret_arn=${CLARITY_ID_SECRET_ARN}" >> $GITHUB_OUTPUT
 
       - name: Install ecspresso
         uses: kayac/ecspresso@v2
@@ -133,6 +139,8 @@ jobs:
           IMAGE_TAG: ${{ needs.build.outputs.image_tag }}
           SITE_URL: ${{ steps.params.outputs.site_url }}
           HMAC_SSR_KEY_SECRET_ARN: ${{ steps.params.outputs.hmac_ssr_key_secret_arn }}
+          GA_ID_SECRET_ARN: ${{ steps.params.outputs.ga_id_secret_arn }}
+          CLARITY_ID_SECRET_ARN: ${{ steps.params.outputs.clarity_id_secret_arn }}
         run: |
           ecspresso deploy \
             --config infrastructure/ecspresso/cs-frontend/ecspresso.yml

--- a/infrastructure/ecspresso/cs-frontend/ecs-task-def.json
+++ b/infrastructure/ecspresso/cs-frontend/ecs-task-def.json
@@ -30,6 +30,14 @@
         {
           "name": "CS_API_HMAC_KEY_SSR",
           "valueFrom": "{{ must_env `HMAC_SSR_KEY_SECRET_ARN` }}"
+        },
+        {
+          "name": "GOOGLE_GA_ID",
+          "valueFrom": "{{ must_env `GA_ID_SECRET_ARN` }}"
+        },
+        {
+          "name": "MICROSOFT_CLARITY_ID",
+          "valueFrom": "{{ must_env `CLARITY_ID_SECRET_ARN` }}"
         }
       ],
       "logConfiguration": {

--- a/infrastructure/terraform/environments/prod/main.tf
+++ b/infrastructure/terraform/environments/prod/main.tf
@@ -231,6 +231,8 @@ module "ecs_cs_frontend" {
   use_spot            = false
   secret_arns = [
     aws_secretsmanager_secret.cs_frontend_hmac_ssr_key.arn,
+    aws_secretsmanager_secret.cs_frontend_google_ga_id.arn,
+    aws_secretsmanager_secret.cs_frontend_microsoft_clarity_id.arn,
   ]
   environment = [
     { name = "CS_API_BASE_URL", value = "http://cs-api.${local.env}.local:8080" },
@@ -238,6 +240,8 @@ module "ecs_cs_frontend" {
   ]
   secrets = [
     { name = "CS_API_HMAC_KEY_SSR", valueFrom = aws_secretsmanager_secret.cs_frontend_hmac_ssr_key.arn },
+    { name = "GOOGLE_GA_ID", valueFrom = aws_secretsmanager_secret.cs_frontend_google_ga_id.arn },
+    { name = "MICROSOFT_CLARITY_ID", valueFrom = aws_secretsmanager_secret.cs_frontend_microsoft_clarity_id.arn },
   ]
 }
 

--- a/infrastructure/terraform/environments/prod/secrets.tf
+++ b/infrastructure/terraform/environments/prod/secrets.tf
@@ -85,3 +85,28 @@ resource "aws_ssm_parameter" "cs_frontend_hmac_ssr_key_secret_arn" {
   type  = "String"
   value = aws_secretsmanager_secret.cs_frontend_hmac_ssr_key.arn
 }
+
+# GA4測定ID。HTMLに露出する公開値だが、環境変数の受け渡しはSecrets Managerに統一する。
+# 値はTerraform管理外で投入する。
+resource "aws_secretsmanager_secret" "cs_frontend_google_ga_id" {
+  name                    = "${local.account_id}-${local.env}-cs-frontend-google-ga-id"
+  recovery_window_in_days = 0
+}
+
+resource "aws_ssm_parameter" "cs_frontend_google_ga_id_secret_arn" {
+  name  = "/${local.env}/cs-frontend/google-ga-id-secret-arn"
+  type  = "String"
+  value = aws_secretsmanager_secret.cs_frontend_google_ga_id.arn
+}
+
+# Microsoft ClarityのプロジェクトID。値はTerraform管理外で投入する。
+resource "aws_secretsmanager_secret" "cs_frontend_microsoft_clarity_id" {
+  name                    = "${local.account_id}-${local.env}-cs-frontend-microsoft-clarity-id"
+  recovery_window_in_days = 0
+}
+
+resource "aws_ssm_parameter" "cs_frontend_microsoft_clarity_id_secret_arn" {
+  name  = "/${local.env}/cs-frontend/microsoft-clarity-id-secret-arn"
+  type  = "String"
+  value = aws_secretsmanager_secret.cs_frontend_microsoft_clarity_id.arn
+}


### PR DESCRIPTION
## 概要
cs-frontendが参照する `GOOGLE_GA_ID` / `MICROSOFT_CLARITY_ID` がAWS側で未設定だったため、Secrets Manager経由でECSタスクに注入するインフラ定義を追加する。

## 背景
- `frontend/src/app/layout.tsx` はGA4測定IDとMicrosoft ClarityプロジェクトIDを環境変数から読むが、ECSタスク定義に存在せず `"no-config"` フォールバックのまま稼働していた
- 受け渡しは既存のHMAC鍵と同じパターン(Secrets Manager作成 → ARNをSSMパラメータに保存 → デプロイ時に取得してecspressoの `secrets` で注入)に統一

## 変更内容
- **`infrastructure/terraform/environments/prod/secrets.tf`**: `cs_frontend_google_ga_id` / `cs_frontend_microsoft_clarity_id` のSecrets Managerシークレットと、ARNを保存するSSMパラメータを追加
- **`infrastructure/terraform/environments/prod/main.tf`**: `module "ecs_cs_frontend"` の `secret_arns`(実行ロールの `GetSecretValue` 許可)とseedタスク定義の `secrets` に2変数を追加
- **`infrastructure/ecspresso/cs-frontend/ecs-task-def.json`**: `secrets` に `GOOGLE_GA_ID` / `MICROSOFT_CLARITY_ID` を追加
- **`.github/workflows/deploy-cs-frontend.yml`**: SSMパラメータからARNを取得してecspressoに渡すよう追加。あわせてSSM取得を他のdeployワークフローと同じ `get_param()` 形式に統一

## 対象環境
prodのみ(dev環境は未構築のため対象外)

## マージ後の作業
`terraform apply` 後、次回のcs-frontendデプロイまでに値の投入が必要(未投入のままデプロイするとタスクがシークレット解決に失敗して起動不可):

```shell
aws secretsmanager put-secret-value --secret-id {account_id}-prod-cs-frontend-google-ga-id --secret-string "G-XXXXXXXXXX"
aws secretsmanager put-secret-value --secret-id {account_id}-prod-cs-frontend-microsoft-clarity-id --secret-string "ClarityのプロジェクトID"
```

## 検証
- `terraform validate` / `terraform fmt -check` 通過
- タスク定義JSONの構文チェック通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)